### PR TITLE
Add Github Action to publish chart versions

### DIFF
--- a/.github/workflows/chart_publish.yml
+++ b/.github/workflows/chart_publish.yml
@@ -1,0 +1,30 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        env:
+          CR_TOKEN: "${{ secrets.GH_PROJECTS_ACTION_TOKEN }}"


### PR DESCRIPTION
Uses https://github.com/marketplace/actions/helm-chart-releaser to auto-publish the helm chart to a Github page (https://sourcegraph.github.io/deploy-sourcegraph-helm/). Right now it will publish any commit on main to the releases page, but we can make it dependent on checks passing (like those added in https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/23).