### PR TITLE
Fix jaeger labels selector

### DIFF
--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -106,3 +106,25 @@ tolerations:
 {{- $globalTolerations | toYaml | trim | nindent 2 }}
 {{- end }}
 {{- end }}
+
+{{/*
+Jaeger common labels
+*/}}
+{{- define "sourcegraph.jaeger.labels" -}}
+helm.sh/chart: {{ include "sourcegraph.chart" . }}
+{{ include "sourcegraph.jaeger.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.sourcegraph.labels }}
+{{ toYaml .Values.sourcegraph.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Jaeger selector labels
+*/}}
+{{- define "sourcegraph.jaeger.selectorLabels" -}}
+app.kubernetes.io/name: jaeger
+{{- end }}

--- a/charts/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
   labels:
     deploy: sourcegraph
-    app.kubernetes.io/component: jaeger
+    app.kubernetes.io/component: all-in-one
     app: jaeger
     app.kubernetes.io/name: jaeger
     {{- if .Values.tracing.collector.serviceLabels }}
@@ -30,8 +30,9 @@ spec:
     protocol: TCP
     targetPort: 14250
   selector:
-    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/name: jaeger
+    {{- include "sourcegraph.jaeger.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: all-in-one
+    app: jaeger
   type: {{ .Values.tracing.collector.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/charts/sourcegraph/templates/jaeger/jaeger-query.Service.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger-query.Service.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
   labels:
     deploy: sourcegraph
-    app.kubernetes.io/component: jaeger
+    app.kubernetes.io/component: all-in-one
     app: jaeger
     app.kubernetes.io/name: jaeger
     {{- if .Values.tracing.query.serviceLabels }}
@@ -22,8 +22,9 @@ spec:
     protocol: TCP
     targetPort: 16686
   selector:
-    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/name: jaeger
+    {{- include "sourcegraph.jaeger.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: all-in-one
+    app: jaeger
   type: {{ .Values.tracing.query.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -4,21 +4,20 @@ kind: Deployment
 metadata:
   name: {{ default "jaeger" .Values.tracing.name }}
   labels:
-    {{- include "sourcegraph.labels" . | nindent 4 }}
+    {{- include "sourcegraph.jaeger.labels" . | nindent 4 }}
     {{- if .Values.tracing.labels }}
       {{- toYaml .Values.tracing.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    app.kubernetes.io/component: jaeger
+    app.kubernetes.io/component: all-in-one
     app: jaeger
-    app.kubernetes.io/name: jaeger
 spec:
   replicas: {{ .Values.tracing.replicaCount }}
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
   selector:
     matchLabels:
+      {{- include "sourcegraph.jaeger.selectorLabels" . | nindent 6 }}
       app: jaeger
-      app.kubernetes.io/name: jaeger
       app.kubernetes.io/component: all-in-one
   strategy:
     type: Recreate
@@ -35,16 +34,16 @@ spec:
       {{- toYaml .Values.tracing.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
-      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
+      {{- include "sourcegraph.jaeger.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}
       {{- if .Values.tracing.podLabels }}
       {{- toYaml .Values.tracing.podLabels | nindent 8 }}
       {{- end }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         app: jaeger
         deploy: sourcegraph
-        app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: all-in-one
     spec:
       containers:


### PR DESCRIPTION
We were rendering duplicated labels `app.kubernetes.io/component` and `app.kubernetes.io/name` in jaeger `deploy` and `svc`. This is causing problems when piping rendered output to `kustomize`. 

```
stomize-chart/kustomize. error output:
Error: received error yaml: unmarshal errors:
  line 29: mapping key "app.kubernetes.io/name" already defined at line 27 for the following resource:
```

This PR 

- cleans up all these duplicated labels.
- enforce consistency to some extent without introducing any breaking change
  - use `app.kubernetes.io/component: all-in-one` and `app.kubernetes.io/name: jaeger` as much as possible. They are the value of `matchLabels` right now and we can't change them, so we might as well use them as the standard for all jaeger components.

See below comment for the latest diff

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Deploy the chart from the last release

```sh
helm upgrade --install -n sourcegraph -f ./override.yaml sourcegraph sourcegraph/sourcegraph
```

Inspect the diff, jaeger deployment and services should no longer contain duplicate labels.

```sh
helm diff -n sourcegraph -f ./override.yaml sourcegraph charts/sourcegraph/.
```

Deploy the changes make sure it's non-breaking

```sh
helm upgrade --install -n sourcegraph -f ./override.yaml sourcegraph charts/sourcegraph/.
```

Of course, verify tracing still works