### PR TITLE
Migrate Code Insights db to postgres, add exporter

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- **CAUTION** Migrated Code Insights from Timescale to Postgres. If you have customized the configmap or connection parameters for codeinsights-db, manual updates may be required. [#74](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/74)
 
 ### Fixed
 

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -106,7 +106,6 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.image.defaultTag | string | `"3.38.0@sha256:4f971b00939ebbf7d9d622f40fc84a4fde994c67ebd023ed49ccad066aae2044"` | Docker image tag for the `codeinsights-db` image |
 | codeInsightsDB.image.name | string | `"codeinsights-db"` | Docker image name for the `codeinsights-db` image |
 | codeInsightsDB.podSecurityContext | object | `{"fsGroup":70,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":70}` | Security context for the `codeinsights-db` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| codeInsightsDB.postgresExporter.env | object | `{"DATA_SOURCE_NAME":{"value":"postgres://postgres:@localhost:5432/?sslmode=disable"}}` | Environment variables for the `pgsql-exporter` sidecar container |
 | codeInsightsDB.resources | object | `{"limits":{"cpu":"4","memory":"2Gi"},"requests":{"cpu":"4","memory":"2Gi"}}` | Resource requests & limits for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | codeInsightsDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeinsights-db` |
 | codeInsightsDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -101,11 +101,12 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
 | codeInsightsDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":70,"runAsUser":70}` | Security context for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeInsightsDB.enabled | bool | `true` | Enable `codeinsights-db` PostgreSQL server |
-| codeInsightsDB.env | object | `{"POSTGRES_PASSWORD":{"value":"password"}}` | Environment variables for the `codeinsights-db` container |
+| codeInsightsDB.env | object | `{"POSTGRES_DB":{"value":"postgres"},"POSTGRES_PASSWORD":{"value":"password"},"POSTGRES_USER":{"value":"postgres"}}` | Environment variables for the `codeinsights-db` container |
 | codeInsightsDB.existingConfig | string | `""` | Name of existing ConfigMap for `codeinsights-db`. It must contain a `postgresql.conf` key. |
 | codeInsightsDB.image.defaultTag | string | `"3.38.0@sha256:4f971b00939ebbf7d9d622f40fc84a4fde994c67ebd023ed49ccad066aae2044"` | Docker image tag for the `codeinsights-db` image |
 | codeInsightsDB.image.name | string | `"codeinsights-db"` | Docker image name for the `codeinsights-db` image |
 | codeInsightsDB.podSecurityContext | object | `{"fsGroup":70,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":70}` | Security context for the `codeinsights-db` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| codeInsightsDB.postgresExporter.env | object | `{"DATA_SOURCE_NAME":{"value":"postgres://postgres:@localhost:5432/?sslmode=disable"}}` | Environment variables for the `pgsql-exporter` sidecar container |
 | codeInsightsDB.resources | object | `{"limits":{"cpu":"4","memory":"2Gi"},"requests":{"cpu":"4","memory":"2Gi"}}` | Resource requests & limits for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | codeInsightsDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeinsights-db` |
 | codeInsightsDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.ConfigMap.yaml
@@ -6,20 +6,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    description: Configuration for TimescaleDB
+    description: Configuration for Code Insights
   labels:
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
   name: codeinsights-db-conf
 data:
   postgresql.conf: |
-    # --------------------------------------------------------------------------
-    # IMPORTANT: This is a TimescaleDB configuration file, not vanilla Postgres.
-    # Consider reading https://docs.timescale.com/latest/getting-started/configuring
-    # or running the 'timescaledb-tune' command from within the container to update
-    # your configuration file instead of making edits otherwise.
-    # --------------------------------------------------------------------------
-    #
     # -----------------------------
     # PostgreSQL configuration file
     # -----------------------------
@@ -695,7 +688,7 @@ data:
 
     # - Shared Library Preloading -
 
-    shared_preload_libraries = 'timescaledb'        # (change requires restart)
+    shared_preload_libraries = ''        # (change requires restart)
     #local_preload_libraries = ''
     #session_preload_libraries = ''
     #jit_provider = 'llvmjit'                # JIT library to use
@@ -770,10 +763,6 @@ data:
     #------------------------------------------------------------------------------
 
     # Add settings for extensions here
-    timescaledb.telemetry_level=basic
-    timescaledb.max_background_workers = 8
-    timescaledb.last_tuned = '2021-02-16T03:10:41Z'
-    timescaledb.last_tuned_version = '0.10.0'
 
     {{ tpl .Values.codeInsightsDB.additionalConfig . | nindent 4 | trim }}
 {{- end }}

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Service.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Service.yaml
@@ -18,9 +18,9 @@ metadata:
   name: codeinsights-db
 spec:
   ports:
-  - name: timescaledb
+  - name: codeinsights-db
     port: 5432
-    targetPort: timescaledb
+    targetPort: codeinsights-db
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: codeinsights-db

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    description: Code Insights TimescaleDB instance.
+    description: Code Insights Postgresql instance.
   labels:
     {{- include "sourcegraph.labels" . | nindent 4 }}
     {{- if .Values.codeInsightsDB.labels }}
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: timescaledb
+        kubectl.kubernetes.io/default-container: codeinsights
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}
@@ -43,7 +43,7 @@ spec:
         group: backend
     spec:
       containers:
-      - name: timescaledb
+      - name: codeinsights
         image: {{ include "sourcegraph.image" (list . "codeInsightsDB") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         {{- with .Values.codeInsightsDB.args }}
@@ -62,7 +62,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 5432
-          name: timescaledb
+          name: codeinsights-db
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.codeInsightsDB.resources | nindent 10 }}
@@ -73,11 +73,25 @@ spec:
         - mountPath: /var/lib/postgresql/data/
           name: disk
         - mountPath: /conf
-          name: timescaledb-conf
+          name: codeinsights-conf
         - mountPath: /var/run/postgresql
           name: lockdir
         {{- if .Values.codeInsightsDB.extraVolumeMounts }}
         {{- toYaml .Values.codeInsightsDB.extraVolumeMounts | nindent 8 }}
+        {{- end }}
+      - env:
+        {{- range $name, $item := .Values.codeInsightsDB.postgresExporter.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
+        - name: PG_EXPORTER_EXTEND_QUERY_PATH
+          value: /config/code_insights_queries.yaml
+        image: {{ include "sourcegraph.image" (list . "postgresExporter") }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        name: pgsql-exporter
+        {{- if not .Values.sourcegraph.localDevMode }}
+        resources:
+          {{- toYaml .Values.postgresExporter.resources | nindent 10 }}
         {{- end }}
       {{- if .Values.codeInsightsDB.extraContainers }}
         {{- toYaml .Values.codeInsightsDB.extraContainers | nindent 6 }}
@@ -97,7 +111,7 @@ spec:
       - name: disk
         persistentVolumeClaim:
           claimName: codeinsights-db
-      - name: timescaledb-conf
+      - name: codeinsights-conf
         configMap:
           defaultMode: 0777
           name: {{ default "codeinsights-db-conf" .Values.codeInsightsDB.existingConfig }}

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -79,20 +79,6 @@ spec:
         {{- if .Values.codeInsightsDB.extraVolumeMounts }}
         {{- toYaml .Values.codeInsightsDB.extraVolumeMounts | nindent 8 }}
         {{- end }}
-      - env:
-        {{- range $name, $item := .Values.codeInsightsDB.postgresExporter.env}}
-        - name: {{ $name }}
-          {{- $item | toYaml | nindent 10 }}
-        {{- end }}
-        - name: PG_EXPORTER_EXTEND_QUERY_PATH
-          value: /config/code_insights_queries.yaml
-        image: {{ include "sourcegraph.image" (list . "postgresExporter") }}
-        terminationMessagePolicy: FallbackToLogsOnError
-        name: pgsql-exporter
-        {{- if not .Values.sourcegraph.localDevMode }}
-        resources:
-          {{- toYaml .Values.postgresExporter.resources | nindent 10 }}
-        {{- end }}
       {{- if .Values.codeInsightsDB.extraContainers }}
         {{- toYaml .Values.codeInsightsDB.extraContainers | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -164,11 +164,6 @@ codeInsightsDB:
     runAsUser: 70
     runAsGroup: 70
     readOnlyRootFilesystem: true
-  postgresExporter:
-    # -- Environment variables for the `pgsql-exporter` sidecar container
-    env:
-      DATA_SOURCE_NAME:
-        value: postgres://postgres:@localhost:5432/?sslmode=disable
   # -- Resource requests & limits for the `codeinsights-db` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -140,8 +140,12 @@ codeInsightsDB:
   enabled: true
   # -- Environment variables for the `codeinsights-db` container
   env:
+    POSTGRES_DB:
+      value: postgres
     POSTGRES_PASSWORD: # Accessible by Sourcegraph applications on the network only, so password auth is not used.
       value: password
+    POSTGRES_USER:
+      value: postgres
   # -- Name of existing ConfigMap for `codeinsights-db`. It must contain a `postgresql.conf` key.
   existingConfig: "" # Name of an existing configmap
   # -- Additional PostgreSQL configuration. This will override or extend our default configuration.
@@ -160,6 +164,11 @@ codeInsightsDB:
     runAsUser: 70
     runAsGroup: 70
     readOnlyRootFilesystem: true
+  postgresExporter:
+    # -- Environment variables for the `pgsql-exporter` sidecar container
+    env:
+      DATA_SOURCE_NAME:
+        value: postgres://postgres:@localhost:5432/?sslmode=disable
   # -- Resource requests & limits for the `codeinsights-db` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:


### PR DESCRIPTION
Migrates Code Insights to use a Postgres base image.

**Q**: This change won't work without an image update (https://github.com/sourcegraph/sourcegraph/pull/32616). We don't normally update image references until a release, but this is actually a backwards compatible change with the 3.37 release Should I update the image ref and merge, or label this as a release-blocker instead?

### Checklist

- [X] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Tested both a clean install and an upgrade - no issues. This is basically the same change as https://github.com/sourcegraph/deploy-sourcegraph/pull/4099.

Diff on the template looks correct:
```diff
50c50
<     description: Configuration for TimescaleDB
---
>     description: Configuration for Code Insights
57,63d56
<     # --------------------------------------------------------------------------
<     # IMPORTANT: This is a TimescaleDB configuration file, not vanilla Postgres.
<     # Consider reading https://docs.timescale.com/latest/getting-started/configuring
<     # or running the 'timescaledb-tune' command from within the container to update
<     # your configuration file instead of making edits otherwise.
<     # --------------------------------------------------------------------------
<     #
739c732
<     shared_preload_libraries = 'timescaledb'        # (change requires restart)
---
>     shared_preload_libraries = ''        # (change requires restart)
814,817d806
<     timescaledb.telemetry_level=basic
<     timescaledb.max_background_workers = 8
<     timescaledb.last_tuned = '2021-02-16T03:10:41Z'
<     timescaledb.last_tuned_version = '0.10.0'
2830c2819
<   - name: timescaledb
---
>   - name: codeinsights-db
2832c2821
<     targetPort: timescaledb
---
>     targetPort: codeinsights-db
4873c4862
<     description: Code Insights TimescaleDB instance.
---
>     description: Code Insights Postgresql instance.
4895c4884
<         kubectl.kubernetes.io/default-container: timescaledb
---
>         kubectl.kubernetes.io/default-container: codeinsights
4904c4893
<       - name: timescaledb
---
>       - name: codeinsights
4907a4897,4898
>         - name: POSTGRES_DB
>           value: postgres
4909a4901,4902
>         - name: POSTGRES_USER
>           value: postgres
4917c4910
<           name: timescaledb
---
>           name: codeinsights-db
4934c4927
<           name: timescaledb-conf
---
>           name: codeinsights-conf
4936a4930,4944
>       - env:
>         - name: DATA_SOURCE_NAME
>           value: postgres://postgres:@localhost:5432/?sslmode=disable
>         - name: PG_EXPORTER_EXTEND_QUERY_PATH
>           value: /config/code_insights_queries.yaml
>         image: index.docker.io/sourcegraph/postgres_exporter:3.37.0@sha256:20e58b62f064037ac3d901eba565f49d7e1daae2a237e6fa3d5351580d576dea
>         terminationMessagePolicy: FallbackToLogsOnError
>         name: pgsql-exporter
>         resources:
>           limits:
>             cpu: 10m
>             memory: 50Mi
>           requests:
>             cpu: 10m
>             memory: 50Mi
4950c4958
<       - name: timescaledb-conf
---
>       - name: codeinsights-conf
```