### PR TITLE
Add mandatory /tmp dir to searcher deployment, fix missing volume configuration

### DIFF
--- a/charts/sourcegraph/Chart.yaml
+++ b/charts/sourcegraph/Chart.yaml
@@ -5,7 +5,7 @@ description: Chart for installing Sourcegraph
 type: application
 
 # Chart version, separate from Sourcegraph
-version: 0.1.3
+version: 0.1.4
 
 # Version of Sourcegraph release
 appVersion: "3.35.1"

--- a/charts/sourcegraph/examples/extra-volumes/override.yaml
+++ b/charts/sourcegraph/examples/extra-volumes/override.yaml
@@ -1,0 +1,9 @@
+# Demonstrate adding an additional volume to a deployment
+
+frontend:
+  extraVolumes:
+  - emptyDir: {}
+    name: tmpdir
+  extraVolumeMounts:
+  - mountPath: /tmp
+    name: tmpdir

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -64,6 +64,10 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.githubProxy.podSecurityContext | nindent 10 }}
+        volumeMounts:
+        {{- if .Values.githubProxy.extraVolumeMounts }}
+        {{- toYaml .Values.githubProxy.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       {{- include "sourcegraph.tracing" . | nindent 6 }}
       {{- if .Values.githubProxy.extraContainers }}
         {{- toYaml .Values.githubProxy.extraContainers | nindent 6 }}
@@ -85,4 +89,8 @@ spec:
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.githubProxy.extraVolumes }}
+      {{- toYaml .Values.githubProxy.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -79,6 +79,10 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.tracing.podSecurityContext | nindent 10 }}
+        volumeMounts:
+        {{- if .Values.tracing.extraVolumeMounts }}
+        {{- toYaml .Values.tracing.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       {{- if .Values.tracing.extraContainers }}
         {{- toYaml .Values.tracing.extraContainers | nindent 6 }}
       {{- end }}
@@ -99,5 +103,9 @@ spec:
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.tracing.extraVolumes }}
+      {{- toYaml .Values.tracing.extraVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -83,6 +83,10 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.preciseCodeIntel.podSecurityContext | nindent 10 }}
+        volumeMounts:
+        {{- if .Values.preciseCodeIntel.extraVolumeMounts }}
+        {{- toYaml .Values.preciseCodeIntel.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       {{- if .Values.preciseCodeIntel.extraContainers }}
         {{- toYaml .Values.preciseCodeIntel.extraContainers | nindent 6 }}
       {{- end }}
@@ -103,4 +107,8 @@ spec:
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.preciseCodeIntel.extraVolumes }}
+      {{- toYaml .Values.preciseCodeIntel.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -66,6 +66,9 @@ spec:
           name: data
         - mountPath: /sg_prometheus_add_ons
           name: config
+        {{- if .Values.prometheus.extraVolumeMounts }}
+        {{- toYaml .Values.prometheus.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.prometheus.resources | nindent 10 }}
@@ -103,4 +106,7 @@ spec:
           defaultMode: 0777
           name: {{ default "prometheus" .Values.prometheus.existingConfig .Values.prometheus.name }}
         name: config
+      {{- if .Values.prometheus.extraVolumes }}
+      {{- toYaml .Values.prometheus.extraVolumes | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -72,6 +72,9 @@ spec:
         volumeMounts:
         - mountPath: /redis-data
           name: redis-data
+        {{- if .Values.redisCache.extraVolumeMounts }}
+        {{- toYaml .Values.redisCache.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       - name: redis-exporter
         image: {{ include "sourcegraph.image" (list . "redisExporter") }}
         terminationMessagePolicy: FallbackToLogsOnError
@@ -113,4 +116,7 @@ spec:
       - name: redis-data
         persistentVolumeClaim:
           claimName: {{ default "redis-cache" .Values.redisCache.name }}
+      {{- if .Values.redisCache.extraVolumes }}
+      {{- toYaml .Values.redisCache.extraVolumes | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -71,6 +71,9 @@ spec:
         volumeMounts:
         - mountPath: /redis-data
           name: redis-data
+        {{- if .Values.redisStore.extraVolumeMounts }}
+        {{- toYaml .Values.redisStore.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       - name: redis-exporter
         image: {{ include "sourcegraph.image" (list . "redisExporter") }}
         terminationMessagePolicy: FallbackToLogsOnError
@@ -113,4 +116,7 @@ spec:
       - name: redis-data
         persistentVolumeClaim:
           claimName: {{ default "redis-store" .Values.redisStore.name }}
+      {{- if .Values.redisStore.extraVolumes }}
+      {{- toYaml .Values.redisStore.extraVolumes | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -82,6 +82,10 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.repoUpdater.podSecurityContext | nindent 10 }}
+        volumeMounts:
+        {{- if .Values.repoUpdater.extraVolumeMounts }}
+        {{- toYaml .Values.repoUpdater.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       {{- include "sourcegraph.tracing" . | nindent 6 }}
       {{- if .Values.repoUpdater.extraContainers }}
         {{- toYaml .Values.repoUpdater.extraContainers | nindent 6 }}
@@ -103,4 +107,8 @@ spec:
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.repoUpdater.extraVolumes }}
+      {{- toYaml .Values.repoUpdater.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -83,6 +83,8 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
+        - mountPath: /tmp
+          name: tmpdir
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.searcher.resources | nindent 10 }}
@@ -114,3 +116,5 @@ spec:
       volumes:
       - emptyDir: {}
         name: cache-ssd
+      - emptyDir: {}
+        name: tmpdir

--- a/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -85,6 +85,9 @@ spec:
           name: cache-ssd
         - mountPath: /tmp
           name: tmpdir
+        {{- if .Values.searcher.extraVolumeMounts }}
+        {{- toYaml .Values.searcher.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.searcher.resources | nindent 10 }}
@@ -118,3 +121,6 @@ spec:
         name: cache-ssd
       - emptyDir: {}
         name: tmpdir
+      {{- if .Values.searcher.extraVolumes }}
+      {{- toYaml .Values.searcher.extraVolumes | nindent 6 }}
+      {{- end }}

--- a/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -89,6 +89,9 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
+        {{- if .Values.symbols.extraVolumeMounts }}
+        {{- toYaml .Values.symbols.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.symbols.resources | nindent 10 }}
@@ -120,3 +123,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: cache-ssd
+      {{- if .Values.symbols.extraVolumes }}
+      {{- toYaml .Values.symbols.extraVolumes | nindent 6 }}
+      {{- end }}

--- a/charts/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -73,6 +73,10 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.syntectServer.podSecurityContext | nindent 10 }}
+        volumeMounts:
+        {{- if .Values.syntectServer.extraVolumeMounts }}
+        {{- toYaml .Values.syntectServer.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       {{- if .Values.syntectServer.extraContainers }}
         {{- toYaml .Values.syntectServer.extraContainers | nindent 6 }}
       {{- end }}
@@ -93,4 +97,8 @@ spec:
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.syntectServer.extraVolumes }}
+      {{- toYaml .Values.syntectServer.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -83,6 +83,10 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.worker.podSecurityContext | nindent 10 }}
+        volumeMounts:
+        {{- if .Values.worker.extraVolumeMounts }}
+        {{- toYaml .Values.worker.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       {{- if .Values.worker.extraContainers }}
         {{- toYaml .Values.worker.extraContainers | nindent 6 }}
       {{- end }}
@@ -103,4 +107,8 @@ spec:
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.worker.extraVolumes }}
+      {{- toYaml .Values.worker.extraVolumes | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
The searcher deployment relies on having a writable `/tmp` directory. Since we run by default with a read-only root file system, structural searches fail to run without this directory.

While adding the /tmp mount, I noticed that the optional volume configuration was missing on many deployments, so I fixed that as well.