### PR TITLE
Small changes based on customer manifests

### DIFF
--- a/sourcegraph/templates/_helpers.tpl
+++ b/sourcegraph/templates/_helpers.tpl
@@ -65,11 +65,17 @@ Create the name of the service account to use
 
 {{/*
 Create the image name and allow it to be overridden on a per-service basis
+Default tags are toggled between a global and service-specific setting by the
+useGlobalTagAsDefault configuration
 */}}
 {{- define "sourcegraph.image" -}}
 {{- $top := index . 0 }}
 {{- $service := index . 1 }}
 {{- $imageName := $service }}
 {{- if ge (len .) 3 }}{{ $imageName = index . 2 }}{{ end }}
-{{- $top.Values.sourcegraph.image.repository }}/{{ default $imageName (index $top.Values $service "image" "name") }}:{{ default (tpl $top.Values.sourcegraph.image.tag $top) (index $top.Values $service "image" "tag") }}
+
+{{- $defaultTag := (index $top.Values $service "image" "defaultTag")}}
+{{- if $top.Values.sourcegraph.image.useGlobalTagAsDefault }}{{ $defaultTag = (tpl $top.Values.sourcegraph.image.defaultTag $top) }}{{ end }}
+
+{{- $top.Values.sourcegraph.image.repository }}/{{ default $imageName (index $top.Values $service "image" "name") }}:{{ default $defaultTag (index $top.Values $service "image" "tag") }}
 {{- end }}

--- a/sourcegraph/templates/codeinsights-db/codeinsights-db.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/codeinsights-db/codeinsights-db.PersistentVolumeClaim.yaml
@@ -13,4 +13,7 @@ spec:
     requests:
       storage: {{ .Values.codeInsightsDB.storageSize }}
   storageClassName: {{ .Values.storageClass.name }}
+  {{- if .Values.codeInsightsDB.volumeName }}
+  volumeName: {{ .Values.codeInsightsDB.volumeName }}
+  {{- end }}
 {{- end }}

--- a/sourcegraph/templates/codeinsights-db/codeinsights-db.Service.yaml
+++ b/sourcegraph/templates/codeinsights-db/codeinsights-db.Service.yaml
@@ -24,5 +24,5 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: codeinsights-db
-  type: ClusterIP
+  type: {{ .Values.codeInsightsDB.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/sourcegraph/templates/codeintel-db/codeintel-db.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/codeintel-db/codeintel-db.PersistentVolumeClaim.yaml
@@ -13,4 +13,7 @@ spec:
     requests:
       storage: {{ .Values.codeIntelDB.storageSize }}
   storageClassName: {{ .Values.storageClass.name }}
+  {{- if .Values.codeIntelDB.volumeName }}
+  volumeName: {{ .Values.codeIntelDB.volumeName }}
+  {{- end }}
 {{- end }}

--- a/sourcegraph/templates/codeintel-db/codeintel-db.Service.yaml
+++ b/sourcegraph/templates/codeintel-db/codeintel-db.Service.yaml
@@ -24,5 +24,5 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: codeintel-db
-  type: ClusterIP
+  type: {{ .Values.codeIntelDB.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -21,4 +21,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: sourcegraph-frontend
-  type: ClusterIP
+  type: {{ .Values.frontend.internalServiceType | default "ClusterIP" }}

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -23,4 +23,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: sourcegraph-frontend
-  type: ClusterIP
+  type: {{ .Values.frontend.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -23,4 +23,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: github-proxy
-  type: ClusterIP
+  type: {{ .Values.githubProxy.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -28,4 +28,4 @@ spec:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: gitserver
     type: gitserver
-  type: ClusterIP
+  type: {{ .Values.gitserver.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/grafana/grafana.Service.yaml
+++ b/sourcegraph/templates/grafana/grafana.Service.yaml
@@ -22,5 +22,5 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: grafana
-  type: ClusterIP
+  type: {{ .Values.grafana.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/sourcegraph/templates/indexed-search/indexed-search.IndexerService.yaml
+++ b/sourcegraph/templates/indexed-search/indexed-search.IndexerService.yaml
@@ -25,4 +25,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: indexed-search
-  type: ClusterIP
+  type: {{ .Values.indexedSearch.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -24,4 +24,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: indexed-search
-  type: ClusterIP
+  type: {{ .Values.indexedSearch.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
+++ b/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
@@ -33,5 +33,5 @@ spec:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: all-in-one
-  type: ClusterIP
+  type: {{ .Values.jaeger.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/sourcegraph/templates/minio/minio.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/minio/minio.PersistentVolumeClaim.yaml
@@ -13,4 +13,7 @@ spec:
     requests:
       storage: {{ .Values.minio.storageSize }}
   storageClassName: {{ .Values.storageClass.name }}
+  {{- if .Values.minio.volumeName }}
+  volumeName: {{ .Values.minio.volumeName }}
+  {{- end }}
 {{- end }}

--- a/sourcegraph/templates/minio/minio.Service.yaml
+++ b/sourcegraph/templates/minio/minio.Service.yaml
@@ -25,5 +25,5 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: minio
-  type: ClusterIP
+  type: {{ .Values.minio.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -13,4 +13,7 @@ spec:
     requests:
       storage: {{ .Values.pgsql.storageSize }}
   storageClassName: {{ .Values.storageClass.name }}
+  {{- if .Values.pgsql.volumeName }}
+  volumeName: {{ .Values.pgsql.volumeName }}
+  {{- end }}
 {{- end }}

--- a/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -24,5 +24,5 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: pgsql
-  type: ClusterIP
+  type: {{ .Values.pgsql.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/sourcegraph/templates/precise-code-intel/worker.Service.yaml
+++ b/sourcegraph/templates/precise-code-intel/worker.Service.yaml
@@ -26,4 +26,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: precise-code-intel-worker
-  type: ClusterIP
+  type: {{ .Values.preciseCodeIntel.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
@@ -13,4 +13,7 @@ spec:
     requests:
       storage: {{ .Values.prometheus.storageSize }}
   storageClassName: {{ .Values.storageClass.name }}
+  {{- if .Values.prometheus.volumeName }}
+  volumeName: {{ .Values.prometheus.volumeName }}
+  {{- end }}
 {{- end }}

--- a/sourcegraph/templates/prometheus/prometheus.Service.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.Service.yaml
@@ -22,5 +22,5 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: prometheus
-  type: ClusterIP
+  type: {{ .Values.prometheus.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -23,4 +23,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: query-runner
-  type: ClusterIP
+  type: {{ .Values.queryRunner.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -13,4 +13,7 @@ spec:
     requests:
       storage: {{ .Values.redisCache.storageSize }}
   storageClassName: {{ .Values.storageClass.name }}
+  {{- if .Values.redisCache.volumeName }}
+  volumeName: {{ .Values.redisCache.volumeName }}
+  {{- end }}
 {{- end }}

--- a/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -24,5 +24,5 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: redis-cache
-  type: ClusterIP
+  type: {{ .Values.redisCache.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -13,4 +13,7 @@ spec:
     requests:
       storage: {{ .Values.redisStore.storageSize }}
   storageClassName: {{ .Values.storageClass.name }}
+  {{- if .Values.redisStore.volumeName }}
+  volumeName: {{ .Values.redisStore.volumeName }}
+  {{- end }}
 {{- end }}

--- a/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -24,5 +24,5 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: redis-store
-  type: ClusterIP
+  type: {{ .Values.redisStore.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -23,4 +23,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: repo-updater
-  type: ClusterIP
+  type: {{ .Values.repoUpdater.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -26,4 +26,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: searcher
-  type: ClusterIP
+  type: {{ .Values.searcher.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -26,4 +26,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: symbols
-  type: ClusterIP
+  type: {{ .Values.symbols.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -21,4 +21,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: syntect-server
-  type: ClusterIP
+  type: {{ .Values.syntectServer.serviceType | default "ClusterIP" }}

--- a/sourcegraph/templates/worker/worker.Service.yaml
+++ b/sourcegraph/templates/worker/worker.Service.yaml
@@ -26,4 +26,4 @@ spec:
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: worker
-  type: ClusterIP
+  type: {{ .Values.worker.serviceType | default "ClusterIP" }}

--- a/sourcegraph/values.yaml
+++ b/sourcegraph/values.yaml
@@ -4,7 +4,8 @@ sourcegraph:
   image:
     repository: index.docker.io/sourcegraph
     pullPolicy: IfNotPresent
-    tag: "{{ .Chart.AppVersion }}"
+    defaultTag: "{{ .Chart.AppVersion }}"
+    useGlobalTagAsDefault: false # When true, sourcegraph.image.defaultTag is used as the default defaultTag for all services, instead of service-specific default defaultTags
   imagePullSecrets: []
   revisionHistoryLimit: 10
 
@@ -15,7 +16,7 @@ sourcegraph:
 
 alpine:
   image:
-    tag: "insiders@sha256:670237bcaea9f8055d8986b5d992970f3f22c6f2f2e855d441b1ec074ebc6ff2"
+    defaultTag: "insiders@sha256:670237bcaea9f8055d8986b5d992970f3f22c6f2f2e855d441b1ec074ebc6ff2"
   resources:
     limits:
       cpu: "10m"
@@ -29,7 +30,7 @@ alpine:
 cadvisor:
   enabled: true
   image:
-    tag: "insiders@sha256:9d274f2cb48b2bd7df24e02e81da96b28e297a5671ccabbdf5cbf733605293a1"
+    defaultTag: "insiders@sha256:9d274f2cb48b2bd7df24e02e81da96b28e297a5671ccabbdf5cbf733605293a1"
   resources:
     requests:
       memory: 200Mi
@@ -47,7 +48,7 @@ codeInsightsDB:
     POSTGRES_PASSWORD: # Accessible by Sourcegraph applications on the network only, so password auth is not used.
       value: password
   image:
-    tag: "insiders@sha256:dfd916b6456ffbeb6ba2d05f92aa2bd77273e617d80142d76bfb23fa255e5e21"
+    defaultTag: "insiders@sha256:dfd916b6456ffbeb6ba2d05f92aa2bd77273e617d80142d76bfb23fa255e5e21"
   replicaCount: 1
   resources:
     limits:
@@ -64,7 +65,7 @@ codeInsightsDB:
 codeIntelDB:
   enabled: true
   image:
-    tag: "insiders@sha256:d42cefb7dfa69c08361ad4aba37c20ae36dfdcf2ca6ed05e2d85b2bfa7305f57"
+    defaultTag: "insiders@sha256:d42cefb7dfa69c08361ad4aba37c20ae36dfdcf2ca6ed05e2d85b2bfa7305f57"
   replicaCount: 1
   resources:
     limits:
@@ -84,7 +85,7 @@ codeIntelDB:
 
 frontend:
   image:
-    tag: "insiders@sha256:cc01a2f65e5bb9ef8d762eaa973cf1287507c74d5d4c76b3e00d278c40b356a9"
+    defaultTag: "insiders@sha256:cc01a2f65e5bb9ef8d762eaa973cf1287507c74d5d4c76b3e00d278c40b356a9"
   replicaCount: 2
   resources:
     limits:
@@ -130,7 +131,7 @@ frontend:
 
 githubProxy:
   image:
-    tag: "insiders@sha256:efd6d9b1093d18202323cf9bca788df146d155ccb117d6488066beb867ac4e2e"
+    defaultTag: "insiders@sha256:efd6d9b1093d18202323cf9bca788df146d155ccb117d6488066beb867ac4e2e"
   replicaCount: 1
   resources:
     limits:
@@ -144,7 +145,7 @@ githubProxy:
 
 gitserver:
   image:
-    tag: "insiders@sha256:37f04a63676a2496bfb87f55442e574dc20dcba66a8ebd636c7f7212fef2e0d4"
+    defaultTag: "insiders@sha256:37f04a63676a2496bfb87f55442e574dc20dcba66a8ebd636c7f7212fef2e0d4"
   replicaCount: 1
   storageSize: "200Gi"
   resources:
@@ -162,7 +163,7 @@ gitserver:
 grafana:
   enabled: true
   image:
-    tag: "insiders@sha256:1331577ff6080e4a9ac6ec32074815a6eabe7e6abbe8042aa6f05a25eb742a39"
+    defaultTag: "insiders@sha256:1331577ff6080e4a9ac6ec32074815a6eabe7e6abbe8042aa6f05a25eb742a39"
   replicaCount: 1
   storageSize: "2Gi"
   resources:
@@ -180,7 +181,7 @@ grafana:
 
 indexedSearch:
   image:
-    tag: "insiders@sha256:5168403765834c6fd064fc7004efd6530104430868712a1ebd3a47ab5e2be031"
+    defaultTag: "insiders@sha256:5168403765834c6fd064fc7004efd6530104430868712a1ebd3a47ab5e2be031"
   replicaCount: 1
   # The size of disk to used for search indexes.
   # This should typically be gitserver disk size multipled by the number of gitserver shards.
@@ -200,7 +201,7 @@ minio:
   replicaCount: 1
   storageSize: "100Gi"
   image:
-    tag: "insiders@sha256:fccfad6cbd7b717472c7f200cdd65807ff742f883fe1d08986fc09ff3bd7df5e"
+    defaultTag: "insiders@sha256:fccfad6cbd7b717472c7f200cdd65807ff742f883fe1d08986fc09ff3bd7df5e"
   resources:
     limits:
       cpu: "1"
@@ -218,7 +219,7 @@ minio:
 
 searchIndexer:
   image:
-    tag: "insiders@sha256:2d0b691e5495a6bcc154e2c9d17a2721e3b2358a71a88cb9f84f284f7980d1dd"
+    defaultTag: "insiders@sha256:2d0b691e5495a6bcc154e2c9d17a2721e3b2358a71a88cb9f84f284f7980d1dd"
   resources:
     # zoekt-indexserver is CPU bound. The more CPU you allocate to it, the
     # lower lag between a new commit and it being indexed for search.
@@ -232,7 +233,7 @@ searchIndexer:
 pgsql:
   enabled: true
   image:
-    tag: "insiders@sha256:98d134adbc3e29c7125b541a58771f4a6d818876c47bc385ef4ab889d8633a2a"
+    defaultTag: "insiders@sha256:98d134adbc3e29c7125b541a58771f4a6d818876c47bc385ef4ab889d8633a2a"
   replicaCount: 1
   resources:
     limits:
@@ -253,7 +254,7 @@ pgsql:
 
 postgresExporter:
   image:
-    tag: "insiders@sha256:ed49696495575ef26dd51997eac9fcc92be9023bc7762b56f045e8615595e61e"
+    defaultTag: "insiders@sha256:ed49696495575ef26dd51997eac9fcc92be9023bc7762b56f045e8615595e61e"
   resources:
     limits:
       cpu: 10m
@@ -264,7 +265,7 @@ postgresExporter:
 
 preciseCodeIntel:
   image:
-    tag: "insiders@sha256:c1690021447dc6f9b50d520df9284d594b24f09f3acadc27a407b31f7592fc0f"
+    defaultTag: "insiders@sha256:c1690021447dc6f9b50d520df9284d594b24f09f3acadc27a407b31f7592fc0f"
   replicaCount: 2
   resources:
     limits:
@@ -281,7 +282,7 @@ preciseCodeIntel:
 
 queryRunner:
   image:
-    tag: "insiders@sha256:cb6285b7021f0fe3953846e58006f82816cba046cbe6892cebff667905ab5a50"
+    defaultTag: "insiders@sha256:cb6285b7021f0fe3953846e58006f82816cba046cbe6892cebff667905ab5a50"
   replicaCount: 1
   resources:
     limits:
@@ -296,7 +297,7 @@ queryRunner:
 redisCache:
   enabled: true
   image:
-    tag: "insiders@sha256:3c83d172a9c320ef4a5a236a76df7611d7f8f76021eb3bf22b28200ce764acce"
+    defaultTag: "insiders@sha256:3c83d172a9c320ef4a5a236a76df7611d7f8f76021eb3bf22b28200ce764acce"
   replicaCount: 1
   resources:
     limits:
@@ -311,7 +312,7 @@ redisCache:
 
 redisExporter:
   image:
-    tag: "84464_2021-01-15_c2e4c28@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70"
+    defaultTag: "84464_2021-01-15_c2e4c28@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70"
   resources:
     limits:
       cpu: 10m
@@ -323,7 +324,7 @@ redisExporter:
 redisStore:
   enabled: true
   image:
-    tag: "insiders@sha256:bd1035f2407901ad6c954933e41f5d555786a20b7cb2bafd6649cecd16522602"
+    defaultTag: "insiders@sha256:bd1035f2407901ad6c954933e41f5d555786a20b7cb2bafd6649cecd16522602"
   replicaCount: 1
   resources:
     limits:
@@ -338,7 +339,7 @@ redisStore:
 
 repoUpdater:
   image:
-    tag: "insiders@sha256:7a54d944125aae8e985ec5c607ec1435d7410687f26b7c705e8baa9f94a41191"
+    defaultTag: "insiders@sha256:7a54d944125aae8e985ec5c607ec1435d7410687f26b7c705e8baa9f94a41191"
   replicaCount: 1
   resources:
     limits:
@@ -352,7 +353,7 @@ repoUpdater:
 
 searcher:
   image:
-    tag: "insiders@sha256:bde5e1eaaf73adf6e915ec47a788bdee96b72d617b89acb0e350001addc08d28"
+    defaultTag: "insiders@sha256:bde5e1eaaf73adf6e915ec47a788bdee96b72d617b89acb0e350001addc08d28"
   replicaCount: 2
   resources:
     limits:
@@ -368,7 +369,7 @@ searcher:
 
 symbols:
   image:
-    tag: "insiders@sha256:468ce5a77133f508f1ef5f4010b7676c4db7f6795137f768e36fc46ee5c6c072"
+    defaultTag: "insiders@sha256:468ce5a77133f508f1ef5f4010b7676c4db7f6795137f768e36fc46ee5c6c072"
   replicaCount: 1
   resources:
     limits:
@@ -384,7 +385,7 @@ symbols:
 
 syntectServer:
   image:
-    tag: "insiders@sha256:f15a5dcc88ab8574049e37c9985750d0a4aa3d1ec665ec8345f85206155364fb"
+    defaultTag: "insiders@sha256:f15a5dcc88ab8574049e37c9985750d0a4aa3d1ec665ec8345f85206155364fb"
   replicaCount: 1
   resources:
     limits:
@@ -398,7 +399,7 @@ syntectServer:
 
 worker:
   image:
-    tag: "insiders@sha256:f23c47ec08a7e31bad546b967fd7e7cb9811c4e7a1147f79a59944cd9e24be40"
+    defaultTag: "insiders@sha256:f23c47ec08a7e31bad546b967fd7e7cb9811c4e7a1147f79a59944cd9e24be40"
   replicaCount: 1
   resources:
     limits:
@@ -413,7 +414,7 @@ worker:
 prometheus:
   enabled: true
   image:
-    tag: "insiders@sha256:525fe0479ea043e1c154f656f187d825f40b57c6a38fcbf2b2eb98d4a1f8d8c8"
+    defaultTag: "insiders@sha256:525fe0479ea043e1c154f656f187d825f40b57c6a38fcbf2b2eb98d4a1f8d8c8"
   replicaCount: 1
   # Prometheus is relied upon to monitor services for sending alerts to site admins when
   # something is wrong with Sourcegraph, thus its memory requests and limits are the same to
@@ -439,7 +440,7 @@ prometheus:
 jaeger:
   enabled: true
   image:
-    tag: "insiders@sha256:abcbae9cb113f1ff2b0ad77583b23ea144a481bb2fa1a982d770b49dcd3f784e"
+    defaultTag: "insiders@sha256:abcbae9cb113f1ff2b0ad77583b23ea144a481bb2fa1a982d770b49dcd3f784e"
   replicaCount: 1
   resources:
     limits:
@@ -457,7 +458,7 @@ tracing:
   enabled: true
   image:
     name: jaeger-agent
-    tag: "insiders@sha256:b980c65f7675a83c2181ba9b5d98efd257709dec1c261d1f93197238076249ab"
+    defaultTag: "insiders@sha256:b980c65f7675a83c2181ba9b5d98efd257709dec1c261d1f93197238076249ab"
   resources:
     limits:
       cpu: "1"


### PR DESCRIPTION
- Modify the image tag logic so customers can better take advantage of both a global default and service-specific overrides
- Allow customization for service types. This is not fully fleshed out and changing the service type on a headless service may actually be impossible.
- Allow PVC's to be bound to a specific volume name