### PR TITLE
Add migrator initContainers to frontend

### DIFF
--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -45,6 +45,26 @@ spec:
         app: sourcegraph-frontend
         deploy: sourcegraph
     spec:
+      initContainers:
+      {{- if .Values.migrator.enabled }}
+      - name: migrator
+        image: {{ include "sourcegraph.image" (list . "migrator") }}
+        args:
+        - up
+        env:
+        {{- range $name, $item := .Values.frontend.env }}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
+        {{- range $name, $item := .Values.migrator.env }}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.migrator.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.migrator.podSecurityContext | nindent 10 }}
+      {{- end }}
       containers:
       - name: frontend
         image: {{ include "sourcegraph.image" (list . "frontend") }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -221,6 +221,19 @@ frontend:
     create: true
     name: sourcegraph-frontend
 
+migrator:
+  enabled: true
+  image:
+    defaultTag: 3.37.0@sha256:404df69cfee90eaa9a3ab8b540a2d9affd22605caa5326a8ac4ba016e1d6d815
+    name: "migrator"
+  env: {}
+  resources: {}
+  podSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 100
+    runAsGroup: 101
+    readOnlyRootFilesystem: true
+
 githubProxy:
   image:
     defaultTag: 3.37.0@sha256:3b173e36f958b68479ae829d784c63346701df417afa14d14ae657a84e630dd5


### PR DESCRIPTION
close https://github.com/sourcegraph/sourcegraph/issues/31257

Not blocking 3.37 release

### Should we use a `Job` with [helm hook](https://helm.sh/docs/topics/charts_hooks/)?

I don't have good experience working with helm hook in the past and often yield unexpected result. For example, the `helm install/update` will just fail when the cluster fails to schedule pods, or `pgsql` is not ready yet.

On the other hand, we can run the `Job` with `post-install` and `post-upgrade` hooks. Maybe it can help increase visibility when there's a failing migration?