### PR TITLE
Rename searchIndexer to indexedSearchIndexer to keep configuration alongside indexedSearch

### DIFF
--- a/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -73,10 +73,10 @@ spec:
         {{- toYaml .Values.indexedSearch.extraVolumeMounts | nindent 8 }}
         {{- end }}
       - name: zoekt-indexserver
-        image: {{ include "sourcegraph.image" (list . "searchIndexer" "search-indexer") }}
+        image: {{ include "sourcegraph.image" (list . "indexedSearchIndexer" "search-indexer") }}
         terminationMessagePolicy: FallbackToLogsOnError
         env:
-        {{- range $name, $item := .Values.searchIndexer.env}}
+        {{- range $name, $item := .Values.indexedSearchIndexer.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}
         {{- end }}
@@ -84,14 +84,14 @@ spec:
         - containerPort: 6072
           name: index-http
         resources:
-        {{- toYaml .Values.searchIndexer.resources | nindent 10 }}
+        {{- toYaml .Values.indexedSearchIndexer.resources | nindent 10 }}
         securityContext:
-          {{- toYaml .Values.searchIndexer.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.indexedSearchIndexer.podSecurityContext | nindent 10 }}
         volumeMounts:
         - mountPath: /data
           name: data
-        {{- if .Values.searchIndexer.extraVolumeMounts }}
-        {{- toYaml .Values.searchIndexer.extraVolumeMounts | nindent 8 }}
+        {{- if .Values.indexedSearchIndexer.extraVolumeMounts }}
+        {{- toYaml .Values.indexedSearchIndexer.extraVolumeMounts | nindent 8 }}
         {{- end }}
       {{- if .Values.indexedSearch.extraContainers }}
         {{- toYaml .Values.indexedSearch.extraContainers | nindent 6 }}

--- a/sourcegraph/values.yaml
+++ b/sourcegraph/values.yaml
@@ -248,6 +248,24 @@ indexedSearch:
   # This should typically be gitserver disk size multipled by the number of gitserver shards.
   storageSize: 200Gi
 
+indexedSearchIndexer:
+  image:
+    defaultTag: insiders@sha256:2d0b691e5495a6bcc154e2c9d17a2721e3b2358a71a88cb9f84f284f7980d1dd
+  podSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 100
+    runAsGroup: 101
+    readOnlyRootFilesystem: true
+  resources:
+    # zoekt-indexserver is CPU bound. The more CPU you allocate to it, the
+    # lower lag between a new commit and it being indexed for search.
+    limits:
+      cpu: "8"
+      memory: 8G
+    requests:
+      cpu: "4"
+      memory: 4G
+
 minio:
   enabled: true
   env:
@@ -464,24 +482,6 @@ repoUpdater:
     requests:
       cpu: "1"
       memory: 500Mi
-
-searchIndexer:
-  image:
-    defaultTag: insiders@sha256:2d0b691e5495a6bcc154e2c9d17a2721e3b2358a71a88cb9f84f284f7980d1dd
-  podSecurityContext:
-    allowPrivilegeEscalation: false
-    runAsUser: 100
-    runAsGroup: 101
-    readOnlyRootFilesystem: true
-  resources:
-    # zoekt-indexserver is CPU bound. The more CPU you allocate to it, the
-    # lower lag between a new commit and it being indexed for search.
-    limits:
-      cpu: "8"
-      memory: 8G
-    requests:
-      cpu: "4"
-      memory: 4G
 
 searcher:
   image:


### PR DESCRIPTION
indexedSearch is unusual because it combines both zoekt-webserver and indexserver, each with separate images, resources and security contexts. Since they're deployed together, I wanted to keep the configuration relatively close as well.

An alternative approach would be to make both the searcher and indexer a subconfiguration of indexedSearch, i.e.:
```
indexedSearch:
  indexer:
    image: <zoekt-indexserver>
    etc etc
  searcher:
    image: <zoekt-webserver>
    etc etc
```

I chose not to take that approach and instead keep both as a top-level configuration because it makes the structure more consistent. The consistency make it easier to automate changes such as updating the image references.