### PR TITLE
Fix securityContext values name

### DIFF
--- a/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
+++ b/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
@@ -46,12 +46,12 @@ spec:
         resources:
           {{- toYaml .Values.migrator.resources | nindent 10 }}
         securityContext:
-          {{- toYaml .Values.migrator.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.migrator.containerSecurityContext | nindent 10 }}
       {{- if .Values.migrator.extraContainers }}
         {{- toYaml .Values.migrator.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.migrator.securityContext | nindent 8 }}
+        {{- toYaml .Values.migrator.podSecurityContext | nindent 8 }}
       {{- with .Values.sourcegraph.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph-migrator/values.yaml
+++ b/charts/sourcegraph-migrator/values.yaml
@@ -91,7 +91,7 @@ migrator:
     PGUSER:
       value: sg
   resources: {}
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -1,0 +1,27 @@
+<!-- README:
+Use `**BREAKING**:` to denote a breaking change
+-->
+
+# Changelog
+
+All notable changes to Sourcegraph are documented in this file.
+
+<!-- START CHANGELOG -->
+
+## Unreleased
+
+### Added
+
+- 
+
+### Changed
+
+- **BREAKING**: The use of `.<service>.podSecurityContext` and `.<service>.securityContext` is causing confusion and misleading, we are using `podSecurityContext` as container-level `securityContext` and `securityContext` as pod-level `securityContext`. `podSecurityContext` are renamed to `containerSecurityContext`, and `securityContext` are renamed to `podSecurityContext` to better illustrate their actual usage [#48](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/48)
+
+### Fixed
+
+-
+
+### Removed
+
+-

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- **BREAKING**: The use of `.<service>.podSecurityContext` and `.<service>.securityContext` is causing confusion and misleading, we are using `podSecurityContext` as container-level `securityContext` and `securityContext` as pod-level `securityContext`. `podSecurityContext` are renamed to `containerSecurityContext`, and `securityContext` are renamed to `podSecurityContext` to better illustrate their actual usage [#48](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/48)
+- **BREAKING**: Uses of `podSecurityContext` have been renamed to `containerSecurityContext`, and `securityContext` renamed to `podSecurityContext` to better illustrate their actual usage [#48](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/48)
 
 ### Fixed
 

--- a/charts/sourcegraph/templates/_tracing.tpl
+++ b/charts/sourcegraph/templates/_tracing.tpl
@@ -31,5 +31,5 @@ Define the tracing sidecar
     - --reporter.type=grpc
 {{- end }}
   securityContext:
-    {{- toYaml .Values.tracingAgent.podSecurityContext | nindent 4 }}
+    {{- toYaml .Values.tracingAgent.containerSecurityContext | nindent 4 }}
 {{- end }}

--- a/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
@@ -65,7 +65,7 @@ spec:
           {{- toYaml .Values.cadvisor.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.cadvisor.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.cadvisor.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - name: rootfs
           mountPath: /rootfs
@@ -95,7 +95,7 @@ spec:
         {{- toYaml .Values.cadvisor.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.cadvisor.securityContext | nindent 8 }}
+        {{- toYaml .Values.cadvisor.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "cadvisor" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "cadvisor" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "cadvisor" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -70,7 +70,7 @@ spec:
           {{- toYaml .Values.codeInsightsDB.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.codeInsightsDB.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.codeInsightsDB.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - mountPath: /var/lib/postgresql/data/
           name: disk
@@ -85,7 +85,7 @@ spec:
         {{- toYaml .Values.codeInsightsDB.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.codeInsightsDB.securityContext | nindent 8 }}
+        {{- toYaml .Values.codeInsightsDB.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "codeInsightsDB" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "codeInsightsDB" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "codeInsightsDB" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - mountPath: /data
           name: disk
         securityContext:
-        {{- toYaml .Values.alpine.podSecurityContext | nindent 10 }}
+        {{- toYaml .Values.alpine.containerSecurityContext | nindent 10 }}
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.alpine.resources | nindent 10 }}
@@ -88,7 +88,7 @@ spec:
           {{- toYaml .Values.codeIntelDB.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.codeIntelDB.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.codeIntelDB.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - mountPath: /data
           name: disk
@@ -118,7 +118,7 @@ spec:
         {{- end }}
       terminationGracePeriodSeconds: 120
       securityContext:
-        {{- toYaml .Values.codeIntelDB.securityContext | nindent 8 }}
+        {{- toYaml .Values.codeIntelDB.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "codeIntelDB" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "codeIntelDB" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "codeIntelDB" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -62,7 +62,7 @@ spec:
         resources:
           {{- toYaml .Values.migrator.resources | nindent 10 }}
         securityContext:
-          {{- toYaml .Values.migrator.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.migrator.containerSecurityContext | nindent 10 }}
       {{- end }}
       containers:
       - name: frontend
@@ -110,7 +110,7 @@ spec:
           {{- toYaml .Values.frontend.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.frontend.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.frontend.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
@@ -124,7 +124,7 @@ spec:
         {{- toYaml .Values.frontend.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.frontend.securityContext | nindent 8 }}
+        {{- toYaml .Values.frontend.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "frontend" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "frontend" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "frontend" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -67,7 +67,7 @@ spec:
           {{- toYaml .Values.githubProxy.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.githubProxy.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.githubProxy.containerSecurityContext | nindent 10 }}
         volumeMounts:
         {{- if .Values.githubProxy.extraVolumeMounts }}
         {{- toYaml .Values.githubProxy.extraVolumeMounts | nindent 8 }}
@@ -77,7 +77,7 @@ spec:
         {{- toYaml .Values.githubProxy.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.githubProxy.securityContext | nindent 8 }}
+        {{- toYaml .Values.githubProxy.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "githubProxy" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "githubProxy" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "githubProxy" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -66,7 +66,7 @@ spec:
           {{- toYaml .Values.gitserver.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.gitserver.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.gitserver.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - mountPath: /data/repos
           name: repos
@@ -82,7 +82,7 @@ spec:
         {{- toYaml .Values.gitserver.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.gitserver.securityContext | nindent 8 }}
+        {{- toYaml .Values.gitserver.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "gitserver" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "gitserver" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "gitserver" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -75,13 +75,13 @@ spec:
           {{- toYaml .Values.grafana.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.grafana.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.grafana.containerSecurityContext | nindent 10 }}
       serviceAccountName: grafana
       {{- if .Values.grafana.extraContainers }}
         {{- toYaml .Values.grafana.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.grafana.securityContext | nindent 8 }}
+        {{- toYaml .Values.grafana.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "grafana" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "grafana" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "grafana" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -68,7 +68,7 @@ spec:
           {{- toYaml .Values.indexedSearch.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.indexedSearch.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.indexedSearch.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - mountPath: /data
           name: data
@@ -91,7 +91,7 @@ spec:
           {{- toYaml .Values.indexedSearchIndexer.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.indexedSearchIndexer.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.indexedSearchIndexer.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - mountPath: /data
           name: data
@@ -102,7 +102,7 @@ spec:
         {{- toYaml .Values.indexedSearch.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.indexedSearch.securityContext | nindent 8 }}
+        {{- toYaml .Values.indexedSearch.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "indexedSearch" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "indexedSearch" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "indexedSearch" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -79,7 +79,7 @@ spec:
           {{- toYaml .Values.tracing.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.tracing.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.tracing.containerSecurityContext | nindent 10 }}
         volumeMounts:
         {{- if .Values.tracing.extraVolumeMounts }}
         {{- toYaml .Values.tracing.extraVolumeMounts | nindent 8 }}
@@ -88,7 +88,7 @@ spec:
         {{- toYaml .Values.tracing.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.tracing.securityContext | nindent 8 }}
+        {{- toYaml .Values.tracing.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "tracing" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "tracing" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "tracing" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/minio/minio.Deployment.yaml
+++ b/charts/sourcegraph/templates/minio/minio.Deployment.yaml
@@ -76,7 +76,7 @@ spec:
           {{- toYaml .Values.minio.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.minio.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.minio.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - name: minio-data
           mountPath: /data
@@ -89,7 +89,7 @@ spec:
         {{- toYaml .Values.minio.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.minio.securityContext | nindent 8 }}
+        {{- toYaml .Values.minio.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "minio" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "minio" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "minio" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - mountPath: /data
           name: disk
         securityContext:
-        {{- toYaml .Values.alpine.podSecurityContext | nindent 10 }}
+        {{- toYaml .Values.alpine.containerSecurityContext | nindent 10 }}
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.alpine.resources | nindent 10 }}
@@ -88,7 +88,7 @@ spec:
           {{- toYaml .Values.pgsql.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.pgsql.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.pgsql.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - mountPath: /data
           name: disk
@@ -119,10 +119,10 @@ spec:
           {{- toYaml .Values.postgresExporter.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.postgresExporter.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.postgresExporter.containerSecurityContext | nindent 10 }}
       terminationGracePeriodSeconds: 120
       securityContext:
-        {{- toYaml .Values.pgsql.securityContext | nindent 8 }}
+        {{- toYaml .Values.pgsql.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "pgsql" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "pgsql" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "pgsql" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -87,7 +87,7 @@ spec:
           {{- toYaml .Values.preciseCodeIntel.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.preciseCodeIntel.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.preciseCodeIntel.containerSecurityContext | nindent 10 }}
         volumeMounts:
         {{- if .Values.preciseCodeIntel.extraVolumeMounts }}
         {{- toYaml .Values.preciseCodeIntel.extraVolumeMounts | nindent 8 }}
@@ -96,7 +96,7 @@ spec:
         {{- toYaml .Values.preciseCodeIntel.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.preciseCodeIntel.securityContext | nindent 8 }}
+        {{- toYaml .Values.preciseCodeIntel.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "preciseCodeIntel" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "preciseCodeIntel" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "preciseCodeIntel" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -79,13 +79,13 @@ spec:
           {{- toYaml .Values.prometheus.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.prometheus.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.prometheus.containerSecurityContext | nindent 10 }}
       terminationGracePeriodSeconds: 120
       {{- if .Values.prometheus.extraContainers }}
         {{- toYaml .Values.prometheus.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.prometheus.securityContext | nindent 8 }}
+        {{- toYaml .Values.prometheus.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "prometheus" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "prometheus" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "prometheus" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -72,7 +72,7 @@ spec:
           {{- toYaml .Values.redisCache.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.redisCache.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.redisCache.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - mountPath: /redis-data
           name: redis-data
@@ -95,12 +95,12 @@ spec:
           {{- toYaml .Values.redisExporter.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.redisExporter.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.redisExporter.containerSecurityContext | nindent 10 }}
       {{- if .Values.redisCache.extraContainers }}
         {{- toYaml .Values.redisCache.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.redisCache.securityContext | nindent 8 }}
+        {{- toYaml .Values.redisCache.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "redisCache" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "redisCache" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "redisCache" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -72,7 +72,7 @@ spec:
           {{- toYaml .Values.redisStore.resources | nindent 10 }}
         {{- end }}
         securityContext:
-        {{- toYaml .Values.redisStore.podSecurityContext | nindent 10 }}
+        {{- toYaml .Values.redisStore.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - mountPath: /redis-data
           name: redis-data
@@ -95,12 +95,12 @@ spec:
           {{- toYaml .Values.redisExporter.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.redisExporter.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.redisExporter.containerSecurityContext | nindent 10 }}
       {{- if .Values.redisStore.extraContainers }}
         {{- toYaml .Values.redisStore.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.redisStore.securityContext | nindent 8 }}
+        {{- toYaml .Values.redisStore.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "redisStore" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "redisStore" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "redisStore" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -85,7 +85,7 @@ spec:
           {{- toYaml .Values.repoUpdater.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.repoUpdater.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.repoUpdater.containerSecurityContext | nindent 10 }}
         volumeMounts:
         {{- if .Values.repoUpdater.extraVolumeMounts }}
         {{- toYaml .Values.repoUpdater.extraVolumeMounts | nindent 8 }}
@@ -95,7 +95,7 @@ spec:
         {{- toYaml .Values.repoUpdater.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.repoUpdater.securityContext | nindent 8 }}
+        {{- toYaml .Values.repoUpdater.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "repoUpdater" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "repoUpdater" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "repoUpdater" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -97,13 +97,13 @@ spec:
           {{- toYaml .Values.searcher.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.searcher.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.searcher.containerSecurityContext | nindent 10 }}
       {{- include "sourcegraph.tracing" . | nindent 6 }}
       {{- if .Values.searcher.extraContainers }}
         {{- toYaml .Values.searcher.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.searcher.securityContext | nindent 8 }}
+        {{- toYaml .Values.searcher.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "searcher" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "searcher" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "searcher" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -101,13 +101,13 @@ spec:
           {{- toYaml .Values.symbols.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.symbols.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.symbols.containerSecurityContext | nindent 10 }}
       {{- include "sourcegraph.tracing" . | nindent 6 }}
       {{- if .Values.symbols.extraContainers }}
         {{- toYaml .Values.symbols.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.symbols.securityContext | nindent 8 }}
+        {{- toYaml .Values.symbols.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "symbols" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "symbols" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "symbols" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -77,7 +77,7 @@ spec:
           {{- toYaml .Values.syntectServer.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.syntectServer.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.syntectServer.containerSecurityContext | nindent 10 }}
         volumeMounts:
         {{- if .Values.syntectServer.extraVolumeMounts }}
         {{- toYaml .Values.syntectServer.extraVolumeMounts | nindent 8 }}
@@ -86,7 +86,7 @@ spec:
         {{- toYaml .Values.syntectServer.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.syntectServer.securityContext | nindent 8 }}
+        {{- toYaml .Values.syntectServer.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "syntectServer" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "syntectServer" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "syntectServer" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -87,7 +87,7 @@ spec:
           {{- toYaml .Values.worker.resources | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- toYaml .Values.worker.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.worker.containerSecurityContext | nindent 10 }}
         volumeMounts:
         {{- if .Values.worker.extraVolumeMounts }}
         {{- toYaml .Values.worker.extraVolumeMounts | nindent 8 }}
@@ -96,7 +96,7 @@ spec:
         {{- toYaml .Values.worker.extraContainers | nindent 6 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.worker.securityContext | nindent 8 }}
+        {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "worker" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "worker" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "worker" ) | trim | nindent 6 }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -50,8 +50,8 @@ sourcegraph:
 #   env: {}
 #   # Set resource requests / limits
 #   resources: {}
+#   containerSecurityContext: {}
 #   podSecurityContext: {}
-#   securityContext: {}
 #   # Add additional volumes and mounts to deployments
 #   extraVolumeMounts: {}
 #   extraVolumes: {}
@@ -76,7 +76,7 @@ alpine: # Used in init containers
   image:
     defaultTag: 3.37.0@sha256:946f83cf1d822434f242c522cf71717de6cf014a6fc226c9ed82f27ad7e17aa3
     name: "alpine-3.12"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 999
     runAsGroup: 999
@@ -116,7 +116,7 @@ codeInsightsDB:
   image:
     defaultTag: 3.37.0@sha256:fa608333a6ca1aef148abd33e4ee14886d4f172e0db1e5c9ee6bac36adec0bf1
     name: "codeinsights-db"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 70
     runAsGroup: 70
@@ -129,7 +129,7 @@ codeInsightsDB:
     requests:
       cpu: "4"
       memory: 2Gi
-  securityContext:
+  podSecurityContext:
     runAsUser: 70
     fsGroup: 70
     fsGroupChangePolicy: "OnRootMismatch"
@@ -141,7 +141,7 @@ codeIntelDB:
   image:
     defaultTag: 3.37.0@sha256:fc2ab91482f85f77eb73c69a35a2a4cc5055a1b93ef1c1d0f183a7003e632082
     name: "codeintel-db"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 999
     runAsGroup: 999
@@ -158,7 +158,7 @@ codeIntelDB:
     requests:
       cpu: "4"
       memory: 4Gi
-  securityContext:
+  podSecurityContext:
     runAsUser: 999
     fsGroup: 999
     fsGroupChangePolicy: "OnRootMismatch"
@@ -201,7 +201,7 @@ frontend:
     host: "" # External host name for SSL
     ingressClassName: null # Available in Kubernetes 1.18+
     tlsSecret: "" # Secret containing SSL cert
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -228,7 +228,7 @@ migrator:
     name: "migrator"
   env: {}
   resources: {}
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -238,7 +238,7 @@ githubProxy:
   image:
     defaultTag: 3.37.0@sha256:3b173e36f958b68479ae829d784c63346701df417afa14d14ae657a84e630dd5
     name: "github-proxy"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -257,7 +257,7 @@ gitserver:
     defaultTag: 3.37.0@sha256:9d005ebd221b3e9e5f41ad2c91f8f1b06758a70c6ddbff11acbf037461f7f3d5
     name: "gitserver"
   labels: {}
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -270,7 +270,7 @@ gitserver:
     requests:
       cpu: "4"
       memory: 8G
-  securityContext:
+  podSecurityContext:
     runAsUser: 100
     runAsGroup: 101
     fsGroup: 101
@@ -283,7 +283,7 @@ grafana:
   image:
     defaultTag: 3.37.0@sha256:a47fde087ee42864ed6108796e95045857b55b3d9327b2d74257321384f6bbd1
     name: "grafana"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 472
     runAsGroup: 472
@@ -296,7 +296,7 @@ grafana:
     requests:
       cpu: 100m
       memory: 512Mi
-  securityContext:
+  podSecurityContext:
     runAsUser: 472
     runAsGroup: 472
     fsGroup: 472
@@ -309,7 +309,7 @@ indexedSearch:
   image:
     defaultTag: 3.37.0@sha256:0f81c4d33c852fc0ee819d5139efa1c48d6cb10a5f86fa2d37ed698bb2a0a892
     name: "indexed-searcher"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -322,7 +322,7 @@ indexedSearch:
     requests:
       cpu: 500m
       memory: 2G
-  securityContext:
+  podSecurityContext:
     fsGroup: 101
     fsGroupChangePolicy: "OnRootMismatch"
   # The size of disk to used for search indexes.
@@ -333,7 +333,7 @@ indexedSearchIndexer:
   image:
     defaultTag: 3.37.0@sha256:2a85ddfc2533e525cd7a3a7327fd0174976dcb40d933db8aaafe21ae7ec209c5
     name: "search-indexer"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -358,7 +358,7 @@ minio:
   image:
     defaultTag: 3.37.0@sha256:66925bab722ed11584e1135687b5c1e00a13c550e38d954a56048c90f17edc53
     name: "minio"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -370,7 +370,7 @@ minio:
     requests:
       cpu: "1"
       memory: 500M
-  securityContext:
+  podSecurityContext:
     runAsUser: 100
     runAsGroup: 101
     fsGroup: 101
@@ -383,7 +383,7 @@ pgsql:
   image:
     defaultTag: 3.37.0@sha256:af00a4465f435742df9980cc9d8a8bda49d6adea173558a371e276b476ea94ae
     name: "postgres-12.6-alpine"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 999
     runAsGroup: 999
@@ -400,7 +400,7 @@ pgsql:
     requests:
       cpu: "4"
       memory: 4Gi
-  securityContext:
+  podSecurityContext:
     # Required to prevent escalations to root.
     runAsUser: 999
     runAsGroup: 999
@@ -427,7 +427,7 @@ preciseCodeIntel:
   image:
     defaultTag: 3.37.0@sha256:8435299294539b1144bb897541de7c2535bacae486d91bba4656178b2ecf4d9f
     name: "precise-code-intel-worker"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -447,7 +447,7 @@ prometheus:
   image:
     defaultTag: 3.37.0@sha256:b51ccc7c9f19eacfeaa22f888432415dda3bebad58e14b84c829e02b2c719e66
     name: "prometheus"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 100
@@ -468,7 +468,7 @@ prometheus:
     requests:
       cpu: 500m
       memory: 6G
-  securityContext:
+  podSecurityContext:
     fsGroup: 100
     fsGroupChangePolicy: "OnRootMismatch"
   serviceAccount:
@@ -480,7 +480,7 @@ redisCache:
   image:
     defaultTag: 3.37.0@sha256:ff28c3902b0ba142e3409e3bb905913aaabc821e7efdaa43458ea3bbe65b7e16
     name: "redis-cache"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 999
     runAsGroup: 1000
@@ -493,7 +493,7 @@ redisCache:
     requests:
       cpu: "1"
       memory: 7Gi
-  securityContext:
+  podSecurityContext:
     fsGroup: 1000
     fsGroupChangePolicy: "OnRootMismatch"
   storageSize: 100Gi
@@ -502,7 +502,7 @@ redisExporter:
   image:
     defaultTag: 3.37.0@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
     name: "redis_exporter"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 999
     runAsGroup: 1000
@@ -520,7 +520,7 @@ redisStore:
   image:
     defaultTag: 3.37.0@sha256:e1cfaeb18367d76838fec0e5f52e2c7d85f2fb63537a3fe809014a986393c9c7
     name: "redis-store"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 999
     runAsGroup: 1000
@@ -533,7 +533,7 @@ redisStore:
     requests:
       cpu: "1"
       memory: 7Gi
-  securityContext:
+  podSecurityContext:
     fsGroup: 1000
     fsGroupChangePolicy: "OnRootMismatch"
   storageSize: 100Gi
@@ -542,7 +542,7 @@ repoUpdater:
   image:
     defaultTag: 3.37.0@sha256:fd0562d9d3972d2e4f504b0de8803f485603b57fbc4dd77ac085b1f96dfacbe4
     name: "repo-updater"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -560,7 +560,7 @@ searcher:
   image:
     defaultTag: 3.37.0@sha256:f603c68f8ece63fb3b49cfe09df8a4e7407c713dd6e0267395ba781f1c6fc36c
     name: "searcher"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -586,7 +586,7 @@ symbols:
   image:
     defaultTag: 3.37.0@sha256:b0a3b576e7d61bc9c489fa1378ab0ead4b28fe5fb85d96ae8bf7cd5d9b3631c9
     name: "symbols"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -606,7 +606,7 @@ syntectServer:
   image:
     defaultTag: 3.37.0@sha256:4c371a925ce1b97f2ec7f44c582795409c0b19d073a41c7123b07be06e2ebd47
     name: "syntax-highlighter"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -626,7 +626,7 @@ tracing:
   image:
     defaultTag: 3.37.0@sha256:aece0527d8efcee8ca7ee013a834ba8c332c44666542a45f6b5451d6e7949b74
     name: "jaeger-all-in-one"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -646,7 +646,7 @@ tracingAgent:
   image:
     defaultTag: 3.37.0@sha256:04026339976f6107b6490dfe61c9d9b3a541594ba99ff5115667a54e4ec917ba
     name: "jaeger-agent"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
@@ -663,7 +663,7 @@ worker:
   image:
     defaultTag: 3.37.0@sha256:0b3a8d3a59a65c5aabfa4c5bb78cc6eea1c7926fa66ae7558e20f8ca6b11d629
     name: "worker"
-  podSecurityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101


### PR DESCRIPTION
We're currently using and

- `podSecurityContext` as container-level `securityContext` (the naming is misleading)
- `securityContext` as pod-level `securityContext` (okay, but we should be more explicit)

This PR

- renamed `podSecurityContext` to `containerSecurityContext`
- renamed `securityContext` to `podSecurityContext`

## Test plan

The test plan is to `diff` the output of rendered manifest, no change is expected.

```sh
kind create cluster
```

Revert to `main`

```sh
 git checkout HEAD~
```

```sh
helm upgrade --install -n sourcegraph --set storageClass.create=false,storageClass.name=standard,sourcegraph.localDevMode=true sourcegraph charts/sourcegraph/.
```

```sh
git checkout 02-25-Fix_securityContext_values_name
```

```sh
helm diff -n sourcegraph --set storageClass.create=false,storageClass.name=standard,sourcegraph.localDevMode=true sourcegraph charts/sourcegraph/.
```

There should be no difference.

close https://github.com/sourcegraph/sourcegraph/issues/31888