### PR TITLE
Fix ingress settings on GCP example

### DIFF
--- a/charts/sourcegraph/examples/gcp/override.yaml
+++ b/charts/sourcegraph/examples/gcp/override.yaml
@@ -3,8 +3,7 @@ frontend:
   ingress:
     enabled: true
     annotations:
-      kubernetes.io/ingress.class: null
-    ingressClassName: gce
+      kubernetes.io/ingress.class: gce
     host: sourcegraph.company.com # Replace with your actual domain
   serviceAnnotations:
     cloud.google.com/neg: '{"ingress": true}'


### PR DESCRIPTION
The example given for GCP did not actually create a load balancer. According to [the docs](https://cloud.google.com/kubernetes-engine/docs/how-to/custom-ingress-controller#controller_summary), GKE relies on the `kubernetes.io/ingress.class` annotation. If that annotation is not set but ingressClassName is, no load balancer is provisioned.

Supposedly you're able to specify both `kubernetes.io/ingress.class` and `ingressClassName`, but in practice I got an error when trying to provide both, so I removed it.

I'll update the example in the main docs as well, but there's an open PR + a couple other changes we might want to make before then.

### Checklist

- [X] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Install the chart, confirm a load balancer gets created.