### PR TITLE
Only render tls section on frontend ingress if both variables provided

### DIFF
--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- end }}
   name: sourcegraph-frontend
 spec:
-  {{- if .Values.frontend.ingress.host }}
+  {{- if and .Values.frontend.ingress.host .Values.frontend.ingress.tlsSecret }}
   tls:
   - hosts:
     - {{ .Values.frontend.ingress.host }}


### PR DESCRIPTION
Testing https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/89 I realized that the ingress logic was slightly incomplete. Now we only render the tls section when both variables are provided.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Rendering looks ok, we can now provide host value only if it's really important.