### PR TITLE
Add docs to kustomize chart

### DIFF
--- a/charts/sourcegraph/examples/kustomize-chart/README.md
+++ b/charts/sourcegraph/examples/kustomize-chart/README.md
@@ -6,6 +6,8 @@ This example demonstrate the escape hatch whenever you encounter something that 
 
 In this example, we will change the `http` port of `sourcegraph-frontend.Service.yaml` and update the corresponding backend service port number in `sourcegraph-frontend.Ingress.yaml`.
 
+We will utilize the [post renderering] featue from Helm to integrate with [Kustomize]. The `./kustomize` script below will run `kustomize build` on the rendered manifests from helm and return the transformed manifests back to Helm.
+
 > Below command should be run within the current directory
 
 ```sh
@@ -15,3 +17,4 @@ helm upgrade --install --create-namespace -n sourcegraph sourcegraph sourcegraph
 [kustomize]: https://kustomize.io
 [strategic merge patch]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md
 [json patch]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment
+[post renderering]: https://helm.sh/docs/topics/advanced/#post-rendering

--- a/charts/sourcegraph/examples/kustomize-chart/README.md
+++ b/charts/sourcegraph/examples/kustomize-chart/README.md
@@ -1,0 +1,17 @@
+# kustomize chart
+
+This example demonstrate the escape hatch whenever you encounter something that our helm charts do not support yet. [Kustomize] allows you to apply [strategic merge patch] and [json patch] on helm chart without maintaining a custom fork. This is our **recommended** approach to customize helm chart, and you should avoid forking unless absolutely necessary.
+
+## Customize `frontend` service port
+
+In this example, we will change the `http` port of `sourcegraph-frontend.Service.yaml` and update the corresponding backend service port number in `sourcegraph-frontend.Ingress.yaml`.
+
+> Below command should be run within the current directory
+
+```sh
+helm upgrade --install --create-namespace -n sourcegraph sourcegraph sourcegraph/sourcegraph --post-renderer ./kustomize
+```
+
+[kustomize]: https://kustomize.io
+[strategic merge patch]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md
+[json patch]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment

--- a/charts/sourcegraph/examples/kustomize-chart/kustomization.yaml
+++ b/charts/sourcegraph/examples/kustomize-chart/kustomization.yaml
@@ -1,0 +1,20 @@
+resources:
+  - all.yaml
+
+patches:
+- target:
+    version: v1
+    kind: Service
+    name: sourcegraph-frontend
+  patch: |-
+    - op: replace
+      path: /spec/ports/0/port
+      value: 80
+- target:
+    version: v1
+    kind: Ingress
+    name: sourcegraph-frontend
+  patch: |-
+    - op: replace
+      path: /spec/rules/0/http/paths/0/backend/service/port/number
+      value: 80

--- a/charts/sourcegraph/examples/kustomize-chart/kustomize
+++ b/charts/sourcegraph/examples/kustomize-chart/kustomize
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+cat <&0 > all.yaml
+
+kustomize build . && rm all.yaml

--- a/charts/sourcegraph/examples/kustomize-chart/kustomize
+++ b/charts/sourcegraph/examples/kustomize-chart/kustomize
@@ -2,6 +2,8 @@
 
 set -euf -o pipefail
 
+# Save the rendered manifests from STDIN to a temporary file
 cat <&0 > all.yaml
 
+# Apply kustomize on rendered manifests and remvoe the temporary file
 kustomize build . && rm all.yaml

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -106,3 +106,25 @@ tolerations:
 {{- $globalTolerations | toYaml | trim | nindent 2 }}
 {{- end }}
 {{- end }}
+
+{{/*
+Jaeger common labels
+*/}}
+{{- define "sourcegraph.jaeger.labels" -}}
+helm.sh/chart: {{ include "sourcegraph.chart" . }}
+{{ include "sourcegraph.jaeger.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.sourcegraph.labels }}
+{{ toYaml .Values.sourcegraph.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Jaeger selector labels
+*/}}
+{{- define "sourcegraph.jaeger.selectorLabels" -}}
+app.kubernetes.io/name: jaeger
+{{- end }}

--- a/charts/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
   labels:
     deploy: sourcegraph
-    app.kubernetes.io/component: jaeger
+    app.kubernetes.io/component: all-in-one
     app: jaeger
     app.kubernetes.io/name: jaeger
     {{- if .Values.tracing.collector.serviceLabels }}
@@ -30,8 +30,9 @@ spec:
     protocol: TCP
     targetPort: 14250
   selector:
-    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/name: jaeger
+    {{- include "sourcegraph.jaeger.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: all-in-one
+    app: jaeger
   type: {{ .Values.tracing.collector.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/charts/sourcegraph/templates/jaeger/jaeger-query.Service.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger-query.Service.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
   labels:
     deploy: sourcegraph
-    app.kubernetes.io/component: jaeger
+    app.kubernetes.io/component: all-in-one
     app: jaeger
     app.kubernetes.io/name: jaeger
     {{- if .Values.tracing.query.serviceLabels }}
@@ -22,8 +22,9 @@ spec:
     protocol: TCP
     targetPort: 16686
   selector:
-    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/name: jaeger
+    {{- include "sourcegraph.jaeger.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: all-in-one
+    app: jaeger
   type: {{ .Values.tracing.query.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -4,21 +4,20 @@ kind: Deployment
 metadata:
   name: {{ default "jaeger" .Values.tracing.name }}
   labels:
-    {{- include "sourcegraph.labels" . | nindent 4 }}
+    {{- include "sourcegraph.jaeger.labels" . | nindent 4 }}
     {{- if .Values.tracing.labels }}
       {{- toYaml .Values.tracing.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
-    app.kubernetes.io/component: jaeger
+    app.kubernetes.io/component: all-in-one
     app: jaeger
-    app.kubernetes.io/name: jaeger
 spec:
   replicas: {{ .Values.tracing.replicaCount }}
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
   selector:
     matchLabels:
+      {{- include "sourcegraph.jaeger.selectorLabels" . | nindent 6 }}
       app: jaeger
-      app.kubernetes.io/name: jaeger
       app.kubernetes.io/component: all-in-one
   strategy:
     type: Recreate
@@ -35,16 +34,16 @@ spec:
       {{- toYaml .Values.tracing.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
-      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
+      {{- include "sourcegraph.jaeger.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
       {{- end }}
       {{- if .Values.tracing.podLabels }}
       {{- toYaml .Values.tracing.podLabels | nindent 8 }}
       {{- end }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         app: jaeger
         deploy: sourcegraph
-        app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: all-in-one
     spec:
       containers:


### PR DESCRIPTION
This PR added example to integrate kustomize into `helm install`

Why not `helm-x`? I just realize the project was abandoned and doesn't work with helm v3. Its core functionality was extracted into another library https://github.com/variantdev/chartify. 

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

See added README.md

close https://github.com/sourcegraph/sourcegraph/issues/32178