### PR TITLE
Publish chart on release branches instead of main

### DIFF
--- a/.github/workflows/chart_publish.yml
+++ b/.github/workflows/chart_publish.yml
@@ -3,7 +3,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - main
+      - release/**
 
 jobs:
   release:


### PR DESCRIPTION
Switch to publishing from a release branch instead of main. ~~The name standard is up for debate! Alternatively, we could publish from tags?~~

After discussion, we're happy with the release branch name convention. Tags will be created by the chart publisher.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Charts are only published from release branches