### PR TITLE
Fix default global tolerations value

### DIFF
--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -23,7 +23,7 @@ sourcegraph:
   podLabels: {}
   revisionHistoryLimit: 10
   serviceLabels: {}
-  tolerations: {}
+  tolerations: []
 
 
 # Generic application configuration options, used by most applications below


### PR DESCRIPTION
## Test plan
before the change running `helm template`

```
coalesce.go:220: warning: cannot overwrite table with non table for sourcegraph.sourcegraph.tolerations (map[])
```

After the change, it's no longer there.