### PR TITLE
Add toggle for cadvisor podSecurityPolicy resource

### DIFF
--- a/charts/sourcegraph/Chart.yaml
+++ b/charts/sourcegraph/Chart.yaml
@@ -5,7 +5,7 @@ description: Chart for installing Sourcegraph
 type: application
 
 # Chart version, separate from Sourcegraph
-version: 0.1.0
+version: 0.1.1
 
 # Version of Sourcegraph release
 appVersion: "3.35.1"

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -74,8 +74,6 @@ To upgrade to a new version of the helm chart:
 Search for available versions by running:
 `helm search repo sourcegraph --versions`
 
-TODO: define versioning scheme
-
 ## Third-party resources
 
 ### cAdvisor

--- a/charts/sourcegraph/templates/cadvisor/cadvisor.PodSecurityPolicy.yaml
+++ b/charts/sourcegraph/templates/cadvisor/cadvisor.PodSecurityPolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cadvisor.enabled -}}
+{{- if and .Values.cadvisor.enabled .Values.cadvisor.podSecurityPolicy.enabled  -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -91,6 +91,8 @@ cadvisor:
   image:
     defaultTag: 3.35.1@sha256:1a1b07c91ee0bd32240a75370998d7a990dc5ebe34d1aa4b19f331adb9017034
     name: "cadvisor"
+  podSecurityPolicy:
+    enabled: false
   resources:
     limits:
       cpu: 300m


### PR DESCRIPTION
Allow cadvisor PSP resource to be toggled off. PSP's are deprecated as of Kubernetes 1.21 and will be fully removed in Kubernetes 1.25.

It's not terribly urgent to make this change but I'm using this opportunity to test the publish pipeline.