### PR TITLE
Fix broken indentation in storageClass params

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- Fix broken indentation in storageClass parameters [#73](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/73)
 
 ### Removed
 

--- a/charts/sourcegraph/templates/storageclass.yaml
+++ b/charts/sourcegraph/templates/storageclass.yaml
@@ -14,7 +14,7 @@ provisioner: {{ .Values.storageClass.provisioner }}
 parameters:
   type: {{ .Values.storageClass.type }}
   {{- if .Values.storageClass.parameters}}
-  {{- toYaml .Values.storageClass.parameters| nindent 4 }}
+  {{- toYaml .Values.storageClass.parameters | nindent 2 }}
   {{- end }}
 allowVolumeExpansion: {{ default true .Values.storageClass.allowVolumeExpansion }}
 reclaimPolicy: {{ default "Retain" .Values.storageClass.reclaimPolicy }}

--- a/charts/sourcegraph/tests/storageClass_test.yaml
+++ b/charts/sourcegraph/tests/storageClass_test.yaml
@@ -1,0 +1,14 @@
+suite: storageClass
+templates:
+- storageclass.yaml
+tests:
+- it: should have parameters rendered when storageClass.parameters.zones=us-central1-f
+  set:
+    storageClass:
+      create: true
+      parameters:
+        zones: us-central1-f
+  asserts:
+  - equal:
+      path: parameters.zones
+      value: us-central1-f


### PR DESCRIPTION
Rendered manifest had broken indentation when `storageClass.parameters` is not empty

```
Error: Error: YAML parse error on sourcegraph/templates/storageclass.yaml: error converting YAML to JSON: yaml: line 16: mapping values are not allowed in this context
```

```yaml
# Source: sourcegraph/templates/storageclass.yaml

kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name:  standard
  labels:
    helm.sh/chart: sourcegraph-0.5.0
    app.kubernetes.io/name: sourcegraph
    app.kubernetes.io/instance: sourcegraph
    app.kubernetes.io/version: "3.37.0"
    app.kubernetes.io/managed-by: Helm
    deploy: sourcegraph-storage
  annotations:
provisioner: kubernetes.io/gce-pd
parameters:
  type: pd-ssd
    zones: us-central1-f
allowVolumeExpansion: true
reclaimPolicy: Retain
volumeBindingMode: Immediate
```

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
See added unit test