### PR TITLE
Mount home directory as an emptyDir for frontend

### DIFF
--- a/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -100,6 +100,8 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
+        - mountPath: /home/sourcegraph
+          name: home-dir
         {{- if .Values.frontend.extraVolumeMounts }}
         {{- toYaml .Values.frontend.extraVolumeMounts | nindent 8 }}
         {{- end }}
@@ -125,6 +127,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: cache-ssd
+      - emptyDir: {}
+        name: home-dir
       {{- if .Values.frontend.extraVolumes }}
       {{- toYaml .Values.frontend.extraVolumes | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
Frontend pods try to write the site-config.json to /home/sourcegraph, but fail because we're forcing a read-only root file system.

I confirmed that the instructions to use a configmap for the site config still work with this change (https://docs.sourcegraph.com/admin/config/advanced_config_file)