### PR TITLE
Fix postgres monitoring for pgsql

### DIFF
--- a/charts/sourcegraph/Chart.yaml
+++ b/charts/sourcegraph/Chart.yaml
@@ -5,7 +5,7 @@ description: Chart for installing Sourcegraph
 type: application
 
 # Chart version, separate from Sourcegraph
-version: 0.1.1
+version: 0.1.2
 
 # Version of Sourcegraph release
 appVersion: "3.35.1"

--- a/charts/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -105,10 +105,12 @@ spec:
         {{- toYaml .Values.pgsql.extraContainers | nindent 6 }}
       {{- end }}
       - env:
-        {{- range $name, $item := .Values.postgresExporter.env}}
+        {{- range $name, $item := .Values.pgsql.postgresExporter.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}
         {{- end }}
+        - name: PG_EXPORTER_EXTEND_QUERY_PATH
+          value: /config/queries.yaml
         image: {{ include "sourcegraph.image" (list . "postgresExporter") }}
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -363,11 +363,6 @@ minio:
 
 pgsql:
   enabled: true
-  env:
-    DATA_SOURCE_NAME:
-      value: postgres://sg:@localhost:5432/?sslmode=disable
-    PG_EXPORTER_EXTEND_QUERY_PATH:
-      value: /config/queries.yaml
   existingConfig: "" # Name of an existing configmap
   image:
     defaultTag: 3.35.1@sha256:4766d3f59d8c81c1e525cbc03cf2c8fb321026821c4230ab63eed8b36b87e09e
@@ -377,6 +372,10 @@ pgsql:
     runAsUser: 999
     runAsGroup: 999
     readOnlyRootFilesystem: true
+  postgresExporter:
+    env:
+      DATA_SOURCE_NAME:
+        value: postgres://sg:@localhost:5432/?sslmode=disable
   replicaCount: 1
   resources:
     limits:


### PR DESCRIPTION
The postgres exporter for the pgsql deployment was not configured correctly - now the env specification matches codeintel-db, as intended, and monitoring is working.