### PR TITLE
Support custom service account name

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -93,7 +93,7 @@ In addition to the documented values, all services also support the following va
 | cadvisor.podSecurityPolicy.enabled | bool | `false` | Enable [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for `cadvisor` pods |
 | cadvisor.resources | object | `{"limits":{"cpu":"300m","memory":"2000Mi"},"requests":{"cpu":"150m","memory":"200Mi"}}` | Resource requests & limits for the `cadvisor` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | cadvisor.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `cadvisor` |
-| cadvisor.serviceAccount.name | string | `"cadvisor"` | Name of the ServiceAccount |
+| cadvisor.serviceAccount.name | string | `"cadvisor"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeInsightsDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":70,"runAsUser":70}` | Security context for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeInsightsDB.enabled | bool | `true` | Enable `codeinsights-db` PostgreSQL server |
 | codeInsightsDB.env | object | `{"POSTGRES_PASSWORD":{"value":"password"}}` | Environment variables for the `codeinsights-db` container |
@@ -102,6 +102,8 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.image.name | string | `"codeinsights-db"` | Docker image name for the `codeinsights-db` image |
 | codeInsightsDB.podSecurityContext | object | `{"fsGroup":70,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":70}` | Security context for the `codeinsights-db` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | codeInsightsDB.resources | object | `{"limits":{"cpu":"4","memory":"2Gi"},"requests":{"cpu":"4","memory":"2Gi"}}` | Resource requests & limits for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| codeInsightsDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeinsights-db` |
+| codeInsightsDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeInsightsDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeinsights-db` data volume |
 | codeIntelDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `codeintel-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeIntelDB.enabled | bool | `true` | Enable `codeintel-db` PostgreSQL server |
@@ -111,6 +113,8 @@ In addition to the documented values, all services also support the following va
 | codeIntelDB.podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":999}` | Security context for the `codeintel-db` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | codeIntelDB.postgresExporter.env | object | `{"DATA_SOURCE_NAME":{"value":"postgres://sg:@localhost:5432/?sslmode=disable"}}` | Environment variables for the `pgsql-exporter` sidecar container |
 | codeIntelDB.resources | object | `{"limits":{"cpu":"4","memory":"4Gi"},"requests":{"cpu":"4","memory":"4Gi"}}` | Resource requests & limits for the `codeintel-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| codeIntelDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeintel-db` |
+| codeIntelDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeIntelDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeintel-db` data volume |
 | frontend.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `frontend` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | frontend.env | object | the chart will add some default environment values | Environment variables for the `frontend` container |
@@ -126,19 +130,23 @@ In addition to the documented values, all services also support the following va
 | frontend.replicaCount | int | `2` | Number of `frontend` pod |
 | frontend.resources | object | `{"limits":{"cpu":"2","ephemeral-storage":"8Gi","memory":"4G"},"requests":{"cpu":"2","ephemeral-storage":"4Gi","memory":"2G"}}` | Resource requests & limits for the `frontend` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | frontend.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `frontend` |
-| frontend.serviceAccount.name | string | `"sourcegraph-frontend"` | Name of the ServiceAccount |
+| frontend.serviceAccount.name | string | `"sourcegraph-frontend"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | githubProxy.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `github-proxy` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | githubProxy.image.defaultTag | string | `"3.37.0@sha256:3b173e36f958b68479ae829d784c63346701df417afa14d14ae657a84e630dd5"` | Docker image tag for the `github-proxy` image |
 | githubProxy.image.name | string | `"github-proxy"` | Docker image name for the `github-proxy` image |
 | githubProxy.podSecurityContext | object | `{}` | Security context for the `github-proxy` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | githubProxy.replicaCount | int | `1` | Number of `github-proxy` pod |
 | githubProxy.resources | object | `{"limits":{"cpu":"1","memory":"1G"},"requests":{"cpu":"100m","memory":"250M"}}` | Resource requests & limits for the `github-proxy` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| githubProxy.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `github-proxy` |
+| githubProxy.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | gitserver.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `gitserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | gitserver.image.defaultTag | string | `"3.37.0@sha256:9d005ebd221b3e9e5f41ad2c91f8f1b06758a70c6ddbff11acbf037461f7f3d5"` | Docker image tag for the `gitserver` image |
 | gitserver.image.name | string | `"gitserver"` | Docker image name for the `gitserver` image |
 | gitserver.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":101,"runAsUser":100}` | Security context for the `gitserver` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | gitserver.replicaCount | int | `1` | Number of `gitserver` pod |
 | gitserver.resources | object | `{"limits":{"cpu":"4","memory":"8G"},"requests":{"cpu":"4","memory":"8G"}}` | Resource requests & limits for the `gitserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| gitserver.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `gitserver` |
+| gitserver.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | gitserver.storageSize | string | `"200Gi"` | PVC Storage Request for `gitserver` data volume |
 | grafana.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":472,"runAsUser":472}` | Security context for the `grafana` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | grafana.enabled | bool | `true` | Enable `grafana` dashboard (recommended) |
@@ -149,6 +157,7 @@ In addition to the documented values, all services also support the following va
 | grafana.replicaCount | int | `1` | Number of `grafana` pod |
 | grafana.resources | object | `{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"100m","memory":"512Mi"}}` | Resource requests & limits for the `grafana` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | grafana.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `grafana` |
+| grafana.serviceAccount.name | string | `"grafana"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | grafana.storageSize | string | `"2Gi"` | PVC Storage Request for `grafana` data volume |
 | indexedSearch.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `zoekt-webserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | indexedSearch.image.defaultTag | string | `"3.37.0@sha256:0f81c4d33c852fc0ee819d5139efa1c48d6cb10a5f86fa2d37ed698bb2a0a892"` | Docker image tag for the `zoekt-webserver` image |
@@ -156,6 +165,8 @@ In addition to the documented values, all services also support the following va
 | indexedSearch.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch"}` | Security context for the `indexed-search` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | indexedSearch.replicaCount | int | `1` | Number of `indexed-search` pod |
 | indexedSearch.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `zoekt-webserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| indexedSearch.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `indexed-search` |
+| indexedSearch.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | indexedSearch.storageSize | string | `"200Gi"` | PVC Storage Request for `indexed-search` data volume The size of disk to used for search indexes. This should typically be gitserver disk size multipled by the number of gitserver shards. |
 | indexedSearchIndexer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `zoekt-indexserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | indexedSearchIndexer.image.defaultTag | string | `"3.37.0@sha256:2a85ddfc2533e525cd7a3a7327fd0174976dcb40d933db8aaafe21ae7ec209c5"` | Docker image tag for the `zoekt-indexserver` image |
@@ -175,6 +186,8 @@ In addition to the documented values, all services also support the following va
 | minio.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":101,"runAsUser":100}` | Security context for the `minio` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | minio.replicaCount | int | `1` | Number of `minio` pod |
 | minio.resources | object | `{"limits":{"cpu":"1","memory":"500M"},"requests":{"cpu":"1","memory":"500M"}}` | Resource requests & limits for the `minio` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| minio.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `minio` |
+| minio.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | minio.storageSize | string | `"100Gi"` | PVC Storage Request for `minio` data volume |
 | pgsql.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | pgsql.enabled | bool | `true` | Enable `pgsql` PostgreSQL server |
@@ -184,6 +197,8 @@ In addition to the documented values, all services also support the following va
 | pgsql.podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsUser":999}` | Security context for the `pgsql` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | pgsql.postgresExporter.env | object | `{"DATA_SOURCE_NAME":{"value":"postgres://sg:@localhost:5432/?sslmode=disable"}}` | Environment variables for the `pgsql-exporter` sidecar container |
 | pgsql.resources | object | `{"limits":{"cpu":"4","memory":"4Gi"},"requests":{"cpu":"4","memory":"4Gi"}}` | Resource requests & limits for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| pgsql.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `pgsql` |
+| pgsql.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | pgsql.storageSize | string | `"200Gi"` | PVC Storage Request for `pgsql` data volume |
 | postgresExporter.image.defaultTag | string | `"3.37.0@sha256:20e58b62f064037ac3d901eba565f49d7e1daae2a237e6fa3d5351580d576dea"` | Docker image tag for the `pgsql-exporter` image |
 | postgresExporter.image.name | string | `"postgres_exporter"` | Docker image name for the `pgsql-exporter` image |
@@ -195,6 +210,8 @@ In addition to the documented values, all services also support the following va
 | preciseCodeIntel.podSecurityContext | object | `{}` | Security context for the `precise-code-intel-worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | preciseCodeIntel.replicaCount | int | `2` | Number of `precise-code-intel-worker` pod |
 | preciseCodeIntel.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `precise-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| preciseCodeIntel.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `precise-code-intel-worker` |
+| preciseCodeIntel.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | prometheus.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":100,"runAsUser":100}` | Security context for the `prometheus` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | prometheus.enabled | bool | `true` | Enable `prometheus` (recommended) |
 | prometheus.existingConfig | string | `""` | Name of existing ConfigMap for `pgsql`. It must contain a `prometheus.yml` key |
@@ -205,6 +222,7 @@ In addition to the documented values, all services also support the following va
 | prometheus.replicaCount | int | `1` | Number of `prometheus` pod |
 | prometheus.resources | object | `{"limits":{"cpu":"2","memory":"6G"},"requests":{"cpu":"500m","memory":"6G"}}` | Resource requests & limits for the `prometheus` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) Prometheus is relied upon to monitor services for sending alerts to site admins when something is wrong with Sourcegraph, thus its memory requests and limits are the same to guarantee it has enough memory to perform its job reliably and prevent conflicts with other pods on the same host node. The limit chosen here is based on what works reliably on Sourcegraph.com with lots of traffic. |
 | prometheus.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount |
+| prometheus.serviceAccount.name | string | `"prometheus"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | prometheus.storageSize | string | `"200Gi"` | PVC Storage Request for `prometheus` data volume |
 | redisCache.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsUser":999}` | Security context for the `redis-cache` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | redisCache.enabled | bool | `true` | Enable `redis-cache` Redis server |
@@ -212,6 +230,8 @@ In addition to the documented values, all services also support the following va
 | redisCache.image.name | string | `"redis-cache"` | Docker image name for the `redis-cache` image |
 | redisCache.podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch"}` | Security context for the `redis-cache` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | redisCache.resources | object | `{"limits":{"cpu":"1","memory":"7Gi"},"requests":{"cpu":"1","memory":"7Gi"}}` | Resource requests & limits for the `redis-cache` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| redisCache.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `redis-cache` |
+| redisCache.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | redisCache.storageSize | string | `"100Gi"` | PVC Storage Request for `redis-cache` data volume |
 | redisExporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsUser":999}` | Security context for the `redis-exporter` sidecar container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | redisExporter.image.defaultTag | string | `"3.37.0@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70"` | Docker image tag for the `redis-exporter` image |
@@ -223,6 +243,8 @@ In addition to the documented values, all services also support the following va
 | redisStore.image.name | string | `"redis-store"` | Docker image name for the `redis-store` image |
 | redisStore.podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch"}` | Security context for the `redis-store` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | redisStore.resources | object | `{"limits":{"cpu":"1","memory":"7Gi"},"requests":{"cpu":"1","memory":"7Gi"}}` | Resource requests & limits for the `redis-store` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| redisStore.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `redis-store` |
+| redisStore.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | redisStore.storageSize | string | `"100Gi"` | PVC Storage Request for `redis-store` data volume |
 | repoUpdater.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `repo-updater` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | repoUpdater.image.defaultTag | string | `"3.37.0@sha256:fd0562d9d3972d2e4f504b0de8803f485603b57fbc4dd77ac085b1f96dfacbe4"` | Docker image tag for the `repo-updater` image |
@@ -230,12 +252,16 @@ In addition to the documented values, all services also support the following va
 | repoUpdater.podSecurityContext | object | `{}` | Security context for the `repo-updater` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | repoUpdater.replicaCount | int | `1` | Number of `repo-updater` pod |
 | repoUpdater.resources | object | `{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"1","memory":"500Mi"}}` | Resource requests & limits for the `repo-updater` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| repoUpdater.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `repo-updater` |
+| repoUpdater.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | searcher.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | searcher.image.defaultTag | string | `"3.37.0@sha256:f603c68f8ece63fb3b49cfe09df8a4e7407c713dd6e0267395ba781f1c6fc36c"` | Docker image tag for the `searcher` image |
 | searcher.image.name | string | `"searcher"` | Docker image name for the `searcher` image |
 | searcher.podSecurityContext | object | `{}` | Security context for the `searcher` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | searcher.replicaCount | int | `2` | Number of `searcher` pod |
 | searcher.resources | object | `{"limits":{"cpu":"2","ephemeral-storage":"26G","memory":"2G"},"requests":{"cpu":"500m","ephemeral-storage":"25G","memory":"500M"}}` | Resource requests & limits for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| searcher.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `searcher` |
+| searcher.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | sourcegraph.affinity | object | `{}` | Global Affinity, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | sourcegraph.image.defaultTag | string | `"{{ .Chart.AppVersion }}"` | Global docker image tag |
 | sourcegraph.image.pullPolicy | string | `"IfNotPresent"` | Global docker image pull policy |
@@ -262,12 +288,16 @@ In addition to the documented values, all services also support the following va
 | symbols.podSecurityContext | object | `{}` | Security context for the `symbols` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | symbols.replicaCount | int | `1` | Number of `symbols` pod |
 | symbols.resources | object | `{"limits":{"cpu":"2","ephemeral-storage":"12G","memory":"2G"},"requests":{"cpu":"500m","ephemeral-storage":"10G","memory":"500M"}}` | Resource requests & limits for the `symbols` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| symbols.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `symbols` |
+| symbols.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | syntectServer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | syntectServer.image.defaultTag | string | `"3.37.0@sha256:4c371a925ce1b97f2ec7f44c582795409c0b19d073a41c7123b07be06e2ebd47"` | Docker image tag for the `syntect-server` image |
 | syntectServer.image.name | string | `"syntax-highlighter"` | Docker image name for the `syntect-server` image |
 | syntectServer.podSecurityContext | object | `{}` | Security context for the `syntect-server` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | syntectServer.replicaCount | int | `1` | Number of `syntect-server` pod |
 | syntectServer.resources | object | `{"limits":{"cpu":"4","memory":"6G"},"requests":{"cpu":"250m","memory":"2G"}}` | Resource requests & limits for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| syntectServer.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `syntect-server` |
+| syntectServer.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | tracing.collector.name | string | `""` | Name of jaeger `collector` service  |
 | tracing.collector.serviceAnnotations | object | `{}` | Add extra annotations to jaeger `collector` service |
 | tracing.collector.serviceLabels | object | `{}` | Add extra labels to jaeger `collector` service |
@@ -283,6 +313,8 @@ In addition to the documented values, all services also support the following va
 | tracing.query.serviceType | string | "ClusterIP" | Kubernetes service type of jaeger `query` service, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | tracing.replicaCount | int | `1` | Number of `jaeger` pod |
 | tracing.resources | object | `{"limits":{"cpu":"1","memory":"1G"},"requests":{"cpu":"500m","memory":"500M"}}` | Resource requests & limits for the `jaeger` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| tracing.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `jaeger` |
+| tracing.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | tracingAgent.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `jaeger-agent` sidecar container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | tracingAgent.enabled | bool | `true` |  |
 | tracingAgent.image.defaultTag | string | `"3.37.0@sha256:04026339976f6107b6490dfe61c9d9b3a541594ba99ff5115667a54e4ec917ba"` | Docker image tag for the `jaeger-agent` image |
@@ -294,6 +326,8 @@ In addition to the documented values, all services also support the following va
 | worker.podSecurityContext | object | `{}` | Security context for the `worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | worker.replicaCount | int | `1` | Number of `worker` pod |
 | worker.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| worker.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `worker` |
+| worker.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 
 ## Upgrades
 

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -41,7 +41,16 @@ Create the name of the service account to use
 {{- define "sourcegraph.serviceAccountName" -}}
 {{- $top := index . 0 }}
 {{- $service := index . 1 }}
-{{- default $service (index $top.Values $service "serviceAccount" "name") }}
+{{- $defaultServiceAccountName := ((snakecase $service) | replace "_" "-") }}
+{{- default $defaultServiceAccountName (index $top.Values $service "serviceAccount" "name") }}
+{{- end }}
+
+{{- define "sourcegraph.renderServiceAccountName" -}}
+{{- $top := index . 0 }}
+{{- $service := index . 1 }}
+{{- if or (index $top.Values $service "serviceAccount" "create") (index $top.Values $service "serviceAccount" "name") }}
+serviceAccountName: {{ include "sourcegraph.serviceAccountName" (list $top $service) }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
@@ -42,7 +42,7 @@ spec:
         deploy: sourcegraph
         app: cadvisor
     spec:
-      serviceAccountName: {{ include "sourcegraph.serviceAccountName" (list . "cadvisor") }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "cadvisor") | trim | nindent 6 }}
       containers:
       - name: cadvisor
         image: {{ include "sourcegraph.image" (list . "cadvisor" ) }}

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -94,6 +94,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 120
+      {{- include "sourcegraph.renderServiceAccountName" (list . "codeInsightsDB") | trim | nindent 6 }}
       volumes:
       - name: disk
         persistentVolumeClaim:

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.codeInsightsDB.enabled .Values.codeInsightsDB.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: codeinsights-db
+  name: {{ include "sourcegraph.serviceAccountName" (list . "codeInsightsDB") }}
+{{- end }}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.Deployment.yaml
@@ -127,6 +127,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "codeIntelDB") | trim | nindent 6 }}
       volumes:
       - name: disk
         persistentVolumeClaim:

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.codeIntelDB.enabled .Values.codeIntelDB.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: codeintel-db
+  name: {{ include "sourcegraph.serviceAccountName" (list . "codeIntelDB") }}
+{{- end }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -133,7 +133,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "sourcegraph.serviceAccountName" (list . "frontend") }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "frontend") | trim | nindent 6 }}
       volumes:
       - emptyDir: {}
         name: cache-ssd

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -85,6 +85,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "githubProxy") | trim | nindent 6 }}
       volumes:
       {{- if .Values.githubProxy.extraVolumes }}
       {{- toYaml .Values.githubProxy.extraVolumes | nindent 6 }}

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.githubProxy.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: github-proxy
+  name: {{ include "sourcegraph.serviceAccountName" (list . "githubProxy") }}
+{{- end }}

--- a/charts/sourcegraph/templates/gitserver/gitserver.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.gitserver.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: gitserver
+  name: {{ include "sourcegraph.serviceAccountName" (list . "gitserver") }}
+{{- end }}

--- a/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -90,6 +90,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "gitserver") | trim | nindent 6 }}
       volumes:
       - name: repos
       {{- if .Values.gitserver.sshSecret }}

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -77,7 +77,7 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.grafana.containerSecurityContext | nindent 10 }}
-      serviceAccountName: grafana
+      {{- include "sourcegraph.renderServiceAccountName" (list . "grafana") | trim | nindent 6 }}
       {{- if .Values.grafana.extraContainers }}
         {{- toYaml .Values.grafana.extraContainers | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.indexedSearch.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: indexed-search
+  name: {{ include "sourcegraph.serviceAccountName" (list . "indexedSearch") }}
+{{- end }}

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -112,6 +112,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "indexedSearch") | trim | nindent 6 }}
       volumes:
       - name: data
       {{- if .Values.indexedSearch.extraVolumes }}

--- a/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -96,6 +96,7 @@ spec:
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "tracing") | trim | nindent 6 }}
       {{- end }}
       volumes:
       {{- if .Values.tracing.extraVolumes }}

--- a/charts/sourcegraph/templates/jaeger/jaeger.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.tracing.enabled .Values.tracing.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: tracing
+  name: {{ include "sourcegraph.serviceAccountName" (list . "tracing") }}
+{{- end }}

--- a/charts/sourcegraph/templates/minio/minio.Deployment.yaml
+++ b/charts/sourcegraph/templates/minio/minio.Deployment.yaml
@@ -97,6 +97,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "minio") | trim | nindent 6 }}
       volumes:
       - name: minio-data
         persistentVolumeClaim:

--- a/charts/sourcegraph/templates/minio/minio.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/minio/minio.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.minio.enabled .Values.minio.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: minio
+  name: {{ include "sourcegraph.serviceAccountName" (list . "minio") }}
+{{- end }}

--- a/charts/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -131,6 +131,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "pgsql") | trim | nindent 6 }}
       volumes:
       - name: disk
         persistentVolumeClaim:

--- a/charts/sourcegraph/templates/pgsql/pgsql.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.pgsql.enabled .Values.pgsql.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: pgsql
+  name: {{ include "sourcegraph.serviceAccountName" (list . "pgsql") }}
+{{- end }}

--- a/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -104,6 +104,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "preciseCodeIntel") | trim | nindent 6 }}
       volumes:
       {{- if .Values.preciseCodeIntel.extraVolumes }}
       {{- toYaml .Values.preciseCodeIntel.extraVolumes | nindent 6 }}

--- a/charts/sourcegraph/templates/precise-code-intel/worker.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.preciseCodeIntel.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: precise-code-intel
+  name: {{ include "sourcegraph.serviceAccountName" (list . "preciseCodeIntel") }}
+{{- end }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -94,7 +94,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: prometheus
+      {{- include "sourcegraph.renderServiceAccountName" (list . "prometheus") | trim | nindent 6 }}
       volumes:
       - name: data
         persistentVolumeClaim:

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -110,6 +110,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "redisCache") | trim | nindent 6 }}
       volumes:
       - name: redis-data
         persistentVolumeClaim:

--- a/charts/sourcegraph/templates/redis/redis-cache.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.redisCache.enabled .Values.redisCache.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: redis
+  name: {{ include "sourcegraph.serviceAccountName" (list . "redisCache") }}
+{{- end }}

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -110,6 +110,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "redisStore") | trim | nindent 6 }}
       volumes:
       - name: redis-data
         persistentVolumeClaim:

--- a/charts/sourcegraph/templates/redis/redis-store.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.redisStore.enabled .Values.redisStore.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: redis
+  name: {{ include "sourcegraph.serviceAccountName" (list . "redisStore") }}
+{{- end }}

--- a/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -104,6 +104,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "repoUpdater") | trim | nindent 6 }}
       volumes:
       {{- if .Values.repoUpdater.extraVolumes }}
       {{- toYaml .Values.repoUpdater.extraVolumes | nindent 6 }}

--- a/charts/sourcegraph/templates/repo-updater/repo-updater.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.repoUpdater.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: repo-updater
+  name: {{ include "sourcegraph.serviceAccountName" (list . "repoUpdater") }}
+{{- end }}

--- a/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -111,6 +111,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "searcher") | trim | nindent 6 }}
       volumes:
       - emptyDir: {}
         name: cache-ssd

--- a/charts/sourcegraph/templates/searcher/searcher.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.searcher.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: searcher
+  name: {{ include "sourcegraph.serviceAccountName" (list . "searcher") }}
+{{- end }}

--- a/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -115,6 +115,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "symbols") | trim | nindent 6 }}
       volumes:
       - emptyDir: {}
         name: cache-ssd

--- a/charts/sourcegraph/templates/symbols/symbols.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.symbols.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: symbols
+  name: {{ include "sourcegraph.serviceAccountName" (list . "symbols") }}
+{{- end }}

--- a/charts/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -94,6 +94,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "syntectServer") | trim | nindent 6 }}
       volumes:
       {{- if .Values.syntectServer.extraVolumes }}
       {{- toYaml .Values.syntectServer.extraVolumes | nindent 6 }}

--- a/charts/sourcegraph/templates/syntect-server/syntect-server.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/syntect-server/syntect-server.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.syntectServer.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: syntect-server
+  name: {{ include "sourcegraph.serviceAccountName" (list . "syntectServer") }}
+{{- end }}

--- a/charts/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -104,6 +104,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "worker") | trim | nindent 6 }}
       volumes:
       {{- if .Values.worker.extraVolumes }}
       {{- toYaml .Values.worker.extraVolumes | nindent 6 }}

--- a/charts/sourcegraph/templates/worker/worker.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/worker/worker.ServiceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.worker.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: worker
+  name: {{ include "sourcegraph.serviceAccountName" (list . "worker") }}
+{{- end }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -132,7 +132,7 @@ cadvisor:
   serviceAccount:
     # -- Enable creation of ServiceAccount for `cadvisor`
     create: true
-    # -- Name of the ServiceAccount
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: cadvisor
 
 codeInsightsDB:
@@ -171,6 +171,11 @@ codeInsightsDB:
     runAsUser: 70
     fsGroup: 70
     fsGroupChangePolicy: "OnRootMismatch"
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `codeinsights-db`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
   # -- PVC Storage Request for `codeinsights-db` data volume
   storageSize: 200Gi
 
@@ -211,6 +216,11 @@ codeIntelDB:
     runAsUser: 999
     fsGroup: 999
     fsGroupChangePolicy: "OnRootMismatch"
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `codeintel-db`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
   # -- PVC Storage Request for `codeintel-db` data volume
   storageSize: 200Gi
 
@@ -288,7 +298,7 @@ frontend:
   serviceAccount:
     # -- Enable creation of ServiceAccount for `frontend`
     create: true
-    # -- Name of the ServiceAccount
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: sourcegraph-frontend
 
 migrator:
@@ -340,6 +350,11 @@ githubProxy:
     requests:
       cpu: 100m
       memory: 250M
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `github-proxy`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
 
 gitserver:
   image:
@@ -372,6 +387,11 @@ gitserver:
     runAsGroup: 101
     fsGroup: 101
     fsGroupChangePolicy: "OnRootMismatch"
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `gitserver`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
   # -- PVC Storage Request for `gitserver` data volume
   storageSize: 200Gi
 
@@ -413,6 +433,8 @@ grafana:
   serviceAccount:
     # -- Enable creation of ServiceAccount for `grafana`
     create: true
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: grafana
   # -- PVC Storage Request for `grafana` data volume
   storageSize: 2Gi
 
@@ -445,6 +467,11 @@ indexedSearch:
   podSecurityContext:
     fsGroup: 101
     fsGroupChangePolicy: "OnRootMismatch"
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `indexed-search`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
   # -- PVC Storage Request for `indexed-search` data volume
   # The size of disk to used for search indexes.
   # This should typically be gitserver disk size multipled by the number of gitserver shards.
@@ -514,6 +541,11 @@ minio:
     runAsGroup: 101
     fsGroup: 101
     fsGroupChangePolicy: "OnRootMismatch"
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `minio`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
   # -- PVC Storage Request for `minio` data volume
   storageSize: 100Gi
 
@@ -556,6 +588,11 @@ pgsql:
     runAsGroup: 999
     fsGroup: 999
     fsGroupChangePolicy: "OnRootMismatch"
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `pgsql`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
   # -- PVC Storage Request for `pgsql` data volume
   storageSize: 200Gi
 
@@ -606,6 +643,11 @@ preciseCodeIntel:
     requests:
       cpu: 500m
       memory: 2G
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `precise-code-intel-worker`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
 
 prometheus:
   # -- Enable `prometheus` (recommended)
@@ -652,6 +694,8 @@ prometheus:
   serviceAccount:
     # -- Enable creation of ServiceAccount
     create: true
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: prometheus
   # -- PVC Storage Request for `prometheus` data volume
   storageSize: 200Gi
 
@@ -684,6 +728,11 @@ redisCache:
   podSecurityContext:
     fsGroup: 1000
     fsGroupChangePolicy: "OnRootMismatch"
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `redis-cache`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
   # -- PVC Storage Request for `redis-cache` data volume
   storageSize: 100Gi
 
@@ -739,6 +788,11 @@ redisStore:
   podSecurityContext:
     fsGroup: 1000
     fsGroupChangePolicy: "OnRootMismatch"
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `redis-store`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
   # -- PVC Storage Request for `redis-store` data volume
   storageSize: 100Gi
 
@@ -769,6 +823,11 @@ repoUpdater:
     requests:
       cpu: "1"
       memory: 500Mi
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `repo-updater`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
 
 searcher:
   image:
@@ -799,6 +858,11 @@ searcher:
       cpu: 500m
       ephemeral-storage: 25G
       memory: 500M
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `searcher`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
 
 storageClass:
   # -- Enable creation of storageClass.
@@ -847,6 +911,11 @@ symbols:
       cpu: 500m
       ephemeral-storage: 10G
       memory: 500M
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `symbols`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
 
 syntectServer:
   image:
@@ -875,6 +944,11 @@ syntectServer:
     requests:
       cpu: 250m
       memory: 2G
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `syntect-server`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
 
 tracing:
   collector:
@@ -927,6 +1001,11 @@ tracing:
     requests:
       cpu: 500m
       memory: 500M
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `jaeger`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
 
 # Jaeger sidecar container
 tracingAgent:
@@ -980,3 +1059,8 @@ worker:
     requests:
       cpu: 500m
       memory: 2G
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `worker`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""


### PR DESCRIPTION
This PR enables users to override service account for all deployed resources

## Test plan

### Initial deployment

```sh
kind create cluster
```

`override.yaml`

```yml
storageClass:
  create: false # Disable if you have your own existing storage class
  name: standard

sourcegraph:
  localDevMode: true
```

```sh
helm upgrade --install -n sourcegraph -f charts/sourcegraph/override.yaml sourcegraph charts/sourcegraph/
```

### Enable SA

Updated `override.yaml`

```yml
storageClass:
  create: false # Disable if you have your own existing storage class
  name: standard

sourcegraph:
  localDevMode: true

codeInsightsDB:
  serviceAccount:
    create: true
codeIntelDB:
  serviceAccount:
    create: true
githubProxy:
  serviceAccount:
    create: true
gitserver:
  serviceAccount:
    create: true
indexedSearch:
  serviceAccount:
    create: true
minio:
  serviceAccount:
    create: true
pgsql:
  serviceAccount:
    create: true
preciseCodeIntel:
  serviceAccount:
    create: true
redisCache:
  serviceAccount:
    create: true
redisStore:
  serviceAccount:
    create: true
repoUpdater:
  serviceAccount:
    create: true
searcher:
  serviceAccount:
    create: true
symbols:
  serviceAccount:
    create: true
syntectServer:
  serviceAccount:
    create: true
tracing:
  serviceAccount:
    create: true
worker:
  serviceAccount:
    create: true
```

```sh
 helm diff -n sourcegraph -f charts/sourcegraph/override.yaml sourcegraph charts/sourcegraph/ 
```

- Verify rendered manifest is expected
- Verify sourcegraph server still works

fix https://github.com/sourcegraph/sourcegraph/issues/31889