### PR TITLE
Support extending postgres server conf

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -98,7 +98,7 @@ In addition to the documented values, all services also support the following va
 | cadvisor.resources | object | `{"limits":{"cpu":"300m","memory":"2000Mi"},"requests":{"cpu":"150m","memory":"200Mi"}}` | Resource requests & limits for the `cadvisor` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | cadvisor.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `cadvisor` |
 | cadvisor.serviceAccount.name | string | `"cadvisor"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
-| codeInsightsDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will overwrite our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
+| codeInsightsDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
 | codeInsightsDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":70,"runAsUser":70}` | Security context for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeInsightsDB.enabled | bool | `true` | Enable `codeinsights-db` PostgreSQL server |
 | codeInsightsDB.env | object | `{"POSTGRES_PASSWORD":{"value":"password"}}` | Environment variables for the `codeinsights-db` container |
@@ -110,7 +110,7 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeinsights-db` |
 | codeInsightsDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeInsightsDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeinsights-db` data volume |
-| codeIntelDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will overwrite our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
+| codeIntelDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
 | codeIntelDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `codeintel-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeIntelDB.enabled | bool | `true` | Enable `codeintel-db` PostgreSQL server |
 | codeIntelDB.existingConfig | string | `""` | Name of existing ConfigMap for `codeintel-db`. It must contain a `postgresql.conf` key |
@@ -193,7 +193,7 @@ In addition to the documented values, all services also support the following va
 | minio.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `minio` |
 | minio.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | minio.storageSize | string | `"100Gi"` | PVC Storage Request for `minio` data volume |
-| pgsql.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will overwrite our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
+| pgsql.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
 | pgsql.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | pgsql.enabled | bool | `true` | Enable `pgsql` PostgreSQL server |
 | pgsql.existingConfig | string | `""` | Name of existing ConfigMap for `pgsql`. It must contain a `postgresql.conf` key |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -98,6 +98,7 @@ In addition to the documented values, all services also support the following va
 | cadvisor.resources | object | `{"limits":{"cpu":"300m","memory":"2000Mi"},"requests":{"cpu":"150m","memory":"200Mi"}}` | Resource requests & limits for the `cadvisor` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | cadvisor.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `cadvisor` |
 | cadvisor.serviceAccount.name | string | `"cadvisor"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| codeInsightsDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will overwrite our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
 | codeInsightsDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":70,"runAsUser":70}` | Security context for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeInsightsDB.enabled | bool | `true` | Enable `codeinsights-db` PostgreSQL server |
 | codeInsightsDB.env | object | `{"POSTGRES_PASSWORD":{"value":"password"}}` | Environment variables for the `codeinsights-db` container |
@@ -109,6 +110,7 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeinsights-db` |
 | codeInsightsDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeInsightsDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeinsights-db` data volume |
+| codeIntelDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will overwrite our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
 | codeIntelDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `codeintel-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeIntelDB.enabled | bool | `true` | Enable `codeintel-db` PostgreSQL server |
 | codeIntelDB.existingConfig | string | `""` | Name of existing ConfigMap for `codeintel-db`. It must contain a `postgresql.conf` key |
@@ -191,6 +193,7 @@ In addition to the documented values, all services also support the following va
 | minio.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `minio` |
 | minio.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | minio.storageSize | string | `"100Gi"` | PVC Storage Request for `minio` data volume |
+| pgsql.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will overwrite our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
 | pgsql.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | pgsql.enabled | bool | `true` | Enable `pgsql` PostgreSQL server |
 | pgsql.existingConfig | string | `""` | Name of existing ConfigMap for `pgsql`. It must contain a `postgresql.conf` key |

--- a/charts/sourcegraph/examples/tune-internal-databases/override.yaml
+++ b/charts/sourcegraph/examples/tune-internal-databases/override.yaml
@@ -1,0 +1,18 @@
+# Demonstrate configuring additional PostgreSQL configuration parameters
+# when internal PostgreSQL deployments are used
+# You should consult your account team prior making any change
+# You can learn more about PostgreSQL configuration from
+# - https://docs.sourcegraph.com/admin/config/postgres-conf
+# - https://www.postgresql.org/docs/12/config-setting.html
+
+pgsql:
+  additionalConfig: |
+    max_connections = 200
+  
+codeIntelDB:
+  additionalConfig: |
+    max_connections = 200
+
+codeInsightsDB:
+  additionalConfig: |
+    max_connections = 200

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.ConfigMap.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.codeInsightsDB.enabled (and .Values.codeInsightsDB.existingConfig .Values.codeInsightsDB.additionalConfig) -}}
+{{- fail "You can only define one of 'codeInsightsDB.existingConfig' and 'codeInsightsDB.additionalConfig' at a time" }}
+{{- end }}
 {{- if and .Values.codeInsightsDB.enabled (not .Values.codeInsightsDB.existingConfig) -}}
 apiVersion: v1
 kind: ConfigMap
@@ -771,4 +774,6 @@ data:
     timescaledb.max_background_workers = 8
     timescaledb.last_tuned = '2021-02-16T03:10:41Z'
     timescaledb.last_tuned_version = '0.10.0'
+
+    {{ tpl .Values.codeInsightsDB.additionalConfig . | nindent 4 | trim }}
 {{- end }}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.ConfigMap.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.codeIntelDB.enabled (and .Values.codeIntelDB.existingConfig .Values.codeIntelDB.additionalConfig) -}}
+{{- fail "You can only define one of 'codeIntelDB.existingConfig' and 'codeIntelDB.additionalConfig' at a time" }}
+{{- end }}
 {{- if and .Values.codeIntelDB.enabled (not .Values.codeIntelDB.existingConfig) -}}
 apiVersion: v1
 kind: ConfigMap
@@ -702,4 +705,5 @@ data:
     #------------------------------------------------------------------------------
 
     # Add settings for extensions here
+    {{ tpl .Values.codeIntelDB.additionalConfig . | nindent 4 | trim }}
 {{- end }}

--- a/charts/sourcegraph/templates/pgsql/pgsql.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.ConfigMap.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.pgsql.enabled (and .Values.pgsql.existingConfig .Values.pgsql.additionalConfig) -}}
+{{- fail "You can only define one of 'pgsql.existingConfig' and 'pgsql.additionalConfig' at a time" }}
+{{- end }}
 {{- if and .Values.pgsql.enabled (not .Values.pgsql.existingConfig) -}}
 apiVersion: v1
 kind: ConfigMap
@@ -702,4 +705,5 @@ data:
     #------------------------------------------------------------------------------
 
     # Add settings for extensions here
+    {{ tpl .Values.pgsql.additionalConfig . | nindent 4 | trim }}
 {{- end }}

--- a/charts/sourcegraph/tests/codeInsightsDBAdditionalConfig_test.yaml
+++ b/charts/sourcegraph/tests/codeInsightsDBAdditionalConfig_test.yaml
@@ -1,0 +1,28 @@
+suite: postgresAdditionalConfig
+templates:
+- codeinsights-db/codeinsights-db.ConfigMap.yaml
+tests:
+- it: should have additional config rendered when *.additionalConfig is defined
+  set:
+    pgsql:
+      additionalConfig: |
+        max_connections = 1000000000000000000
+    codeIntelDB:
+      additionalConfig: |
+        max_connections = 2000000000000000000
+    codeInsightsDB:
+      additionalConfig: |
+        max_connections = 3000000000000000000
+  asserts:
+  - matchRegex:
+      path: data.postgresql\.conf
+      pattern: max_connections = 3000000000000000000
+- it: should fail to render when both codeInsightsDB.additionalConfig and codeInsightsDB.existingConfig are defined
+  set:
+    codeInsightsDB:
+      existingConfig: i-will-break-rendering
+      additionalConfig: |
+        max_connections = 3000000000000000000
+  asserts:
+  - failedTemplate:
+      errorMessage: You can only define one of 'codeInsightsDB.existingConfig' and 'codeInsightsDB.additionalConfig' at a time

--- a/charts/sourcegraph/tests/codeIntelDBAdditionalConfig_test.yaml
+++ b/charts/sourcegraph/tests/codeIntelDBAdditionalConfig_test.yaml
@@ -1,0 +1,28 @@
+suite: codeIntelDBAdditionalConfig
+templates:
+- codeintel-db/codeintel-db.ConfigMap.yaml
+tests:
+- it: should have additional config rendered when *.additionalConfig is defined
+  set:
+    pgsql:
+      additionalConfig: |
+        max_connections = 1000000000000000000
+    codeIntelDB:
+      additionalConfig: |
+        max_connections = 2000000000000000000
+    codeInsightsDB:
+      additionalConfig: |
+        max_connections = 3000000000000000000
+  asserts:
+  - matchRegex:
+      path: data.postgresql\.conf
+      pattern: max_connections = 2000000000000000000
+- it: should fail to render when both codeIntelDB.additionalConfig and codeIntelDB.existingConfig are defined
+  set:
+    codeIntelDB:
+      existingConfig: i-will-break-rendering
+      additionalConfig: |
+        max_connections = 2000000000000000000
+  asserts:
+  - failedTemplate:
+      errorMessage: You can only define one of 'codeIntelDB.existingConfig' and 'codeIntelDB.additionalConfig' at a time

--- a/charts/sourcegraph/tests/pgsqlAdditionalConfig_test.yaml
+++ b/charts/sourcegraph/tests/pgsqlAdditionalConfig_test.yaml
@@ -1,9 +1,7 @@
 ---
-suite: postgresAdditionalConfig_01
+suite: pgsqlAdditionalConfig
 templates:
 - pgsql/pgsql.ConfigMap.yaml
-- codeintel-db/codeintel-db.ConfigMap.yaml
-- codeinsights-db/codeinsights-db.ConfigMap.yaml
 tests:
 - it: should have additional config rendered when *.additionalConfig is defined
   set:
@@ -12,20 +10,15 @@ tests:
         max_connections = 1000000000000000000
     codeIntelDB:
       additionalConfig: |
-        max_connections = 1000000000000000000
+        max_connections = 2000000000000000000
     codeInsightsDB:
       additionalConfig: |
-        max_connections = 1000000000000000000
+        max_connections = 3000000000000000000
   asserts:
   - matchRegex:
       path: data.postgresql\.conf
       pattern: max_connections = 1000000000000000000
----
-suite: postgresAdditionalConfig_02
-templates:
-- pgsql/pgsql.ConfigMap.yaml
-tests:
-- it: should fail to render when both *.additionalConfig and *.existingConfig are defined
+- it: should fail to render when both pgsql.additionalConfig and pgsql.existingConfig are defined
   set:
     pgsql:
       existingConfig: i-will-break-rendering

--- a/charts/sourcegraph/tests/postgresAdditionalConfig_test.yaml
+++ b/charts/sourcegraph/tests/postgresAdditionalConfig_test.yaml
@@ -1,0 +1,36 @@
+---
+suite: postgresAdditionalConfig_01
+templates:
+- pgsql/pgsql.ConfigMap.yaml
+- codeintel-db/codeintel-db.ConfigMap.yaml
+- codeinsights-db/codeinsights-db.ConfigMap.yaml
+tests:
+- it: should have additional config rendered when *.additionalConfig is defined
+  set:
+    pgsql:
+      additionalConfig: |
+        max_connections = 1000000000000000000
+    codeIntelDB:
+      additionalConfig: |
+        max_connections = 1000000000000000000
+    codeInsightsDB:
+      additionalConfig: |
+        max_connections = 1000000000000000000
+  asserts:
+  - matchRegex:
+      path: data.postgresql\.conf
+      pattern: max_connections = 1000000000000000000
+---
+suite: postgresAdditionalConfig_02
+templates:
+- pgsql/pgsql.ConfigMap.yaml
+tests:
+- it: should fail to render when both *.additionalConfig and *.existingConfig are defined
+  set:
+    pgsql:
+      existingConfig: i-will-break-rendering
+      additionalConfig: |
+        max_connections = 1000000000000000000
+  asserts:
+  - failedTemplate:
+      errorMessage: You can only define one of 'pgsql.existingConfig' and 'pgsql.additionalConfig' at a time

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -144,6 +144,10 @@ codeInsightsDB:
       value: password
   # -- Name of existing ConfigMap for `codeinsights-db`. It must contain a `postgresql.conf` key.
   existingConfig: "" # Name of an existing configmap
+  # -- Additional PostgreSQL configuration. This will overwrite our default configuration.
+  # Notes: This is expecting a multiline string.
+  # Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html)
+  additionalConfig: ""
   image:
     # -- Docker image tag for the `codeinsights-db` image
     defaultTag: 3.37.0@sha256:fa608333a6ca1aef148abd33e4ee14886d4f172e0db1e5c9ee6bac36adec0bf1
@@ -184,6 +188,10 @@ codeIntelDB:
   enabled: true
   # -- Name of existing ConfigMap for `codeintel-db`. It must contain a `postgresql.conf` key
   existingConfig: ""
+  # -- Additional PostgreSQL configuration. This will overwrite our default configuration.
+  # Notes: This is expecting a multiline string.
+  # Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html)
+  additionalConfig: ""
   image:
     # -- Docker image tag for the `codeintel-db` image
     defaultTag: 3.37.0@sha256:fc2ab91482f85f77eb73c69a35a2a4cc5055a1b93ef1c1d0f183a7003e632082
@@ -558,6 +566,10 @@ pgsql:
   enabled: true
   # -- Name of existing ConfigMap for `pgsql`. It must contain a `postgresql.conf` key
   existingConfig: "" # Name of an existing configmap
+  # -- Additional PostgreSQL configuration. This will overwrite our default configuration.
+  # Notes: This is expecting a multiline string.
+  # Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html)
+  additionalConfig: ""
   image:
     # -- Docker image tag for the `pgsql` image
     defaultTag: insiders@sha256:3c2de1fbb90a48a64b094eaf402578d17f2d3ba3dd71e572bfd75b36e301f3ac

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -144,7 +144,7 @@ codeInsightsDB:
       value: password
   # -- Name of existing ConfigMap for `codeinsights-db`. It must contain a `postgresql.conf` key.
   existingConfig: "" # Name of an existing configmap
-  # -- Additional PostgreSQL configuration. This will overwrite our default configuration.
+  # -- Additional PostgreSQL configuration. This will override or extend our default configuration.
   # Notes: This is expecting a multiline string.
   # Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html)
   additionalConfig: ""
@@ -188,7 +188,7 @@ codeIntelDB:
   enabled: true
   # -- Name of existing ConfigMap for `codeintel-db`. It must contain a `postgresql.conf` key
   existingConfig: ""
-  # -- Additional PostgreSQL configuration. This will overwrite our default configuration.
+  # -- Additional PostgreSQL configuration. This will override or extend our default configuration.
   # Notes: This is expecting a multiline string.
   # Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html)
   additionalConfig: ""
@@ -566,7 +566,7 @@ pgsql:
   enabled: true
   # -- Name of existing ConfigMap for `pgsql`. It must contain a `postgresql.conf` key
   existingConfig: "" # Name of an existing configmap
-  # -- Additional PostgreSQL configuration. This will overwrite our default configuration.
+  # -- Additional PostgreSQL configuration. This will override or extend our default configuration.
   # Notes: This is expecting a multiline string.
   # Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html)
   additionalConfig: ""


### PR DESCRIPTION
We can now extend existing postgres configmap instead of requiring maintaining a fork of it

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

See added unit tests for template testing and sanity check

To check it actually works

```yaml
storageClass:
  create: false
  name: standard
  reclaimPolicy: Delete

sourcegraph: 
  localDevMode: true

pgsql:
  additionalConfig: |
    max_connections = 500
```

Deploy the chart

```sh
kind create cluster
helm upgrade --install -n sourcegraph -f ./override.yaml sourcegraph charts/sourcegraph/.
```

```sh
kubectl exec pgsql-0 -- psql postgres://sg@localhost -c 'show max_connections;'
```

you should see

```
 max_connections
-----------------
 500
(1 row)
```

The default is

https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/646b48eb80456c53a97b83121322c130680847cf/charts/sourcegraph/templates/pgsql/pgsql.ConfigMap.yaml#L76-L78

hence we can tell stuff at the bottom has higher precendence.

close https://github.com/sourcegraph/sourcegraph/issues/32700