### PR TITLE
Add missing imagePullPolicy 

### DIFF
--- a/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
+++ b/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
@@ -37,6 +37,7 @@ spec:
       containers:
       - name: migrator
         image: {{ include "sourcegraph.image" (list . "migrator") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         args: {{- default (list "up") .Values.migrator.args | toYaml | nindent 8 }}
         env:
         {{- range $name, $item := .Values.migrator.env }}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
@@ -47,6 +47,7 @@ spec:
       initContainers:
       - name: correct-data-dir-permissions
         image: {{ include "sourcegraph.image" (list . "alpine") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         command: ["sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"]
         volumeMounts:
         - mountPath: /data

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -49,6 +49,7 @@ spec:
       {{- if .Values.migrator.enabled }}
       - name: migrator
         image: {{ include "sourcegraph.image" (list . "migrator") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         args: {{- default (list "up") .Values.migrator.args | toYaml | nindent 8 }}
         env:
         {{- range $name, $item := .Values.frontend.env }}

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -45,6 +45,7 @@ spec:
       containers:
       - name: grafana
         image: {{ include "sourcegraph.image" (list . "grafana") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         {{- with .Values.grafana.args }}
         args:
           {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -42,6 +42,7 @@ spec:
       containers:
       - name: zoekt-webserver
         image: {{ include "sourcegraph.image" (list . "indexedSearch") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         {{- with .Values.indexedSearch.args }}
         args:
           {{- toYaml . | nindent 8 }}
@@ -77,6 +78,7 @@ spec:
         {{- end }}
       - name: zoekt-indexserver
         image: {{ include "sourcegraph.image" (list . "indexedSearchIndexer") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         terminationMessagePolicy: FallbackToLogsOnError
         env:
         {{- range $name, $item := .Values.indexedSearchIndexer.env}}

--- a/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -50,6 +50,7 @@ spec:
       containers:
       - name: jaeger
         image: {{ include "sourcegraph.image" (list . "tracing") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         args: {{- default (list "--memory.max-traces=20000") .Values.tracing.args | toYaml | nindent 8 }}
         env:
         {{- range $name, $item := .Values.tracing.env}}

--- a/charts/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -47,6 +47,7 @@ spec:
       initContainers:
       - name: correct-data-dir-permissions
         image: {{ include "sourcegraph.image" (list . "alpine") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         command: ["sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"]
         volumeMounts:
         - mountPath: /data

--- a/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -46,6 +46,7 @@ spec:
       containers:
       - name: prometheus
         image: {{ include "sourcegraph.image" (list . "prometheus") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         {{- with .Values.prometheus.args }}
         args:
           {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -46,6 +46,7 @@ spec:
       containers:
       - name: redis-cache
         image: {{ include "sourcegraph.image" (list . "redisCache") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         {{- with .Values.redisCache.args }}
         args:
           {{- toYaml . | nindent 8 }}
@@ -81,6 +82,7 @@ spec:
         {{- end }}
       - name: redis-exporter
         image: {{ include "sourcegraph.image" (list . "redisExporter") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         terminationMessagePolicy: FallbackToLogsOnError
         env:
         {{- range $name, $item := .Values.redisExporter.env}}

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -46,6 +46,7 @@ spec:
       containers:
       - name: redis-store
         image: {{ include "sourcegraph.image" (list . "redisStore") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         {{- with .Values.redisStore.args }}
         args:
           {{- toYaml . | nindent 8 }}
@@ -81,6 +82,7 @@ spec:
         {{- end }}
       - name: redis-exporter
         image: {{ include "sourcegraph.image" (list . "redisExporter") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         terminationMessagePolicy: FallbackToLogsOnError
         env:
         {{- range $name, $item := .Values.redisExporter.env}}

--- a/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -49,6 +49,7 @@ spec:
       containers:
       - name: repo-updater
         image: {{ include "sourcegraph.image" (list . "repoUpdater") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         {{- with .Values.repoUpdater.args }}
         args:
           {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
current a lot of images are missing imagePullPolicy. Search through all the yaml files that had `images: ` and add the missing `imagePullPolicy: ` 

## Test plan

Inspect the rendered template

```sh
helm template .
```

close https://github.com/sourcegraph/sourcegraph/issues/31887