### PR TITLE
Fix tracing partial template

### DIFF
--- a/charts/sourcegraph/templates/_tracing.tpl
+++ b/charts/sourcegraph/templates/_tracing.tpl
@@ -29,7 +29,7 @@ Define the tracing sidecar
   args:
     - --reporter.grpc.host-port={{ default "jaeger-collector" .Values.tracing.collector.name }}:14250
     - --reporter.type=grpc
-{{- end }}
   securityContext:
     {{- toYaml .Values.tracingAgent.containerSecurityContext | nindent 4 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
The `{{- end }}` was misplaced in the partial template.

When `tracingAgent` is disabled, it will leave a dangling `securityContext:` in the rendered manifests. Tracing is always enabled by default, so we missed it

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Run `helm template` with `tracingAgent.enabled=false`, the rendered manifest should look good