### PR TITLE
Add warning when prometheus is running in non-privileged mode

### DIFF
--- a/charts/sourcegraph/templates/NOTES.txt
+++ b/charts/sourcegraph/templates/NOTES.txt
@@ -11,8 +11,11 @@ To learn more about supported configuration, check out https://docs.sourcegraph.
 {{- if not .Values.prometheus.privileged }}
 🚧 Warning 🚧
 
-You have set 'prometheus.privileged' to 'false'. As a result, our built-in observability stack will not function properly. 
-Please assign proper permission to Service Account '{{ include "sourcegraph.serviceAccountName" (list . "prometheus") }}'.
+You have set 'prometheus.privileged' to 'false' and Prometheus will run with reduced privileges.
+Our observability stack requires some cluster-wide privileges to display provisioning metrics.
+As a result, our built-in observability stack will not function properly. 
+These metrics will provide critial information to help you scale the Sourcegraph deployment.
+Therefore, please assign proper permission to Service Account '{{ include "sourcegraph.serviceAccountName" (list . "prometheus") }}'.
 You can do so by creating the proper ClusterRole and ClusterRoleBinding. 
 You may consult https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
 for a list of expected permissions.

--- a/charts/sourcegraph/templates/NOTES.txt
+++ b/charts/sourcegraph/templates/NOTES.txt
@@ -1,0 +1,20 @@
+{{- "\n" }}
+
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about supported configuration, check out https://docs.sourcegraph.com/admin/install/kubernetes/helm.
+
+{{- "\n" }}
+
+{{- if not .Values.prometheus.privileged }}
+🚧 Warning 🚧
+
+You have set 'prometheus.privileged' to 'false'. As a result, our built-in observability stack will not function properly. 
+Please assign proper permission to Service Account '{{ include "sourcegraph.serviceAccountName" (list . "prometheus") }}'.
+You can do so by creating the proper ClusterRole and ClusterRoleBinding. 
+You may consult https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
+for a list of expected permissions.
+
+{{- end }}

--- a/charts/sourcegraph/templates/NOTES.txt
+++ b/charts/sourcegraph/templates/NOTES.txt
@@ -13,11 +13,8 @@ To learn more about supported configuration, check out https://docs.sourcegraph.
 
 You have set 'prometheus.privileged' to 'false' and Prometheus will run with reduced privileges.
 Our observability stack requires some cluster-wide privileges to display provisioning metrics.
-As a result, our built-in observability stack will not function properly. 
-These metrics will provide critial information to help you scale the Sourcegraph deployment.
-Therefore, please assign proper permission to Service Account '{{ include "sourcegraph.serviceAccountName" (list . "prometheus") }}'.
-You can do so by creating the proper ClusterRole and ClusterRoleBinding. 
-You may consult https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
-for a list of expected permissions.
+These metrics provide critical information to help you scale the Sourcegraph deployment.
+Provisioning metrics can be restored by assigning elevated permissions to Service Account '{{ include "sourcegraph.serviceAccountName" (list . "prometheus") }}'.
+Consult https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml for the necessary permissions.
 
 {{- end }}

--- a/charts/sourcegraph/tests/prometheusPrivileged_test.yaml
+++ b/charts/sourcegraph/tests/prometheusPrivileged_test.yaml
@@ -1,0 +1,16 @@
+suite: prometheusPrivileged
+templates:
+  - NOTES.txt
+tests:
+  - it: should not have the warning text when prometheus.privileged=true
+    set:
+      prometheus.privileged: true
+    asserts:
+      - notMatchRegexRaw:
+          pattern: You have set 'prometheus.privileged' to 'false'
+  - it: should have the warning text when prometheus.privileged=false
+    set:
+      prometheus.privileged: false
+    asserts:
+      - matchRegexRaw:
+          pattern: You have set 'prometheus.privileged' to 'false'


### PR DESCRIPTION
close https://github.com/sourcegraph/sourcegraph/issues/32852

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

```sh
helm upgrade --dry-run --install -n sourcegraph --create-namespace --set prometheus.privileged=false sourcegraph charts/sourcegraph/
```

you should see

```
NOTES:
Thank you for installing sourcegraph.

Your release is named sourcegraph.

To learn more about supported configuration, check out https://docs.sourcegraph.com/admin/install/kubernetes/helm.

🚧 Warning 🚧

You have set 'prometheus.privileged' to 'false'. As a result, our built-in observability stack will not function properly.
Please assign proper permission to Service Account 'prometheus'.
You can do so by creating the proper ClusterRole and ClusterRoleBinding.
You may consult https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
for a list of expected permissions.
```