### PR TITLE
Miscellaneous fixes

### DIFF
--- a/sourcegraph/templates/backend.Service.yaml
+++ b/sourcegraph/templates/backend.Service.yaml
@@ -6,7 +6,6 @@ metadata:
       the same node if possible.
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     group: backend
   name: backend
 spec:

--- a/sourcegraph/templates/cadvisor/cadvisor.ClusterRole.yaml
+++ b/sourcegraph/templates/cadvisor/cadvisor.ClusterRole.yaml
@@ -5,7 +5,6 @@ metadata:
     app: cadvisor
     category: rbac
     deploy: sourcegraph
-    sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: {{ default "cadvisor" .Values.cadvisor.name }}
 rules:

--- a/sourcegraph/templates/cadvisor/cadvisor.ClusterRoleBinding.yaml
+++ b/sourcegraph/templates/cadvisor/cadvisor.ClusterRoleBinding.yaml
@@ -5,7 +5,6 @@ metadata:
     app: cadvisor
     category: rbac
     deploy: sourcegraph
-    sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: {{ default "cadvisor" .Values.cadvisor.name }}
 roleRef:

--- a/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
+++ b/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
@@ -10,7 +10,6 @@ metadata:
       {{- toYaml .Values.cadvisor.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: {{ default "cadvisor" .Values.cadvisor.name }}
 spec:

--- a/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
+++ b/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
@@ -34,6 +34,7 @@ spec:
       {{- toYaml .Values.cadvisor.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/cadvisor/cadvisor.PodSecurityPolicy.yaml
+++ b/sourcegraph/templates/cadvisor/cadvisor.PodSecurityPolicy.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: cadvisor
     deploy: sourcegraph
-    sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: {{ default "cadvisor" .Values.cadvisor.name }}
 spec:

--- a/sourcegraph/templates/cadvisor/cadvisor.ServiceAccount.yaml
+++ b/sourcegraph/templates/cadvisor/cadvisor.ServiceAccount.yaml
@@ -6,7 +6,6 @@ metadata:
     app: cadvisor
     category: rbac
     deploy: sourcegraph
-    sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: {{ include "sourcegraph.serviceAccountName" (list . "cadvisor") }}
 {{- end }}

--- a/sourcegraph/templates/codeinsights-db/codeinsights-db.ConfigMap.yaml
+++ b/sourcegraph/templates/codeinsights-db/codeinsights-db.ConfigMap.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
   name: {{ default "codeinsights-db-conf" .Values.codeInsightsDB.name }}
 data:
   postgresql.conf: |

--- a/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -35,6 +35,7 @@ spec:
       {{- toYaml .Values.codeInsightsDB.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -10,7 +10,6 @@ metadata:
     {{- end }}
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
   name: {{ default "codeinsights-db" .Values.codeInsightsDB.name }}
 spec:
   {{- with .Values.sourcegraph.imagePullSecrets }}

--- a/sourcegraph/templates/codeinsights-db/codeinsights-db.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/codeinsights-db/codeinsights-db.PersistentVolumeClaim.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
   name: {{ default "codeinsights-db" .Values.codeInsightsDB.name }}
 spec:
   accessModes:

--- a/sourcegraph/templates/codeinsights-db/codeinsights-db.Service.yaml
+++ b/sourcegraph/templates/codeinsights-db/codeinsights-db.Service.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/component: codeinsights-db
     app: codeinsights-db
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     {{- if .Values.codeInsightsDB.serviceLabels }}
       {{- toYaml .Values.codeInsightsDB.serviceLabels | nindent 4 }}
     {{- end }}

--- a/sourcegraph/templates/codeintel-db/codeintel-db.ConfigMap.yaml
+++ b/sourcegraph/templates/codeintel-db/codeintel-db.ConfigMap.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/component: codeintel-db
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
   name: {{ default "codeintel-db-conf" .Values.codeIntelDB.name }}
 data:
   postgresql.conf: |

--- a/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
+++ b/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
@@ -11,7 +11,6 @@ metadata:
     {{- end }}
     app.kubernetes.io/component: codeintel-db
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
   name: {{ default "codeintel-db" .Values.codeIntelDB.name }}
 spec:
   {{- with .Values.sourcegraph.imagePullSecrets }}

--- a/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
+++ b/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
@@ -36,6 +36,7 @@ spec:
       {{- toYaml .Values.codeIntelDB.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/codeintel-db/codeintel-db.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/codeintel-db/codeintel-db.PersistentVolumeClaim.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: codeintel-db
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
   name: {{ default "codeintel-db" .Values.codeIntelDB.name }}
 spec:
   accessModes:

--- a/sourcegraph/templates/codeintel-db/codeintel-db.Service.yaml
+++ b/sourcegraph/templates/codeintel-db/codeintel-db.Service.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/component: codeintel-db
     app: codeintel-db
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     {{- if .Values.codeIntelDB.serviceLabels }}
       {{- toYaml .Values.codeIntelDB.serviceLabels | nindent 4 }}
     {{- end }}

--- a/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: frontend
     {{- if .Values.frontend.serviceLabels }}
       {{- toYaml .Values.frontend.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -39,6 +39,7 @@ spec:
       {{- toYaml .Values.frontend.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -10,7 +10,6 @@ metadata:
       {{- toYaml .Values.frontend.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: frontend
   name: {{ default "sourcegraph-frontend" .Values.frontend.name }}
 spec:

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
@@ -11,7 +11,6 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: frontend
     {{- if .Values.frontend.ingress.labels}}
       {{- toYaml .Values.frontend.ingress.labels | nindent 4 }}

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.frontend.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,6 @@ metadata:
     {{- include "sourcegraph.labels" . | nindent 4 }}
     category: rbac
     deploy: sourcegraph
-    sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: frontend
   name: {{ default "sourcegraph-frontend" .Values.frontend.name }}
 rules:

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,6 @@ metadata:
     {{- include "sourcegraph.labels" . | nindent 4 }}
     category: rbac
     deploy: sourcegraph
-    sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: frontend
   name: {{ default "sourcegraph-frontend" .Values.frontend.name }}
 roleRef:

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: frontend
     {{- if .Values.frontend.serviceLabels }}
       {{- toYaml .Values.frontend.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: frontend
   name: {{ include "sourcegraph.serviceAccountName" (list . "frontend") }}
 {{- end }}

--- a/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -10,7 +10,6 @@ metadata:
       {{- toYaml .Values.githubProxy.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: github-proxy
   name: {{ default "github-proxy" .Values.githubProxy.name }}
 spec:

--- a/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -39,6 +39,7 @@ spec:
       {{- toYaml .Values.githubProxy.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: github-proxy
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: github-proxy
     {{- if .Values.githubProxy.serviceLabels }}
       {{- toYaml .Values.githubProxy.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -11,7 +11,6 @@ metadata:
     {{- end }}
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: gitserver
     type: gitserver
     app: gitserver

--- a/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -30,6 +30,7 @@ spec:
       {{- toYaml .Values.gitserver.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -10,7 +10,6 @@ metadata:
       {{- toYaml .Values.gitserver.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: gitserver
   name: {{ default "gitserver" .Values.gitserver.name }}
 spec:

--- a/sourcegraph/templates/grafana/grafana.ConfigMap.yaml
+++ b/sourcegraph/templates/grafana/grafana.ConfigMap.yaml
@@ -18,6 +18,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: grafana
   name: {{ default "grafana" .Values.grafana.name }}

--- a/sourcegraph/templates/grafana/grafana.Service.yaml
+++ b/sourcegraph/templates/grafana/grafana.Service.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: grafana
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: grafana
     {{- if .Values.grafana.serviceLabels }}
       {{- toYaml .Values.grafana.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/grafana/grafana.ServiceAccount.yaml
+++ b/sourcegraph/templates/grafana/grafana.ServiceAccount.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: grafana
   name: {{ include "sourcegraph.serviceAccountName" (list . "grafana") }}
 {{- end }}

--- a/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -10,7 +10,6 @@ metadata:
       {{- toYaml .Values.grafana.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: grafana
   name: {{ default "grafana" .Values.grafana.name }}
 spec:

--- a/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -31,6 +31,7 @@ spec:
       {{- toYaml .Values.grafana.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/indexed-search/indexed-search.IndexerService.yaml
+++ b/sourcegraph/templates/indexed-search/indexed-search.IndexerService.yaml
@@ -12,7 +12,6 @@ metadata:
   labels:
     app: indexed-search-indexer
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: indexed-search
     {{- if .Values.indexedSearch.serviceLabels }}
       {{- toYaml .Values.indexedSearch.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -12,7 +12,6 @@ metadata:
   labels:
     app: indexed-search
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: indexed-search
     {{- if .Values.indexedSearch.serviceLabels }}
       {{- toYaml .Values.indexedSearch.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -28,6 +28,7 @@ spec:
       {{- toYaml .Values.indexedSearch.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -5,7 +5,6 @@ metadata:
     description: Backend for indexed text search operations.
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: indexed-search
     {{- include "sourcegraph.labels" . | nindent 4 }}
     {{- if .Values.indexedSearch.labels }}

--- a/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
+++ b/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
@@ -7,7 +7,6 @@ metadata:
   {{- end }}
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: jaeger
     app: jaeger
     app.kubernetes.io/name: jaeger

--- a/sourcegraph/templates/jaeger/jaeger-query.Service.yaml
+++ b/sourcegraph/templates/jaeger/jaeger-query.Service.yaml
@@ -7,7 +7,6 @@ metadata:
   {{- end }}
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: jaeger
     app: jaeger
     app.kubernetes.io/name: jaeger

--- a/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -33,6 +33,7 @@ spec:
       {{- toYaml .Values.jaeger.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -8,7 +8,6 @@ metadata:
       {{- toYaml .Values.jaeger.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: jaeger
     app: jaeger
     app.kubernetes.io/name: jaeger

--- a/sourcegraph/templates/minio/minio.Deployment.yaml
+++ b/sourcegraph/templates/minio/minio.Deployment.yaml
@@ -36,6 +36,7 @@ spec:
       {{- toYaml .Values.minio.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/minio/minio.Deployment.yaml
+++ b/sourcegraph/templates/minio/minio.Deployment.yaml
@@ -10,7 +10,6 @@ metadata:
       {{- toYaml .Values.minio.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: minio
   name: {{ default "minio" .Values.minio.name }}
 spec:

--- a/sourcegraph/templates/minio/minio.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/minio/minio.PersistentVolumeClaim.yaml
@@ -3,7 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: minio
   name: {{ default "minio" .Values.minio.name }}
 spec:

--- a/sourcegraph/templates/minio/minio.Service.yaml
+++ b/sourcegraph/templates/minio/minio.Service.yaml
@@ -11,7 +11,6 @@ metadata:
   labels:
     app: minio
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: minio
     {{- if .Values.minio.serviceLabels }}
       {{- toYaml .Values.minio.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/pgsql/pgsql.ConfigMap.yaml
+++ b/sourcegraph/templates/pgsql/pgsql.ConfigMap.yaml
@@ -5,7 +5,6 @@ metadata:
     description: Configuration for PostgreSQL
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: pgsql
   name: {{ default "pgsql-conf" .Values.pgsql.name }}
 data:

--- a/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -36,6 +36,7 @@ spec:
       {{- toYaml .Values.pgsql.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     kubectl.kubernetes.io/default-container: pgsql
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: pgsql
     {{- include "sourcegraph.labels" . | nindent 4 }}
     {{- if .Values.pgsql.labels }}

--- a/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -3,7 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: pgsql
   name: {{ default "pgsql" .Values.pgsql.name }}
 spec:

--- a/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: pgsql
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: pgsql
     {{- if .Values.pgsql.serviceLabels }}
       {{- toYaml .Values.pgsql.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -9,7 +9,6 @@ metadata:
       {{- toYaml .Values.preciseCodeIntel.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: precise-code-intel
   name: {{ default "precise-code-intel-worker" .Values.preciseCodeIntel.name }}
 spec:

--- a/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -38,6 +38,7 @@ spec:
       {{- toYaml .Values.preciseCodeIntel.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/precise-code-intel/worker.Service.yaml
+++ b/sourcegraph/templates/precise-code-intel/worker.Service.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: precise-code-intel-worker
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: precise-code-intel
     {{- if .Values.preciseCodeIntel.serviceLabels }}
       {{- toYaml .Values.preciseCodeIntel.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: prometheus
   name: {{ default "prometheus" .Values.prometheus.name }}
 rules:

--- a/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: prometheus
   name: {{ default "prometheus" .Values.prometheus.name }}
 roleRef:

--- a/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
@@ -274,6 +274,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: prometheus
   name: {{ default "prometheus" .Values.prometheus.name }}

--- a/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -31,6 +31,7 @@ spec:
       {{- toYaml .Values.prometheus.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -9,7 +9,6 @@ metadata:
       {{- toYaml .Values.prometheus.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: prometheus
   name: {{ default "prometheus" .Values.prometheus.name }}
 spec:

--- a/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
@@ -3,7 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: prometheus
   name: {{ default "prometheus" .Values.prometheus.name }}
 spec:

--- a/sourcegraph/templates/prometheus/prometheus.Service.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.Service.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: prometheus
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: prometheus
     {{- if .Values.prometheus.serviceLabels }}
       {{- toYaml .Values.prometheus.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: prometheus
   name: {{ include "sourcegraph.serviceAccountName" (list . "prometheus") }}
 {{- end }}

--- a/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -10,7 +10,6 @@ metadata:
       {{- toYaml .Values.queryRunner.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: query-runner
   name: {{ default "query-runner" .Values.queryRunner.name }}
 spec:

--- a/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -39,6 +39,7 @@ spec:
       {{- toYaml .Values.queryRunner.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: query-runner
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: query-runner
     {{- if .Values.queryRunner.serviceLabels }}
       {{- toYaml .Values.queryRunner.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -32,13 +32,13 @@ spec:
       {{- toYaml .Values.redisCache.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}
       {{- if .Values.redisCache.podLabels }}
       {{- toYaml .Values.redisCache.podLabels | nindent 8 }}
       {{- end }}
-      labels:
         deploy: sourcegraph
         app: redis-cache
     spec:

--- a/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -10,7 +10,6 @@ metadata:
       {{- toYaml .Values.redisCache.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: redis
   name: {{ default "redis-cache" .Values.redisCache.name }}
 spec:

--- a/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -3,7 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: redis
   name: {{ default "redis-cache" .Values.redisCache.name }}
 spec:

--- a/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: redis-cache
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: redis
     {{- if .Values.redisCache.serviceLabels }}
       {{- toYaml .Values.redisCache.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -9,7 +9,6 @@ metadata:
       {{- toYaml .Values.redisStore.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: redis
   name: {{ default "redis-store" .Values.redisStore.name }}
 spec:

--- a/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -31,6 +31,7 @@ spec:
       {{- toYaml .Values.redisStore.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -3,7 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: redis
   name: {{ default "redis-store" .Values.redisStore.name }}
 spec:

--- a/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: redis-store
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: redis
     {{- if .Values.redisStore.serviceLabels }}
       {{- toYaml .Values.redisStore.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -11,7 +11,6 @@ metadata:
       {{- toYaml .Values.repoUpdater.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: repo-updater
   name: {{ default "repo-updater" .Values.repoUpdater.name }}
 spec:

--- a/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -36,6 +36,7 @@ spec:
       {{- toYaml .Values.repoUpdater.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: repo-updater
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: repo-updater
     {{- if .Values.repoUpdater.serviceLabels }}
       {{- toYaml .Values.repoUpdater.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -39,13 +39,13 @@ spec:
       {{- toYaml .Values.searcher.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}
       {{- if .Values.searcher.podLabels }}
       {{- toYaml .Values.searcher.podLabels | nindent 8 }}
       {{- end }}
-      labels:
         deploy: sourcegraph
         app: searcher
     spec:

--- a/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -10,7 +10,6 @@ metadata:
       {{- toYaml .Values.searcher.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: searcher
   name: {{ default "searcher" .Values.searcher.name }}
 spec:

--- a/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: searcher
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: searcher
     {{- if .Values.searcher.serviceLabels }}
       {{- toYaml .Values.searcher.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -10,7 +10,6 @@ metadata:
       {{- toYaml .Values.symbols.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: symbols
   name: {{ default "symbols" .Values.symbols.name }}
 spec:

--- a/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -39,13 +39,13 @@ spec:
       {{- toYaml .Values.symbols.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}
       {{- if .Values.symbols.podLabels }}
       {{- toYaml .Values.symbols.podLabels | nindent 8 }}
       {{- end }}
-      labels:
         deploy: sourcegraph
         app: symbols
     spec:

--- a/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -4,11 +4,17 @@ metadata:
   annotations:
     prometheus.io/port: "6060"
     sourcegraph.prometheus/scrape: "true"
+    {{- if .Values.symbols.serviceAnnotations }}
+    {{- toYaml .Values.symbols.serviceAnnotations | nindent 4 }}
+    {{- end }}
   labels:
     app: symbols
     deploy: sourcegraph
     app.kubernetes.io/component: symbols
-  name: symbols
+    {{- if .Values.symbols.serviceLabels }}
+      {{- toYaml .Values.symbols.serviceLabels | nindent 4 }}
+    {{- end }}
+  name: {{ default "symbols" .Values.symbols.name }}
 spec:
   ports:
   - name: http
@@ -18,5 +24,6 @@ spec:
     port: 6060
     targetPort: debug
   selector:
+    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: symbols
   type: ClusterIP

--- a/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: symbols
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: symbols
   name: symbols
 spec:

--- a/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -38,6 +38,7 @@ spec:
       {{- toYaml .Values.syntectServer.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -9,7 +9,6 @@ metadata:
       {{- toYaml .Values.syntectServer.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: syntect-server
   name: {{ default "syntect-server" .Values.syntectServer.name }}
 spec:

--- a/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: syntect-server
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: syntect-server
     {{- if .Values.syntectServer.serviceLabels }}
       {{- toYaml .Values.syntectServer.serviceLabels | nindent 4 }}

--- a/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -9,7 +9,6 @@ metadata:
       {{- toYaml .Values.worker.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: worker
   name: {{ default "worker" .Values.worker.name }}
 spec:

--- a/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -38,6 +38,7 @@ spec:
       {{- toYaml .Values.worker.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}

--- a/sourcegraph/templates/worker/worker.Service.yaml
+++ b/sourcegraph/templates/worker/worker.Service.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: worker
     deploy: sourcegraph
-    sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: worker
     {{- if .Values.worker.serviceLabels }}
       {{- toYaml .Values.worker.serviceLabels | nindent 4 }}


### PR DESCRIPTION
`sourcegraph-resource-requires` label was added to allow admins to selectively deploy resources that required Cluster-wide permissions. This is no longer required - admins will be able to toggle whether those resources are deployed via values.yaml.