### PR TITLE
Allow customization of environment variables

### DIFF
--- a/sourcegraph/templates/_tracing.tpl
+++ b/sourcegraph/templates/_tracing.tpl
@@ -5,6 +5,10 @@ Define the tracing sidecar
 - name: jaeger-agent
   image: {{ include "sourcegraph.image" (list . "tracing") }}
   env:
+  {{- range $name, $item := .Values.tracing.env}}
+    - name: {{ $name }}
+    {{- $item | toYaml | nindent 4 }}
+  {{- end }}
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
+++ b/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
@@ -57,6 +57,11 @@ spec:
         - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid
         # it is safe to uncomment this option if you use docker as your container runtime to reduce noise
         # - --docker_only
+        env:
+        {{- range $name, $item := .Values.cadvisor.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         resources:
         {{- toYaml .Values.cadvisor.resources | nindent 10 }}
         volumeMounts:

--- a/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -51,8 +51,10 @@ spec:
         image: {{ include "sourcegraph.image" (list . "codeInsightsDB" "codeinsights-db") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         env:
-        - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
-          value: password
+        {{- range $name, $item := .Values.codeInsightsDB.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
         - name: POSTGRESQL_CONF_DIR

--- a/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
+++ b/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
@@ -63,6 +63,11 @@ spec:
         image: {{ include "sourcegraph.image" (list . "codeIntelDB" "codeintel-db") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        {{- range $name, $item := .Values.codeIntelDB.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         readinessProbe:
           exec:
             command:
@@ -89,8 +94,10 @@ spec:
         {{- toYaml .Values.codeIntelDB.extraContainers | nindent 6 }}
       {{- end }}
       - env:
-        - name: DATA_SOURCE_NAME
-          value: postgres://sg:@localhost:5432/?sslmode=disable
+        {{- range $name, $item := .Values.codeIntelDB.postgresExporter.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/code_intel_queries.yaml
         image: {{ include "sourcegraph.image" (list . "postgresExporter" "postgres_exporter") }}

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -56,28 +56,10 @@ spec:
         args:
         - serve
         env:
-        - name: PGDATABASE
-          value: sg
-        - name: PGHOST
-          value: pgsql
-        - name: PGPORT
-          value: "5432"
-        - name: PGSSLMODE
-          value: disable
-        - name: PGUSER
-          value: sg
-        - name: CODEINSIGHTS_PGDATASOURCE
-          value: postgres://postgres:password@codeinsights-db:5432/postgres
-        - name: CODEINTEL_PGDATABASE
-          value: sg
-        - name: CODEINTEL_PGHOST
-          value: codeintel-db
-        - name: CODEINTEL_PGPORT
-          value: "5432"
-        - name: CODEINTEL_PGSSLMODE
-          value: disable
-        - name: CODEINTEL_PGUSER
-          value: sg
+        {{- range $name, $item := .Values.frontend.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         # POD_NAME is used by CACHE_DIR
         - name: POD_NAME
           valueFrom:
@@ -87,12 +69,6 @@ spec:
         # archives of repositories at a commit.
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        - name: GRAFANA_SERVER_URL
-          value: http://grafana:30070
-        - name: JAEGER_SERVER_URL
-          value: http://jaeger-query:16686
-        - name: PROMETHEUS_URL
-          value: http://prometheus:30090
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -54,6 +54,11 @@ spec:
         image: {{ include "sourcegraph.image" (list . "githubProxy" "github-proxy") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        {{- range $name, $item := .Values.githubProxy.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 3180
           name: http

--- a/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -51,6 +51,11 @@ spec:
         args: ["run"]
         image: {{ include "sourcegraph.image" (list . "gitserver") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        env:
+        {{- range $name, $item := .Values.gitserver.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5

--- a/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -49,6 +49,11 @@ spec:
       - name: grafana
         image: {{ include "sourcegraph.image" (list . "grafana") }}
         terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        {{- range $name, $item := .Values.grafana.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 3370
           name: http

--- a/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -46,6 +46,11 @@ spec:
       - name: zoekt-webserver
         image: {{ include "sourcegraph.image" (list . "indexedSearch" "indexed-searcher") }}
         terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        {{- range $name, $item := .Values.indexedSearch.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 6070
           name: http
@@ -68,6 +73,11 @@ spec:
       - name: zoekt-indexserver
         image: {{ include "sourcegraph.image" (list . "searchIndexer" "search-indexer") }}
         terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        {{- range $name, $item := .Values.searchIndexer.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 6072
           name: index-http

--- a/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -53,6 +53,11 @@ spec:
       - name: jaeger
         image: {{ include "sourcegraph.image" (list . "jaeger" "jaeger-all-in-one") }}
         args: ["--memory.max-traces=20000"]
+        env:
+        {{- range $name, $item := .Values.jaeger.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         ports:
           - containerPort: 5775
             protocol: UDP

--- a/sourcegraph/templates/minio/minio.Deployment.yaml
+++ b/sourcegraph/templates/minio/minio.Deployment.yaml
@@ -49,10 +49,10 @@ spec:
       containers:
       - name: minio
         env:
-        - name: MINIO_ACCESS_KEY
-          value: AKIAIOSFODNN7EXAMPLE
-        - name: MINIO_SECRET_KEY
-          value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+        {{- range $name, $item := .Values.minio.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         image: {{ include "sourcegraph.image" (list . "minio") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         args: ['minio', 'server', '/data']

--- a/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -59,8 +59,7 @@ spec:
         resources:
         {{- toYaml .Values.alpine.resources | nindent 10 }}
       containers:
-      - env:
-        image: {{ include "sourcegraph.image" (list . "pgsql" "postgres-12.6-alpine") }}
+      - image: {{ include "sourcegraph.image" (list . "pgsql" "postgres-12.6-alpine") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -73,6 +72,11 @@ spec:
             command:
               - /liveness.sh
         name: pgsql
+        env:
+        {{- range $name, $item := .Values.pgsql.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 5432
           name: pgsql
@@ -92,10 +96,10 @@ spec:
         {{- toYaml .Values.pgsql.extraContainers | nindent 6 }}
       {{- end }}
       - env:
-        - name: DATA_SOURCE_NAME
-          value: postgres://sg:@localhost:5432/?sslmode=disable
-        - name: PG_EXPORTER_EXTEND_QUERY_PATH
-          value: /config/queries.yaml
+        {{- range $name, $item := .Values.postgresExporter.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         image: {{ include "sourcegraph.image" (list . "postgresExporter" "postgres_exporter") }}
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter

--- a/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -51,8 +51,10 @@ spec:
       containers:
       - name: precise-code-intel-worker
         env:
-        - name: NUM_WORKERS
-          value: '4'
+        {{- range $name, $item := .Values.preciseCodeIntel.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -45,6 +45,11 @@ spec:
       - name: prometheus
         image: {{ include "sourcegraph.image" (list . "prometheus") }}
         terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        {{- range $name, $item := .Values.prometheus.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /-/ready

--- a/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -54,6 +54,11 @@ spec:
         image: {{ include "sourcegraph.image" (list . "queryRunner" "query-runner") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        {{- range $name, $item := .Values.queryRunner.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 3183
           name: http

--- a/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -51,6 +51,11 @@ spec:
           initialDelaySeconds: 30
           tcpSocket:
             port: redis
+        env:
+        {{- range $name, $item := .Values.redisCache.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 6379
           name: redis
@@ -66,6 +71,10 @@ spec:
       - name: redis-exporter
         image: {{ include "sourcegraph.image" (list . "redisExporter" "redis_exporter") }}
         terminationMessagePolicy: FallbackToLogsOnError
+        {{- range $name, $item := .Values.redisExporter.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 9121
           name: redisexp

--- a/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -45,6 +45,11 @@ spec:
       - name: redis-store
         image: {{ include "sourcegraph.image" (list . "redisStore" "redis-store") }}
         terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        {{- range $name, $item := .Values.redisStore.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:
@@ -64,6 +69,11 @@ spec:
       - name: redis-exporter
         image: {{ include "sourcegraph.image" (list . "redisExporter" "redis_exporter") }}
         terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        {{- range $name, $item := .Values.redisExporter.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 9121
           name: redisexp

--- a/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -50,6 +50,10 @@ spec:
       - name: repo-updater
         image: {{ include "sourcegraph.image" (list . "repoUpdater" "repo-updater") }}
         env:
+        {{- range $name, $item := .Values.repoUpdater.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3182

--- a/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -53,6 +53,10 @@ spec:
       containers:
       - name: searcher
         env:
+        {{- range $name, $item := .Values.searcher.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         - name: SEARCHER_CACHE_SIZE_MB
           valueFrom:
             resourceFieldRef:

--- a/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -53,6 +53,10 @@ spec:
       containers:
       - name: symbols
         env:
+        {{- range $name, $item := .Values.symbols.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         - name: SYMBOLS_CACHE_SIZE_MB
           valueFrom:
             resourceFieldRef:

--- a/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -51,6 +51,10 @@ spec:
       containers:
       - name: syntect-server
         env:
+        {{- range $name, $item := .Values.syntectServer.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         image: {{ include "sourcegraph.image" (list . "syntectServer" "syntax-highlighter") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         terminationMessagePolicy: FallbackToLogsOnError

--- a/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -51,6 +51,10 @@ spec:
       containers:
       - name: worker
         env:
+        {{- range $name, $item := .Values.worker.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/sourcegraph/values.yaml
+++ b/sourcegraph/values.yaml
@@ -41,6 +41,9 @@ cadvisor:
     name: "cadvisor"
 
 codeInsightsDB:
+  env:
+    POSTGRES_PASSWORD: # Accessible by Sourcegraph applications on the network only, so password auth is not used.
+      value: password
   image:
     tag: "insiders@sha256:dfd916b6456ffbeb6ba2d05f92aa2bd77273e617d80142d76bfb23fa255e5e21"
   replicaCount: 1
@@ -67,6 +70,10 @@ codeIntelDB:
       cpu: "4"
       memory: 4Gi
   storageSize: "200Gi"
+  postgresExporter:
+    env:
+      DATA_SOURCE_NAME:
+        value: postgres://sg:@localhost:5432/?sslmode=disable
   podSecurityContext:
     runAsUser: 0
 
@@ -90,6 +97,31 @@ frontend:
     name: "sourcegraph-frontend"
   ingress:
     enabled: true
+  env:
+    PGDATABASE:
+      value: sg
+    PGHOST:
+      value: pgsql
+    PGUSER:
+      value: sg
+    CODEINSIGHTS_PGDATASOURCE:
+      value: postgres://postgres:password@codeinsights-db:5432/postgres
+    CODEINTEL_PGDATABASE:
+      value: sg
+    CODEINTEL_PGHOST:
+      value: codeintel-db
+    CODEINTEL_PGPORT:
+      value: "5432"
+    CODEINTEL_PGSSLMODE:
+      value: disable
+    CODEINTEL_PGUSER:
+      value: sg
+    GRAFANA_SERVER_URL:
+      value: http://grafana:30070
+    JAEGER_SERVER_URL:
+      value: http://jaeger-query:16686
+    PROMETHEUS_URL:
+      value: http://prometheus:30090
 
 githubProxy:
   image:
@@ -170,6 +202,11 @@ minio:
       memory: 500M
   podSecurityContext:
     runAsUser: 0
+  env:
+    MINIO_ACCESS_KEY:
+      value: AKIAIOSFODNN7EXAMPLE
+    MINIO_SECRET_KEY:
+      value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
 searchIndexer:
   image:
@@ -198,6 +235,11 @@ pgsql:
   podSecurityContext:
     runAsUser: 0
   storageSize: "200Gi"
+  env:
+    DATA_SOURCE_NAME:
+      value: postgres://sg:@localhost:5432/?sslmode=disable
+    PG_EXPORTER_EXTEND_QUERY_PATH:
+      value: /config/queries.yaml
 
 postgresExporter:
   image:
@@ -223,6 +265,9 @@ preciseCodeIntel:
       memory: 2G
   podSecurityContext:
     runAsUser: 0
+  env:
+    NUM_WORKERS:
+      value: '4'
 
 queryRunner:
   image:


### PR DESCRIPTION
Environment variables for all deployables can now be customized using a map. Values can be overridden from a separate file like this:
```
pgsql:
  env:
    PGHOST:
      value: something_else // use a custom value instead of the default provided in values.yaml
    PGDATABASE:
      valueFrom:  // replace default value with a secret key ref
        secretKeyRef:
          name: pgsql-secret
          key: database
    CODEINTEL_PGSSLMODE: null // unset this variable entirely, it will not be included in the env list
    NEW_VARIABLE:
      value: "something new" // add a custom variable
```

The result will include all the default values merged with the modifications from the override file.

Two downsides to this implementation:
- Ordering is not preserved (env var's will be alphabetically sorted instead of insertion sorted)
- No templating is allowed - i.e., `value: "{{ .Values.pgsql.replicaCount }}"` will not expand into the actual value but will stay as a string.