### PR TITLE
Switch minio to use a secret for credentials, replace deprecated env vars

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -184,9 +184,12 @@ In addition to the documented values, all services also support the following va
 | migrator.image.defaultTag | string | `"3.38.0@sha256:16b3cebb1447fce75a8cb3acd6b6640294c70ab96adbfbcbc8da565ffffc5a4e"` | Docker image tag for the `migrator` image |
 | migrator.image.name | string | `"migrator"` | Docker image name for the `migrator` image |
 | migrator.resources | object | `{"limits":{"cpu":"500m","memory":"100M"},"requests":{"cpu":"100m","memory":"50M"}}` | Resource requests & limits for the `migrator` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| minio.auth | object | Generate a secret with default credentials | Configure credentials for the `minio` container, learn more from the [Minio documentation](https://docs.min.io/minio/baremetal/reference/minio-server/minio-server.html#root-credentials) |
+| minio.auth.existingSecret | string | `""` | Name of existing secret to use for Minio credentials The secret must contain the keys `user` (root user access key) and `password` (root user secret key) `auth.user` and `auth.password` are ignored if this is enabled |
+| minio.auth.password | string | `"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"` | Sets root user secret key |
+| minio.auth.user | string | `"AKIAIOSFODNN7EXAMPLE"` | Sets root user access key |
 | minio.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsGroup":101,"runAsUser":100}` | Security context for the `minio` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | minio.enabled | bool | `true` | Enable `minio` (S3 compatible storage) |
-| minio.env | object | `{"MINIO_ACCESS_KEY":{"value":"AKIAIOSFODNN7EXAMPLE"},"MINIO_SECRET_KEY":{"value":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"}}` | Environment variables for the `minio` container You should change below variables in production |
 | minio.image.defaultTag | string | `"3.38.0@sha256:0daf4c0c821634eeefbf90f48d467eece09597aff5d9f582685c8c875f03e6fa"` | Docker image tag for the `minio` image |
 | minio.image.name | string | `"minio"` | Docker image tag for the `minio` image |
 | minio.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":101,"runAsUser":100}` | Security context for the `minio` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: frontend
-        checksum/config: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
+        checksum/minio.secret: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,6 +28,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: frontend
+        checksum/config: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}
@@ -84,6 +85,18 @@ spec:
         # archives of repositories at a commit.
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
+        {{- if .Values.minio.enabled }}
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: user
+              name: {{ default "minio-auth" .Values.minio.auth.existingSecret }}
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: {{ default "minio-auth" .Values.minio.auth.existingSecret }}
+        {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/charts/sourcegraph/templates/minio/minio.Deployment.yaml
+++ b/charts/sourcegraph/templates/minio/minio.Deployment.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: minio
+        checksum/config: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}
@@ -46,6 +47,16 @@ spec:
       containers:
       - name: minio
         env:
+        - name: MINIO_ROOT_USER
+          valueFrom:
+            secretKeyRef:
+              key: user
+              name: {{ default "minio-auth" .Values.minio.auth.existingSecret }}
+        - name: MINIO_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: {{ default "minio-auth" .Values.minio.auth.existingSecret }}
         {{- range $name, $item := .Values.minio.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}

--- a/charts/sourcegraph/templates/minio/minio.Deployment.yaml
+++ b/charts/sourcegraph/templates/minio/minio.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: minio
-        checksum/config: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
+        checksum/minio.secret: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}

--- a/charts/sourcegraph/templates/minio/minio.Secret.yaml
+++ b/charts/sourcegraph/templates/minio/minio.Secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.minio.enabled (not .Values.minio.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-auth
+  labels:
+    app: minio
+    deploy: sourcegraph
+    app.kubernetes.io/component: minio
+type: Opaque
+data:
+  user: {{ .Values.minio.auth.user | toString | b64enc | quote }}
+  password: {{ .Values.minio.auth.password | toString | b64enc | quote }}
+{{- end -}}

--- a/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: precise-code-intel-worker
-        checksum/config: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
+        checksum/minio.secret: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}

--- a/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -28,6 +28,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: precise-code-intel-worker
+        checksum/config: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}
@@ -56,6 +57,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        {{- if .Values.minio.enabled }}
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: user
+              name: {{ default "minio-auth" .Values.minio.auth.existingSecret }}
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: {{ default "minio-auth" .Values.minio.auth.existingSecret }}
+        {{- end }}
         image: {{ include "sourcegraph.image" (list . "preciseCodeIntel") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         {{- with .Values.preciseCodeIntel.args }}

--- a/charts/sourcegraph/tests/affinity_test.yaml
+++ b/charts/sourcegraph/tests/affinity_test.yaml
@@ -1,11 +1,13 @@
 suite: affinity
 templates:
+- minio/minio.Secret.yaml
 - frontend/sourcegraph-frontend.Deployment.yaml
 release:
   name: sourcegraph
   namespace: sourcegraph
 tests:
 - it: should render affinity values that contain template
+  template: frontend/sourcegraph-frontend.Deployment.yaml
   set:
     frontend:
       affinity:
@@ -35,6 +37,7 @@ tests:
             weight: 100
 
 - it: should render affinity values that do not contain template
+  template: frontend/sourcegraph-frontend.Deployment.yaml
   set:
     frontend:
       affinity:

--- a/charts/sourcegraph/tests/localDevMode_test.yaml
+++ b/charts/sourcegraph/tests/localDevMode_test.yaml
@@ -1,8 +1,10 @@
 suite: localDevMode
 templates:
+  - minio/minio.Secret.yaml
   - frontend/sourcegraph-frontend.Deployment.yaml
 tests:
   - it: should not have a resource block when localDevMode=true
+    template: frontend/sourcegraph-frontend.Deployment.yaml
     set:
       sourcegraph.localDevMode: true
     asserts:
@@ -10,6 +12,7 @@ tests:
           path: spec.template.spec.containers[0].resources
 
   - it: should have a resource block when localDevMode=false
+    template: frontend/sourcegraph-frontend.Deployment.yaml
     set:
       sourcegraph.localDevMode: false
     asserts:

--- a/charts/sourcegraph/tests/minioAuth_test.yaml
+++ b/charts/sourcegraph/tests/minioAuth_test.yaml
@@ -1,0 +1,73 @@
+---
+suite: minioAuth
+templates:
+- minio/minio.Secret.yaml
+- minio/minio.Deployment.yaml
+tests:
+- it: should reference existing secret name when existingSecret is passed
+  template: minio/minio.Deployment.yaml
+  set:
+    minio:
+      auth:
+        existingSecret: "my-secret"
+  asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: MINIO_ROOT_USER
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: "my-secret"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: MINIO_ROOT_PASSWORD
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: "my-secret"
+- it: should not generate a secret when existingSecret is passed
+  template: minio/minio.Secret.yaml
+  set:
+    minio:
+      auth:
+        existingSecret: "my-secret"
+  asserts:
+      - hasDocuments:
+          count: 0
+- it: should generate a secret when existingSecret is blank
+  template: minio/minio.Secret.yaml
+  set:
+    minio:
+      auth:
+        existingSecret: ""
+  asserts:
+      - hasDocuments:
+          count: 1
+- it: should generate a secret by default
+  template: minio/minio.Secret.yaml
+  asserts:
+      - hasDocuments:
+          count: 1
+- it: should use provided value in secret
+  template: minio/minio.Secret.yaml
+  set:
+    minio:
+      auth:
+        password: "hello"
+  asserts:
+      - equal:
+          path: data.password
+          value: "aGVsbG8="
+- it: should reference default secret name when existingSecret is blank
+  template: minio/minio.Deployment.yaml
+  asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: MINIO_ROOT_USER
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: "minio-auth"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: MINIO_ROOT_PASSWORD
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: "minio-auth"

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -523,13 +523,18 @@ indexedSearchIndexer:
 minio:
   # -- Enable `minio` (S3 compatible storage)
   enabled: true
-  # -- Environment variables for the `minio` container
-  # You should change below variables in production
-  env:
-    MINIO_ACCESS_KEY:
-      value: AKIAIOSFODNN7EXAMPLE
-    MINIO_SECRET_KEY:
-      value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  # -- Configure credentials for the `minio` container,
+  # learn more from the [Minio documentation](https://docs.min.io/minio/baremetal/reference/minio-server/minio-server.html#root-credentials)
+  # @default -- Generate a secret with default credentials
+  auth:
+    # -- Name of existing secret to use for Minio credentials
+    # The secret must contain the keys `user` (root user access key) and `password` (root user secret key)
+    # `auth.user` and `auth.password` are ignored if this is enabled
+    existingSecret: ""
+    # -- Sets root user access key
+    user: "AKIAIOSFODNN7EXAMPLE"
+    # -- Sets root user secret key
+    password: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   image:
     # -- Docker image tag for the `minio` image
     defaultTag: 3.38.0@sha256:0daf4c0c821634eeefbf90f48d467eece09597aff5d9f582685c8c875f03e6fa


### PR DESCRIPTION
Prototype to demonstrate providing an interface for minio credentials that allows us to generate or reuse an existing Secret resource instead of use direct env vars. I haven't fully tested this approach since it's still in the proof-of-concept phase.

**Decisions / consequences:**
- This implementation is opinionated about the structure of the minio-auth Secret, which simplifies the logic and allows us to easily reference the credentials in other deployments. Customers who want to use a different structure can use kustomize to alter the configuration.
- We're not randomly generating values for the credentials to preserve compatibility with the helm template command (we're stuck with either generating a new value every time helm runs, or requiring access to the existing secret).
- I went ahead and swapped the credentials to use the newer minio variables. As far as I can tell it's a naming switch only and should be backwards compatible.
- I added a checksum to force dependent pods to restart when the secret changes. This worked with a subchart but I don't know if there are other consequences to this that make it unsuitable.

Partially addresses https://github.com/sourcegraph/sourcegraph/issues/32694

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
- Existing secret, custom credentials
- Generated secret, custom credentials
- Upgrade from previous chart