### PR TITLE
Remove replicaCount values for github-proxy

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -135,7 +135,6 @@ In addition to the documented values, all services also support the following va
 | githubProxy.image.defaultTag | string | `"3.37.0@sha256:3b173e36f958b68479ae829d784c63346701df417afa14d14ae657a84e630dd5"` | Docker image tag for the `github-proxy` image |
 | githubProxy.image.name | string | `"github-proxy"` | Docker image name for the `github-proxy` image |
 | githubProxy.podSecurityContext | object | `{}` | Security context for the `github-proxy` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| githubProxy.replicaCount | int | `1` | Number of `github-proxy` pod |
 | githubProxy.resources | object | `{"limits":{"cpu":"1","memory":"1G"},"requests":{"cpu":"100m","memory":"250M"}}` | Resource requests & limits for the `github-proxy` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | githubProxy.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `github-proxy` |
 | githubProxy.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ default "github-proxy" .Values.githubProxy.name }}
 spec:
   minReadySeconds: 10
-  replicas: {{ .Values.githubProxy.replicaCount }}
+  replicas: 1
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -345,8 +345,6 @@ githubProxy:
   # -- Security context for the `github-proxy` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
-  # -- Number of `github-proxy` pod
-  replicaCount: 1
   # -- Resource requests & limits for the `github-proxy` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:


### PR DESCRIPTION
[github-proxy](https://github.com/sourcegraph/sourcegraph/tree/main/cmd/github-proxy) is a singleton service

why?

- https://github.com/sourcegraph/sourcegraph/tree/main/cmd/github-proxy
- https://docs.sourcegraph.com/dev/background-information/architecture, it's a rectangle not a box
- it tracks requests in memory, so yeah, you really shouldn't scale it up

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Replicas should stay `1`.

```sh
 helm template --set githubProxy.replicaCount=10 charts/sourcegraph/. | yq e '. | select(.kind == "Deployment" and .metadata.name == "github-proxy")'
```