### PR TITLE
Set deploy_type env var to track helm chart usage

### DIFF
--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -240,6 +240,8 @@ frontend:
       value: disable
     CODEINTEL_PGUSER:
       value: sg
+    DEPLOY_TYPE:
+      value: helm
     GRAFANA_SERVER_URL:
       value: http://grafana:30070
     JAEGER_SERVER_URL:


### PR DESCRIPTION
Enable tracking of helm chart usage by using the deploy_type env var.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Compared diffs before and after - new env var is set. Frontend will crash unless the changes from https://github.com/sourcegraph/sourcegraph/pull/32407 are present.