### PR TITLE
Prototype for including extra manifests in the helm values file

### DIFF
--- a/charts/sourcegraph/examples/gcp/override.yaml
+++ b/charts/sourcegraph/examples/gcp/override.yaml
@@ -17,3 +17,26 @@ storageClass:
   provisioner: pd.csi.storage.gke.io
   volumeBindingMode: WaitForFirstConsumer
   reclaimPolicy: Retain
+
+extraManifests: |
+  apiVersion: cloud.google.com/v1
+  kind: BackendConfig
+  metadata:
+    name: sourcegraph-frontend
+  spec:
+    healthCheck:
+      checkIntervalSec: 5
+      timeoutSec: 5
+      requestPath: /ready
+      port: 6060 # we use a custom port to perform healthcheck
+  ---
+  apiVersion: cloud.google.com/v1 # Second manifest just for demonstration purposes
+  kind: BackendConfig
+  metadata:
+    name: sourcegraph-frontend-example
+  spec:
+    healthCheck:
+      checkIntervalSec: 5
+      timeoutSec: 5
+      requestPath: /ready
+      port: 6060 # we use a custom port to perform healthcheck

--- a/charts/sourcegraph/templates/extraManifests.yaml
+++ b/charts/sourcegraph/templates/extraManifests.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.extraManifests }}
+  {{ tpl .Values.extraManifests . }}
+{{- end -}}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1078,3 +1078,6 @@ worker:
     create: false
     # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: ""
+
+# -- Additional manifests to include in the rendered output
+extraManifests: {}


### PR DESCRIPTION
Simple proof-of-concept for allowing additional manifests to be included in the values file. I can't decide if this is a good idea!

Pros:
- Simple manifests can be embedded in the values file, avoiding the need to use kustomize or subcharts
- We can remove the manual step to deploy a BackendConfig from the gce demo
- Can reference other values since we're templating

Cons:
- Dangerous, very easy to mess up

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
