### PR TITLE
Remove replicaCount values of unscalable services

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -184,7 +184,6 @@ In addition to the documented values, all services also support the following va
 | minio.image.defaultTag | string | `"3.37.0@sha256:66925bab722ed11584e1135687b5c1e00a13c550e38d954a56048c90f17edc53"` | Docker image tag for the `minio` image |
 | minio.image.name | string | `"minio"` | Docker image tag for the `minio` image |
 | minio.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":101,"runAsUser":100}` | Security context for the `minio` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| minio.replicaCount | int | `1` | Number of `minio` pod |
 | minio.resources | object | `{"limits":{"cpu":"1","memory":"500M"},"requests":{"cpu":"1","memory":"500M"}}` | Resource requests & limits for the `minio` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | minio.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `minio` |
 | minio.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
@@ -250,7 +249,6 @@ In addition to the documented values, all services also support the following va
 | repoUpdater.image.defaultTag | string | `"3.37.0@sha256:fd0562d9d3972d2e4f504b0de8803f485603b57fbc4dd77ac085b1f96dfacbe4"` | Docker image tag for the `repo-updater` image |
 | repoUpdater.image.name | string | `"repo-updater"` | Docker image name for the `repo-updater` image |
 | repoUpdater.podSecurityContext | object | `{}` | Security context for the `repo-updater` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| repoUpdater.replicaCount | int | `1` | Number of `repo-updater` pod |
 | repoUpdater.resources | object | `{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"1","memory":"500Mi"}}` | Resource requests & limits for the `repo-updater` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | repoUpdater.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `repo-updater` |
 | repoUpdater.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |

--- a/charts/sourcegraph/templates/minio/minio.Deployment.yaml
+++ b/charts/sourcegraph/templates/minio/minio.Deployment.yaml
@@ -14,7 +14,7 @@ metadata:
   name: {{ default "minio" .Values.minio.name }}
 spec:
   minReadySeconds: 10
-  replicas: {{ .Values.minio.replicaCount }}
+  replicas: 1
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -14,7 +14,7 @@ metadata:
   name: {{ default "repo-updater" .Values.repoUpdater.name }}
 spec:
   minReadySeconds: 10
-  replicas: {{ .Values.repoUpdater.replicaCount }}
+  replicas: 1
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -529,8 +529,6 @@ minio:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
-  # -- Number of `minio` pod
-  replicaCount: 1
   # -- Resource requests & limits for the `minio` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -818,8 +816,6 @@ repoUpdater:
   # -- Security context for the `repo-updater` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
-  # -- Number of `repo-updater` pod
-  replicaCount: 1
   # -- Resource requests & limits for the `repo-updater` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:


### PR DESCRIPTION
- repo-updater
It's loud and clear that repo-updater is not horizontally scalable https://github.com/sourcegraph/sourcegraph/tree/main/cmd/repo-updater 

- ~syntect-server~
~Waiting for confirmation on syntech-server https://sourcegraph.slack.com/archives/CHXHX7XAS/p1646783148867999~
syntect-server is horizontally scable.

- minio
`minio` supports HA, but not the way how we run it nowadays

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

`.spec.replicas` of repo-updater and syntech-server deployment should be unchanged

```sh
 helm template --set repoUpdater.replicaCount=10,syntechServer.replicaCount=10 charts/sourcegraph/. | yq e '. | select(.kind == "Deployment" and (.metadata.name == "repo-updater" or .metadata.name == "syntect-server"))'
```


close https://github.com/sourcegraph/sourcegraph/issues/32095