### PR TITLE
Add mapping between values key and names used for multi-word resources

### DIFF
--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -129,11 +129,21 @@ Jaeger selector labels
 app.kubernetes.io/name: jaeger
 {{- end }}
 
+{{- define "sourcegraph.mappedName" -}}
+{{- $top := index . 0 -}}
+{{- $service := index . 1 -}}
+{{- if (index $top.Values $service "mappingName") }}
+{{- (index $top.Values $service "mappingName") }}
+{{- else }}
+{{- $service }}
+{{- end -}}
+{{- end }}
+
 {{- define "sourcegraph.databaseAuth" -}}
 {{- $top := index . 0 -}}
 {{- $service := index . 1 -}}
 {{- $prefix := index . 2 -}}
-{{- $secretName := ((snakecase $service) | replace "_" "-") -}}
+{{- $secretName := (include "sourcegraph.mappedName" (list $top $service )) }}
 {{- $secretName := printf "%s-auth" $secretName -}}
 {{- if (index $top.Values $service "auth" "existingSecret") }}{{- $secretName = (index $top.Values $service "auth" "existingSecret") }}{{- end -}}
 - name: {{ printf "%sDATABASE" $prefix }}
@@ -166,7 +176,7 @@ app.kubernetes.io/name: jaeger
 {{- define "sourcegraph.dataSource" -}}
 {{- $top := index . 0 -}}
 {{- $service := index . 1 -}}
-{{- $secretName := ((snakecase $service) | replace "_" "-") -}}
+{{- $secretName := (include "sourcegraph.mappedName" (list $top $service )) }}
 {{- $secretName := printf "%s-auth" $secretName -}}
 {{- if (index $top.Values $service "auth" "existingSecret") }}{{- $secretName = (index $top.Values $service "auth" "existingSecret") }}{{- end -}}
 - name: DATA_SOURCE_DB

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -173,6 +173,7 @@ codeInsightsDB:
     requests:
       cpu: "4"
       memory: 2Gi
+  mappingName: "codeinsights-db"
   # -- Security context for the `codeinsights-db` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext:
@@ -222,6 +223,7 @@ codeIntelDB:
     requests:
       cpu: "4"
       memory: 4Gi
+  mappingName: "codeintel-db"
   # -- Security context for the `codeintel-db` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext:
@@ -350,6 +352,7 @@ githubProxy:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  mappingName: "github-proxy"
   # -- Security context for the `github-proxy` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
@@ -474,6 +477,7 @@ indexedSearch:
     requests:
       cpu: 500m
       memory: 2G
+  mappingName: "indexed-search"
   # -- Security context for the `indexed-search` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext:
@@ -660,6 +664,7 @@ preciseCodeIntel:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  mappingName: "precise-code-intel"
   # -- Security context for the `precise-code-intel-worker` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
@@ -754,6 +759,7 @@ redisCache:
     requests:
       cpu: "1"
       memory: 7Gi
+  mappingName: "redis-cache"
   # -- Security context for the `redis-cache` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext:
@@ -814,6 +820,7 @@ redisStore:
     requests:
       cpu: "1"
       memory: 7Gi
+  mappingName: "redis-store"
   # -- Security context for the `redis-store` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext:
@@ -840,6 +847,7 @@ repoUpdater:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  mappingName: "repo-updater"
   # -- Security context for the `repo-updater` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
@@ -959,6 +967,7 @@ syntectServer:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  mappingName: "syntect-server"
   # -- Security context for the `syntect-server` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}


### PR DESCRIPTION
**Goal**: I need to be able to reference the auto-generated database secret by name. The secret name is hardcoded (which is not ideal) but even if it were generated, the same problem would occur (example: we would still need to be able to predict the `"codeintel-db"` section of [this line](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml#L14)).

My untested hack to use `snakecase $service` to convert `codeIntelDB` to `codeintel-db` didn't work (it produces `code-intel-db`, of course).

This approach is pretty much me admitting defeat: I can't think of a better way to map codeIntelDB to codeintel-db. It's a little goofy putting this mapping into the values.yaml since it's not intended to be customized, but maybe leaving it in un-documented will be sufficient?

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
A followup PR actually generates the correct secret references