### PR TITLE
Use secrets for pgsql credentials

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -209,9 +209,10 @@ In addition to the documented values, all services also support the following va
 | minio.storageSize | string | `"100Gi"` | PVC Storage Request for `minio` data volume |
 | pgsql.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
 | pgsql.auth.database | string | `"sg"` | Sets postgres database name |
-| pgsql.auth.existingSecret | string | `""` | Name of existing secret to use for Postgres credentials The secret must contain the keys `user`, `password`, `database` and `host`. `auth.user`, `auth.password`, etc. are ignored if this is enabled |
+| pgsql.auth.existingSecret | string | `""` | Name of existing secret to use for Postgres credentials The secret must contain the keys `user`, `password`, `database`, `host` and `port`. `auth.user`, `auth.password`, etc. are ignored if this is enabled |
 | pgsql.auth.host | string | `"pgsql"` | Sets postgres host |
 | pgsql.auth.password | string | `"password"` | Sets postgres password |
+| pgsql.auth.port | string | `"5432"` | Sets postgres port |
 | pgsql.auth.user | string | `"sg"` | Sets postgres username |
 | pgsql.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | pgsql.enabled | bool | `true` | Enable `pgsql` PostgreSQL server |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -208,6 +208,11 @@ In addition to the documented values, all services also support the following va
 | minio.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | minio.storageSize | string | `"100Gi"` | PVC Storage Request for `minio` data volume |
 | pgsql.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
+| pgsql.auth.database | string | `"sg"` | Sets postgres database name |
+| pgsql.auth.existingSecret | string | `""` | Name of existing secret to use for Postgres credentials The secret must contain the keys `user`, `password`, `database` and `host`. `auth.user`, `auth.password`, etc. are ignored if this is enabled |
+| pgsql.auth.host | string | `"pgsql"` | Sets postgres host |
+| pgsql.auth.password | string | `"password"` | Sets postgres password |
+| pgsql.auth.user | string | `"sg"` | Sets postgres username |
 | pgsql.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | pgsql.enabled | bool | `true` | Enable `pgsql` PostgreSQL server |
 | pgsql.existingConfig | string | `""` | Name of existing ConfigMap for `pgsql`. It must contain a `postgresql.conf` key |
@@ -215,7 +220,7 @@ In addition to the documented values, all services also support the following va
 | pgsql.image.name | string | `"postgres-12-alpine"` | Docker image name for the `pgsql` image |
 | pgsql.name | string | `"pgsql"` | Name used by resources. Does not affect service names or PVCs. |
 | pgsql.podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsUser":999}` | Security context for the `pgsql` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| pgsql.postgresExporter.env | object | `{"DATA_SOURCE_NAME":{"value":"postgres://sg:@localhost:5432/?sslmode=disable"}}` | Environment variables for the `pgsql-exporter` sidecar container |
+| pgsql.postgresExporter | object | `{}` | Configuration for the `pgsql-exporter` sidecar container |
 | pgsql.resources | object | `{"limits":{"cpu":"4","memory":"4Gi"},"requests":{"cpu":"4","memory":"4Gi"}}` | Resource requests & limits for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | pgsql.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `pgsql` |
 | pgsql.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -133,7 +133,7 @@ app.kubernetes.io/name: jaeger
 {{- $top := index . 0 -}}
 {{- $service := index . 1 -}}
 {{- $prefix := index . 2 -}}
-{{- $secretName := ((snakecase $service) | replace "_" "-") -}}
+{{- $secretName := (index $top.Values $service "name") -}}
 {{- $secretName := printf "%s-auth" $secretName -}}
 {{- if (index $top.Values $service "auth" "existingSecret") }}{{- $secretName = (index $top.Values $service "auth" "existingSecret") }}{{- end -}}
 - name: {{ printf "%sDATABASE" $prefix }}
@@ -166,7 +166,7 @@ app.kubernetes.io/name: jaeger
 {{- define "sourcegraph.dataSource" -}}
 {{- $top := index . 0 -}}
 {{- $service := index . 1 -}}
-{{- $secretName := ((snakecase $service) | replace "_" "-") -}}
+{{- $secretName := (index $top.Values $service "name") -}}
 {{- $secretName := printf "%s-auth" $secretName -}}
 {{- if (index $top.Values $service "auth" "existingSecret") }}{{- $secretName = (index $top.Values $service "auth" "existingSecret") }}{{- end -}}
 - name: DATA_SOURCE_DB

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -128,3 +128,57 @@ Jaeger selector labels
 {{- define "sourcegraph.jaeger.selectorLabels" -}}
 app.kubernetes.io/name: jaeger
 {{- end }}
+
+{{- define "sourcegraph.databaseAuth" -}}
+{{- $top := index . 0 -}}
+{{- $service := index . 1 -}}
+{{- $prefix := index . 2 -}}
+{{- $secretName := ((snakecase $service) | replace "_" "-") -}}
+{{- $secretName := printf "%s-auth" $secretName -}}
+{{- if (index $top.Values $service "auth" "existingSecret") }}{{- $secretName = (index $top.Values $service "auth" "existingSecret") }}{{- end -}}
+- name: {{ printf "%sDATABASE" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: database
+      name: {{ $secretName }}
+- name: {{ printf "%sHOST" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: host
+      name: {{ $secretName }}
+- name: {{ printf "%sPASSWORD" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: password
+      name: {{ $secretName }}
+- name: {{ printf "%sUSER" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: user
+      name: {{ $secretName }}
+{{- end }}
+
+{{- define "sourcegraph.dataSource" -}}
+{{- $top := index . 0 -}}
+{{- $service := index . 1 -}}
+{{- $secretName := ((snakecase $service) | replace "_" "-") -}}
+{{- $secretName := printf "%s-auth" $secretName -}}
+{{- if (index $top.Values $service "auth" "existingSecret") }}{{- $secretName = (index $top.Values $service "auth" "existingSecret") }}{{- end -}}
+- name: DATA_SOURCE_DB
+  valueFrom:
+    secretKeyRef:
+      key: database
+      name: {{ $secretName }}
+- name: DATA_SOURCE_PASS
+  valueFrom:
+    secretKeyRef:
+      key: password
+      name: {{ $secretName }}
+- name: DATA_SOURCE_USER
+  valueFrom:
+    secretKeyRef:
+      key: user
+      name: {{ $secretName }}
+- name: DATA_SOURCE_URI
+  value: "localhost:5432/$(DATA_SOURCE_DB)?sslmode=disable"
+{{- end }}

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -151,6 +151,11 @@ app.kubernetes.io/name: jaeger
     secretKeyRef:
       key: password
       name: {{ $secretName }}
+- name: {{ printf "%sPORT" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: port
+      name: {{ $secretName }}
 - name: {{ printf "%sUSER" $prefix }}
   valueFrom:
     secretKeyRef:
@@ -174,11 +179,16 @@ app.kubernetes.io/name: jaeger
     secretKeyRef:
       key: password
       name: {{ $secretName }}
+- name: DATA_SOURCE_PORT
+  valueFrom:
+    secretKeyRef:
+      key: port
+      name: {{ $secretName }}
 - name: DATA_SOURCE_USER
   valueFrom:
     secretKeyRef:
       key: user
       name: {{ $secretName }}
 - name: DATA_SOURCE_URI
-  value: "localhost:5432/$(DATA_SOURCE_DB)?sslmode=disable"
+  value: "localhost:$(DATA_SOURCE_PORT)/$(DATA_SOURCE_DB)?sslmode=disable"
 {{- end }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: frontend
         checksum/minio.secret: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
-        checksum/pgsqlconfig: {{ include (print $.Template.BasePath "/pgsql/pgsql.Secret.yaml") . | sha256sum }}
+        checksum/pgsql.secret: {{ include (print $.Template.BasePath "/pgsql/pgsql.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -29,6 +29,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: frontend
         checksum/minio.secret: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
+        checksum/pgsqlconfig: {{ include (print $.Template.BasePath "/pgsql/pgsql.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}
@@ -53,6 +54,7 @@ spec:
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         args: {{- default (list "up") .Values.migrator.args | toYaml | nindent 8 }}
         env:
+        {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
         {{- range $name, $item := .Values.frontend.env }}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}
@@ -76,6 +78,7 @@ spec:
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}
         {{- end }}
+        {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
         # POD_NAME is used by CACHE_DIR
         - name: POD_NAME
           valueFrom:

--- a/charts/sourcegraph/templates/pgsql/pgsql.Secret.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.pgsql.auth.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pgsql-auth
+  labels:
+    app: pgsql
+    deploy: sourcegraph
+    app.kubernetes.io/component: pgsql
+type: Opaque
+data:
+  database: {{ .Values.pgsql.auth.database | toString | b64enc | quote }}
+  host: {{ .Values.pgsql.auth.host | toString | b64enc | quote }}
+  password: {{ .Values.pgsql.auth.password | toString | b64enc | quote }}
+  user: {{ .Values.pgsql.auth.user | toString | b64enc | quote }}
+{{- end -}}

--- a/charts/sourcegraph/templates/pgsql/pgsql.Secret.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Secret.yaml
@@ -13,4 +13,5 @@ data:
   host: {{ .Values.pgsql.auth.host | toString | b64enc | quote }}
   password: {{ .Values.pgsql.auth.password | toString | b64enc | quote }}
   user: {{ .Values.pgsql.auth.user | toString | b64enc | quote }}
+  port: {{ .Values.pgsql.auth.port | toString | b64enc | quote }}
 {{- end -}}

--- a/charts/sourcegraph/templates/pgsql/pgsql.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.StatefulSet.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: pgsql
-        checksum/pgsqlconfig: {{ include (print $.Template.BasePath "/pgsql/pgsql.Secret.yaml") . | sha256sum }}
+        checksum/pgsql.secret: {{ include (print $.Template.BasePath "/pgsql/pgsql.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}

--- a/charts/sourcegraph/templates/pgsql/pgsql.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.StatefulSet.yaml
@@ -24,6 +24,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: pgsql
+        checksum/pgsqlconfig: {{ include (print $.Template.BasePath "/pgsql/pgsql.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}
@@ -75,6 +76,9 @@ spec:
               - /liveness.sh
         name: pgsql
         env:
+        {{- include "sourcegraph.databaseAuth" (list . "pgsql" "POSTGRES_") | nindent 8 }}
+        - name: POSTGRES_DB
+          value: $(POSTGRES_DATABASE)
         {{- range $name, $item := .Values.pgsql.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}
@@ -104,6 +108,7 @@ spec:
         {{- toYaml .Values.pgsql.extraContainers | nindent 6 }}
       {{- end }}
       - env:
+        {{- include "sourcegraph.dataSource" (list . "pgsql" ) | nindent 8 }}
         {{- range $name, $item := .Values.pgsql.postgresExporter.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}

--- a/charts/sourcegraph/tests/affinity_test.yaml
+++ b/charts/sourcegraph/tests/affinity_test.yaml
@@ -1,6 +1,7 @@
 suite: affinity
 templates:
 - minio/minio.Secret.yaml
+- pgsql/pgsql.Secret.yaml
 - frontend/sourcegraph-frontend.Deployment.yaml
 release:
   name: sourcegraph

--- a/charts/sourcegraph/tests/localDevMode_test.yaml
+++ b/charts/sourcegraph/tests/localDevMode_test.yaml
@@ -1,6 +1,7 @@
 suite: localDevMode
 templates:
   - minio/minio.Secret.yaml
+  - pgsql/pgsql.Secret.yaml
   - frontend/sourcegraph-frontend.Deployment.yaml
 tests:
   - it: should not have a resource block when localDevMode=true

--- a/charts/sourcegraph/tests/pgsqlAuth_test.yaml
+++ b/charts/sourcegraph/tests/pgsqlAuth_test.yaml
@@ -1,0 +1,61 @@
+---
+suite: pgsqlAuth
+templates:
+- pgsql/pgsql.Secret.yaml
+- pgsql/pgsql.StatefulSet.yaml
+tests:
+- it: should reference existing secret name when existingSecret is passed
+  template: pgsql/pgsql.StatefulSet.yaml
+  set:
+    pgsql:
+      auth:
+        existingSecret: "my-secret"
+  asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: POSTGRES_DATABASE
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: "my-secret"
+- it: should not generate a secret when existingSecret is passed
+  template: pgsql/pgsql.Secret.yaml
+  set:
+    pgsql:
+      auth:
+        existingSecret: "my-secret"
+  asserts:
+      - hasDocuments:
+          count: 0
+- it: should generate a secret when existingSecret is blank
+  template: pgsql/pgsql.Secret.yaml
+  set:
+    pgsql:
+      auth:
+        existingSecret: ""
+  asserts:
+      - hasDocuments:
+          count: 1
+- it: should generate a secret by default
+  template: pgsql/pgsql.Secret.yaml
+  asserts:
+      - hasDocuments:
+          count: 1
+- it: should use provided value in secret
+  template: pgsql/pgsql.Secret.yaml
+  set:
+    pgsql:
+      auth:
+        password: "hello"
+  asserts:
+      - equal:
+          path: data.password
+          value: "aGVsbG8="
+- it: should reference default secret name when existingSecret is blank
+  template: pgsql/pgsql.StatefulSet.yaml
+  asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: POSTGRES_DATABASE
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: "pgsql-auth"

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -589,7 +589,7 @@ pgsql:
   enabled: true
   auth:
     # -- Name of existing secret to use for Postgres credentials
-    # The secret must contain the keys `user`, `password`, `database` and `host`.
+    # The secret must contain the keys `user`, `password`, `database`, `host` and `port`.
     # `auth.user`, `auth.password`, etc. are ignored if this is enabled
     existingSecret: ""
     # -- Sets postgres database name
@@ -600,6 +600,8 @@ pgsql:
     user: "sg"
     # -- Sets postgres password
     password: "password"
+    # -- Sets postgres port
+    port: "5432"
   # -- Name of existing ConfigMap for `pgsql`. It must contain a `postgresql.conf` key
   existingConfig: "" # Name of an existing configmap
   # -- Additional PostgreSQL configuration. This will override or extend our default configuration.

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -262,12 +262,6 @@ frontend:
       value: http://grafana:30070
     JAEGER_SERVER_URL:
       value: http://jaeger-query:16686
-    PGDATABASE:
-      value: sg
-    PGHOST:
-      value: pgsql
-    PGUSER:
-      value: sg
     PROMETHEUS_URL:
       value: http://prometheus:30090
   image:
@@ -593,6 +587,19 @@ minio:
 pgsql:
   # -- Enable `pgsql` PostgreSQL server
   enabled: true
+  auth:
+    # -- Name of existing secret to use for Postgres credentials
+    # The secret must contain the keys `user`, `password`, `database` and `host`.
+    # `auth.user`, `auth.password`, etc. are ignored if this is enabled
+    existingSecret: ""
+    # -- Sets postgres database name
+    database: "sg"
+    # -- Sets postgres host
+    host: "pgsql"
+    # -- Sets postgres username
+    user: "sg"
+    # -- Sets postgres password
+    password: "password"
   # -- Name of existing ConfigMap for `pgsql`. It must contain a `postgresql.conf` key
   existingConfig: "" # Name of an existing configmap
   # -- Additional PostgreSQL configuration. This will override or extend our default configuration.
@@ -611,11 +618,8 @@ pgsql:
     runAsUser: 999
     runAsGroup: 999
     readOnlyRootFilesystem: true
-  postgresExporter:
-    # -- Environment variables for the `pgsql-exporter` sidecar container
-    env:
-      DATA_SOURCE_NAME:
-        value: postgres://sg:@localhost:5432/?sslmode=disable
+  # -- Configuration for the `pgsql-exporter` sidecar container
+  postgresExporter: {}
   # -- Name used by resources. Does not affect service names or PVCs.
   name: "pgsql"
   # -- Resource requests & limits for the `pgsql` container,


### PR DESCRIPTION
Similar to https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/85, but for database credentials.

Prototype to demonstrate providing an interface for database credentials that allows us to generate or reuse an existing Secret resource instead of use direct env vars. This isn't a full implementation (missing codeintel / codeinsights) since it's still a proof of concept. The migrator chart would also need to be updated.

Decisions / consequences:
* Just like the minio implementation, this is opinionated about the structure for the Secret. Is this riskier with auth for an external database?
* This approach vastly simplifies the management of database credentials - they're specified in one location now, instead of 4 different places.
* The variable names are all over the place (example: PGDATABASE, POSTGRES_DB, DATA_SOURCE_URI). I couldn't think of a clean solution for handling this so it's pretty messy. Really hoping someone else has a good idea!
* I'm on the fence about whether `host` and `database` belong in the secret. Should those be normal variables instead?

Partially addresses https://github.com/sourcegraph/sourcegraph/issues/32694

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Manual test plan + confirming new functionality