### PR TITLE
Add configuration for mounting ssh secret in gitserver

### DIFF
--- a/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -72,6 +72,10 @@ spec:
         volumeMounts:
         - mountPath: /data/repos
           name: repos
+        {{- if .Values.gitserver.sshSecret }}
+        - mountPath: /home/sourcegraph/.ssh
+          name: ssh
+        {{- end }}
         {{- if .Values.gitserver.extraVolumeMounts }}
         {{- toYaml .Values.gitserver.extraVolumeMounts | nindent 8 }}
         {{- end }}
@@ -95,6 +99,12 @@ spec:
       {{- end }}
       volumes:
       - name: repos
+      {{- if .Values.gitserver.sshSecret }}
+      - name: ssh
+        secret:
+          defaultMode: 0644
+          secretName: {{ .Values.gitserver.sshSecret }}
+      {{- end }}
       {{- if .Values.gitserver.extraVolumes }}
       {{- toYaml .Values.gitserver.extraVolumes | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
Make it easier to use an SSH key for credentials in gitserver by automatically generating the correct volume refs / mounts when `gitserver.sshSecret` is provided (The secret must exist already - we don't generate it). Follows the pattern documented in https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph@a3e354cb4542794683c6df1ee154972b6f08543a/-/blob/base/gitserver/gitserver.StatefulSet.yaml?L89.

Note - there's a little bit of confusion about what file permissions are needed, documented in https://github.com/sourcegraph/sourcegraph/issues/29117. I erred on the side of more permissions in the meantime.