### PR TITLE
Add advanced scheduling example override

### DIFF
--- a/charts/sourcegraph/examples/advanced-scheduling/override.yaml
+++ b/charts/sourcegraph/examples/advanced-scheduling/override.yaml
@@ -2,7 +2,7 @@
 # - the use of advanced scheduling in Kubernetes, including
 #   - node selector
 #   - tolerations
-#   - affinity to scatter services across multi availability zones 
+#   - affinity to scatter services across multiple nodes
 # - the use of YAMl anchor and alias to keep your override.yaml DRY
 #
 # For scaling guide, you should refer to our official docs 
@@ -31,7 +31,7 @@ frontend:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - podAffinityTerm:
-            topologyKey: topology.kubernetes.io/zone
+            topologyKey: kubernetes.io/hostname
             labelSelector:
               matchLabels:
                 <<: *commonSelectorLabels
@@ -47,7 +47,7 @@ gitserver:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - podAffinityTerm:
-            topologyKey: topology.kubernetes.io/zone
+            topologyKey: kubernetes.io/hostname
             labelSelector:
               matchLabels:
                 <<: *commonSelectorLabels
@@ -60,7 +60,7 @@ indexedSearch:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - podAffinityTerm:
-            topologyKey: topology.kubernetes.io/zone
+            topologyKey: kubernetes.io/hostname
             labelSelector:
               matchLabels:
                 <<: *commonSelectorLabels
@@ -73,7 +73,7 @@ preciseCodeIntel:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - podAffinityTerm:
-            topologyKey: topology.kubernetes.io/zone
+            topologyKey: kubernetes.io/hostname
             labelSelector:
               matchLabels:
                 <<: *commonSelectorLabels
@@ -86,7 +86,7 @@ searcher:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - podAffinityTerm:
-            topologyKey: topology.kubernetes.io/zone
+            topologyKey: kubernetes.io/hostname
             labelSelector:
               matchLabels:
                 <<: *commonSelectorLabels
@@ -99,7 +99,7 @@ symbols:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - podAffinityTerm:
-            topologyKey: topology.kubernetes.io/zone
+            topologyKey: kubernetes.io/hostname
             labelSelector:
               matchLabels:
                 <<: *commonSelectorLabels
@@ -112,7 +112,7 @@ worker:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - podAffinityTerm:
-            topologyKey: topology.kubernetes.io/zone
+            topologyKey: kubernetes.io/hostname
             labelSelector:
               matchLabels:
                 <<: *commonSelectorLabels

--- a/charts/sourcegraph/examples/advanced-scheduling/override.yaml
+++ b/charts/sourcegraph/examples/advanced-scheduling/override.yaml
@@ -1,0 +1,120 @@
+## Override file demonstrating 
+# - the use of advanced scheduling in Kubernetes, including
+#   - node selector
+#   - tolerations
+#   - affinity to scatter services across multi availability zones 
+# - the use of YAMl anchor and alias to keep your override.yaml DRY
+#
+# For scaling guide, you should refer to our official docs 
+# - https://docs.sourcegraph.com/admin/install/kubernetes/scale
+# - https://docs.sourcegraph.com/dev/background-information/architecture#diagram
+
+sourcegraph:
+  # Global node selector
+  nodeSelector: &commonNodeSelector
+    kubernetes.io/arch: amd64
+  # Global tolerations
+  tolerations:
+  - key: "some-key"
+    operator: "Equal"
+    value: "some-value"
+    effect: "NoSchedule"
+
+# Common select labels to select pods that belong to the current helm release
+selectorLabels: &commonSelectorLabels
+  app.kubernetes.io/name: '{{ include "sourcegraph.name" . }}'
+  app.kubernetes.io/instance: '{{ .Release.Name }}'
+
+frontend:
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: topology.kubernetes.io/zone
+            labelSelector:
+              matchLabels:
+                <<: *commonSelectorLabels
+                app: frontend
+          weight: 100
+
+gitserver:
+  replicaCount: 3
+  nodeSelector:
+    <<: *commonNodeSelector
+    cloud.google.com/gke-boot-disk: pd-ssd
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: topology.kubernetes.io/zone
+            labelSelector:
+              matchLabels:
+                <<: *commonSelectorLabels
+                app: gitserver
+          weight: 100
+
+indexedSearch:
+  replicaCount: 10
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: topology.kubernetes.io/zone
+            labelSelector:
+              matchLabels:
+                <<: *commonSelectorLabels
+                app: indexed-search
+          weight: 100
+
+preciseCodeIntel:
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: topology.kubernetes.io/zone
+            labelSelector:
+              matchLabels:
+                <<: *commonSelectorLabels
+                app: precise-code-intel-worker
+          weight: 100
+
+searcher:
+  replicaCount: 5
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: topology.kubernetes.io/zone
+            labelSelector:
+              matchLabels:
+                <<: *commonSelectorLabels
+                app: searcher
+          weight: 100
+
+symbols:
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: topology.kubernetes.io/zone
+            labelSelector:
+              matchLabels:
+                <<: *commonSelectorLabels
+                app: symbols
+          weight: 100
+
+worker:
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: topology.kubernetes.io/zone
+            labelSelector:
+              matchLabels:
+                <<: *commonSelectorLabels
+                app: worker
+          weight: 100

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -88,9 +88,9 @@ nodeSelector:
 {{- $serviceAffinity := (index $top.Values $service "affinity") }}
 affinity:
 {{- if $serviceAffinity }}
-{{- $serviceAffinity | toYaml | trim | nindent 2 }}
+{{- tpl ($serviceAffinity | toYaml) $top | trim | nindent 2 }}
 {{- else if $globalAffinity }}
-{{- $globalAffinity | toYaml | trim | nindent 2 }}
+{{- tpl ($globalAffinity | toYaml) $top | trim | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/charts/sourcegraph/tests/affinity_test.yaml
+++ b/charts/sourcegraph/tests/affinity_test.yaml
@@ -1,0 +1,64 @@
+suite: affinity
+templates:
+- frontend/sourcegraph-frontend.Deployment.yaml
+release:
+  name: sourcegraph
+  namespace: sourcegraph
+tests:
+- it: should render affinity values that contain template
+  set:
+    frontend:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: '{{ include "sourcegraph.name" . }}'
+                  app.kubernetes.io/instance: '{{ .Release.Name }}'
+                  app: frontend
+            weight: 100
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity
+      value:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: sourcegraph
+                  app.kubernetes.io/instance: sourcegraph
+                  app: frontend
+            weight: 100
+
+- it: should render affinity values that do not contain template
+  set:
+    frontend:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: sourcegraph
+                  app.kubernetes.io/instance: sourcegraph
+                  app: frontend
+            weight: 100
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity
+      value:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: sourcegraph
+                  app.kubernetes.io/instance: sourcegraph
+                  app: frontend
+            weight: 100


### PR DESCRIPTION
This PR added an example override to show advanced scheduling

Also added `tpl` support to affinity rule, so string template can be evaluated as template during rendering

`override.yaml`
```
labels:
  app.kubernetes.io/name: '{{ include "sourcegraph.name" . }}'
  app.kubernetes.io/instance: '{{ .Release.Name }}'
```

https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/280065f45e5738f1a1deed61b235192d1e5893c4/charts/sourcegraph/templates/_helpers.tpl#L75-L86

## Test plan

```sh
helm template -f ./charts/sourcegraph/examples/advanced-scheduling/override.yaml sourcegraph charts/sourcegraph/.
```

close https://github.com/sourcegraph/sourcegraph/issues/31875