### PR TITLE
sourcegraph: release 0.4.0

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 -
 
-## 1.0.0
+## 0.4.0
 
 :bulb: We revamped the documentation of helm chart configuration options, [learn more](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph#configuration-options)
 

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- **BREAKING**: Uses of `podSecurityContext` have been renamed to `containerSecurityContext`, and `securityContext` renamed to `podSecurityContext` to better illustrate their actual usage [#48](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/48)
+- 
 
 ### Fixed
 
@@ -25,3 +25,23 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 -
+
+## 1.0.0
+
+:bulb: We revamped the documentation of helm chart configuration options, [learn more](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph#configuration-options)
+
+### Added
+
+- Support custom service account name (#52)
+- Support container args override (#44)
+- Add per-service scheduling config support (#46)
+
+### Changed
+
+- **BREAKING**: Uses of `podSecurityContext` have been renamed to `containerSecurityContext`, and `securityContext` renamed to `podSecurityContext` to better illustrate their actual usage [#48](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/48)
+
+### Fixed
+
+- Fix default global tolerations value (#45)
+- Fix `default-container` annotations (#47)
+- Add missing imagePullPolicy (#49)

--- a/charts/sourcegraph/Chart.yaml
+++ b/charts/sourcegraph/Chart.yaml
@@ -5,7 +5,7 @@ description: Chart for installing Sourcegraph
 type: application
 
 # Chart version, separate from Sourcegraph
-version: 0.3.0
+version: 1.0.0
 
 # Version of Sourcegraph release
 appVersion: "3.37.0"

--- a/charts/sourcegraph/Chart.yaml
+++ b/charts/sourcegraph/Chart.yaml
@@ -5,7 +5,7 @@ description: Chart for installing Sourcegraph
 type: application
 
 # Chart version, separate from Sourcegraph
-version: 1.0.0
+version: 0.4.0
 
 # Version of Sourcegraph release
 appVersion: "3.37.0"

--- a/charts/sourcegraph/README.md.gotmpl
+++ b/charts/sourcegraph/README.md.gotmpl
@@ -137,6 +137,6 @@ It is commonly used to track key performance metrics over time, such as the foll
 - HTTP error codes
 - Time since last search index update
 
-A Prometheus instance is part of the default Sourcegraph cluster installa
+A Prometheus instance is part of the default Sourcegraph cluster installation.
 
 The Prometheus deployment can be disabled by setting `prometheus.enabled` to `false`. This is not recommended, as it severely limits your ability to monitor the health of your instance and troubleshoot any issues. Instead, consider setting `prometheus.privileged` to `false`, which reduces the privileges required to deploy a Prometheus instance.

--- a/charts/sourcegraph/README.md.gotmpl
+++ b/charts/sourcegraph/README.md.gotmpl
@@ -137,6 +137,6 @@ It is commonly used to track key performance metrics over time, such as the foll
 - HTTP error codes
 - Time since last search index update
 
-A Prometheus instance is part of the default Sourcegraph cluster installation.
+A Prometheus instance is part of the default Sourcegraph cluster installa
 
 The Prometheus deployment can be disabled by setting `prometheus.enabled` to `false`. This is not recommended, as it severely limits your ability to monitor the health of your instance and troubleshoot any issues. Instead, consider setting `prometheus.privileged` to `false`, which reduces the privileges required to deploy a Prometheus instance.


### PR DESCRIPTION
I backfilled our changelog with commits that I think it's worth mentioning ` git log --oneline -- charts/sourcegraph/`

## Test plan

N/A, new release