### PR TITLE
Add per-service scheduling config support

### DIFF
--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -58,3 +58,42 @@ useGlobalTagAsDefault configuration
 
 {{- $top.Values.sourcegraph.image.repository }}/{{ $imageName }}:{{ default $defaultTag (index $top.Values $service "image" "tag") }}
 {{- end }}
+
+{{- define "sourcegraph.nodeSelector" -}}
+{{- $top := index . 0 }}
+{{- $service := index . 1 }}
+{{- $globalNodeSelector := (index $top.Values "sourcegraph" "nodeSelector") }}
+{{- $serviceNodeSelector := (index $top.Values $service "nodeSelector") }}
+nodeSelector:
+{{- if $serviceNodeSelector }}
+{{- $serviceNodeSelector | toYaml | trim | nindent 2 }}
+{{- else if $globalNodeSelector }}
+{{- $globalNodeSelector | toYaml | trim | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "sourcegraph.affinity" -}}
+{{- $top := index . 0 }}
+{{- $service := index . 1 }}
+{{- $globalAffinity := (index $top.Values "sourcegraph" "affinity") }}
+{{- $serviceAffinity := (index $top.Values $service "affinity") }}
+affinity:
+{{- if $serviceAffinity }}
+{{- $serviceAffinity | toYaml | trim | nindent 2 }}
+{{- else if $globalAffinity }}
+{{- $globalAffinity | toYaml | trim | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "sourcegraph.tolerations" -}}
+{{- $top := index . 0 }}
+{{- $service := index . 1 }}
+{{- $globalTolerations := (index $top.Values "sourcegraph" "tolerations") }}
+{{- $serviceTolerations := (index $top.Values $service "tolerations") }}
+tolerations:
+{{- if $serviceTolerations }}
+{{- $serviceTolerations | toYaml | trim | nindent 2 }}
+{{- else if $globalTolerations }}
+{{- $globalTolerations | toYaml | trim | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
@@ -95,18 +95,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.cadvisor.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "cadvisor" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "cadvisor" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "cadvisor" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -81,18 +81,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.codeInsightsDB.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "codeInsightsDB" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "codeInsightsDB" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "codeInsightsDB" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
@@ -115,18 +115,9 @@ spec:
       terminationGracePeriodSeconds: 120
       securityContext:
         {{- toYaml .Values.codeIntelDB.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "codeIntelDB" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "codeIntelDB" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "codeIntelDB" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -107,18 +107,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.frontend.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "frontend" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "frontend" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "frontend" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -74,18 +74,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.githubProxy.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "githubProxy" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "githubProxy" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "githubProxy" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -83,18 +83,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.gitserver.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "gitserver" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "gitserver" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "gitserver" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -78,18 +78,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.grafana.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "grafana" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "grafana" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "grafana" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -98,18 +98,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.indexedSearch.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "indexedSearch" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "indexedSearch" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "indexedSearch" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -88,18 +88,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.tracing.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "tracing" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "tracing" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "tracing" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/minio/minio.Deployment.yaml
+++ b/charts/sourcegraph/templates/minio/minio.Deployment.yaml
@@ -90,18 +90,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.minio.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "minio" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "minio" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "minio" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -119,18 +119,9 @@ spec:
       terminationGracePeriodSeconds: 120
       securityContext:
         {{- toYaml .Values.pgsql.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "pgsql" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "pgsql" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "pgsql" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -92,18 +92,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.preciseCodeIntel.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "preciseCodeIntel" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "preciseCodeIntel" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "preciseCodeIntel" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -81,18 +81,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.prometheus.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "prometheus" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "prometheus" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "prometheus" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -96,18 +96,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.redisCache.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "redisCache" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "redisCache" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "redisCache" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -96,18 +96,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.redisStore.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "redisStore" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "redisStore" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "redisStore" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -92,18 +92,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.repoUpdater.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "repoUpdater" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "repoUpdater" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "repoUpdater" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -100,18 +100,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.searcher.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "searcher" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "searcher" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "searcher" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -104,18 +104,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.symbols.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "symbols" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "symbols" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "symbols" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -82,18 +82,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.syntectServer.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "syntectServer" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "syntectServer" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "syntectServer" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -92,18 +92,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.worker.securityContext | nindent 8 }}
-      {{- with .Values.sourcegraph.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.sourcegraph.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "sourcegraph.nodeSelector" (list . "worker" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "worker" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "worker" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This PR introduces three partial templates for `tolerations`, `affinity`, and `nodeSelector`.

Usage

> `trim` may seem weird, but this is the only way to avoid introducing the extra `\n` which is bugging me a lot...

```yaml
{{- include "sourcegraph.nodeSelector" (list . "serviceName" ) | trim | nindent 6 }}
{{- include "sourcegraph.affinity" (list . "serviceName" ) | trim | nindent 6 }}
{{- include "sourcegraph.tolerations" (list . "serviceName" ) | trim | nindent 6 }}
```

Most changes are just copying & pasting, but please help me double-check!

## TODO

not blocking

- [ ] Document usage of our per-service magic values, i.e., stuff that are referenced from templates but not defined in `values.yaml`
  - maybe we should include them explicitly in `values.yaml`? Related ->  https://github.com/sourcegraph/sourcegraph/issues/31016
- [ ] Considering adding snapshot (golden files) testing to our helm chart to ensure future changes won't accidentally cause breakage?

## Test plan

`override.yaml`
```
sourcegraph:
  nodeSelector:
    node-type: memory-optimized
  tolerations:
  - key: node-type
    operator: Equal
    value: memory-optimized
    effect: NoSchedule
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/zone
            operator: In
            values:
            - zone-1
            - zone-

frontend:
  nodeSelector:
    node-type: general
```

Inspect the output

```sh
helm template -n sourcegraph -f override.yaml sourcegraph charts/sourcegraph/. > bundle.yaml
```