### PR TITLE
Support running SG without create role permissions

### DIFF
--- a/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.frontend.privileged -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -29,3 +30,4 @@ rules:
     - get
     - list
     - watch
+{{- end }}

--- a/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -8,9 +8,15 @@ metadata:
     app.kubernetes.io/component: frontend
   name: {{ default "sourcegraph-frontend" .Values.frontend.name }}
 roleRef:
+{{- if .Values.frontend.privileged }}
   apiGroup: "rbac.authorization.k8s.io"
   kind: Role
   name: {{ default "sourcegraph-frontend" .Values.frontend.name }}
+{{- else }}
+  apiGroup: ""
+  kind: ClusterRole
+  name: view
+{{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "sourcegraph.serviceAccountName" (list . "frontend") }}

--- a/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enabled -}}
+{{- if and .Values.prometheus.enabled .Values.prometheus.privileged -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
@@ -42,6 +42,7 @@ data:
     # default named port `https`. This works for single API server deployments as
     # well as HA API server deployments.
     scrape_configs:
+    {{- if .Values.prometheus.privileged }}
     - job_name: 'kubernetes-apiservers'
 
       kubernetes_sd_configs:
@@ -111,6 +112,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
+    {{- end }} # End of privileged config
 
     # Scrape config for service endpoints.
     #
@@ -127,6 +129,9 @@ data:
 
       kubernetes_sd_configs:
       - role: endpoints
+        namespaces:
+          names:
+           - {{ .Release.Namespace }}
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_annotation_sourcegraph_prometheus_scrape]
@@ -236,7 +241,7 @@ data:
       # target_label: kubernetes_namespace
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: {{ .Release.Namespace }}
+        target_label: ns
 
       metric_relabel_configs:
       # cAdvisor-specific customization. Drop container metrics exported by cAdvisor

--- a/sourcegraph/templates/prometheus/prometheus.RoleBinding.yaml
+++ b/sourcegraph/templates/prometheus/prometheus.RoleBinding.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.prometheus.enabled .Values.prometheus.privileged -}}
+{{- if and .Values.prometheus.enabled (not .Values.prometheus.privileged) -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   labels:
     category: rbac
@@ -8,9 +8,9 @@ metadata:
     app.kubernetes.io/component: prometheus
   name: {{ default "prometheus" .Values.prometheus.name }}
 roleRef:
-  apiGroup: "rbac.authorization.k8s.io"
+  apiGroup: ""
   kind: ClusterRole
-  name: {{ default "prometheus" .Values.prometheus.name }}
+  name: view
 subjects:
 - kind: ServiceAccount
   name: {{ default "prometheus" .Values.prometheus.name }}

--- a/sourcegraph/values.yaml
+++ b/sourcegraph/values.yaml
@@ -18,7 +18,7 @@ nameOverride: ""
 #   replicaCount: 1
 #   image: {}
 
-alpine:
+alpine: # Used in init containers
   image:
     defaultTag: insiders@sha256:670237bcaea9f8055d8986b5d992970f3f22c6f2f2e855d441b1ec074ebc6ff2
   podSecurityContext:
@@ -367,6 +367,7 @@ prometheus:
     runAsUser: 100
     runAsGroup: 100
     readOnlyRootFilesystem: true
+  privileged: true
   replicaCount: 1
   # Prometheus is relied upon to monitor services for sending alerts to site admins when
   # something is wrong with Sourcegraph, thus its memory requests and limits are the same to

--- a/sourcegraph/values.yaml
+++ b/sourcegraph/values.yaml
@@ -142,6 +142,7 @@ frontend:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  privileged: true # Creates Role instead of using existing roles
   replicaCount: 2
   resources:
     limits:


### PR DESCRIPTION
Matches the changes for frontend and prometheus from the https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph/-/tree/overlays/non-privileged overlay. Prometheus and Frontend bind to a pre-existing clusterrole view instead of creating their own role.

Not enabled by default.