### PR TITLE
Set default name for resources

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -94,6 +94,7 @@ In addition to the documented values, all services also support the following va
 | cadvisor.enabled | bool | `true` | Enable `cadvisor` |
 | cadvisor.image.defaultTag | string | `"3.38.0@sha256:246c3d82072511f376049762056a3c82fce5dbc4a00f29f10f64373b5fe0a9a9"` | Docker image tag for the `cadvisor` image |
 | cadvisor.image.name | string | `"cadvisor"` | Docker image name for the `cadvisor` image |
+| cadvisor.name | string | `"cadvisor"` | Name used by resources. Does not affect service names or PVCs. |
 | cadvisor.podSecurityPolicy.enabled | bool | `false` | Enable [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for `cadvisor` pods |
 | cadvisor.resources | object | `{"limits":{"cpu":"300m","memory":"2000Mi"},"requests":{"cpu":"150m","memory":"200Mi"}}` | Resource requests & limits for the `cadvisor` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | cadvisor.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `cadvisor` |
@@ -105,6 +106,7 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.existingConfig | string | `""` | Name of existing ConfigMap for `codeinsights-db`. It must contain a `postgresql.conf` key. |
 | codeInsightsDB.image.defaultTag | string | `"3.38.0@sha256:4f971b00939ebbf7d9d622f40fc84a4fde994c67ebd023ed49ccad066aae2044"` | Docker image tag for the `codeinsights-db` image |
 | codeInsightsDB.image.name | string | `"codeinsights-db"` | Docker image name for the `codeinsights-db` image |
+| codeInsightsDB.name | string | `"codeinsights-db"` | Name used by resources. Does not affect service names or PVCs. |
 | codeInsightsDB.podSecurityContext | object | `{"fsGroup":70,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":70}` | Security context for the `codeinsights-db` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | codeInsightsDB.resources | object | `{"limits":{"cpu":"4","memory":"2Gi"},"requests":{"cpu":"4","memory":"2Gi"}}` | Resource requests & limits for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | codeInsightsDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeinsights-db` |
@@ -116,6 +118,7 @@ In addition to the documented values, all services also support the following va
 | codeIntelDB.existingConfig | string | `""` | Name of existing ConfigMap for `codeintel-db`. It must contain a `postgresql.conf` key |
 | codeIntelDB.image.defaultTag | string | `"3.38.0@sha256:32682b563f62fd3b883ec8b77b180e4bddff09db51cde17734562f018b5b40a2"` | Docker image tag for the `codeintel-db` image |
 | codeIntelDB.image.name | string | `"codeintel-db"` | Docker image name for the `codeintel-db` image |
+| codeIntelDB.name | string | `"codeintel-db"` | Name used by resources. Does not affect service names or PVCs. |
 | codeIntelDB.podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":999}` | Security context for the `codeintel-db` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | codeIntelDB.postgresExporter.env | object | `{"DATA_SOURCE_NAME":{"value":"postgres://sg:@localhost:5432/?sslmode=disable"}}` | Environment variables for the `pgsql-exporter` sidecar container |
 | codeIntelDB.resources | object | `{"limits":{"cpu":"4","memory":"4Gi"},"requests":{"cpu":"4","memory":"4Gi"}}` | Resource requests & limits for the `codeintel-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -132,6 +135,7 @@ In addition to the documented values, all services also support the following va
 | frontend.ingress.host | string | `""` | External hostname for the Sourcegraph server ingress (SSL) |
 | frontend.ingress.ingressClassName | string | `nil` | IngressClassName for the Ingress (Available in Kubernetes 1.18+) |
 | frontend.ingress.tlsSecret | string | `""` | Secret containing SSL cert |
+| frontend.name | string | `"sourcegraph-frontend"` | Name used by resources. Does not affect service names or PVCs. |
 | frontend.podSecurityContext | object | `{}` | Security context for the `frontend` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | frontend.privileged | bool | `true` | Enable creation of Role and RoleBinding (RBAC). Uses [view](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) ClusterRole if set to false |
 | frontend.replicaCount | int | `2` | Number of `frontend` pod |
@@ -141,6 +145,7 @@ In addition to the documented values, all services also support the following va
 | githubProxy.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `github-proxy` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | githubProxy.image.defaultTag | string | `"3.38.0@sha256:c7c2179aec8889ea87fe70002b6e2e519dbf84aa19dd0f563938c4f504174d4e"` | Docker image tag for the `github-proxy` image |
 | githubProxy.image.name | string | `"github-proxy"` | Docker image name for the `github-proxy` image |
+| githubProxy.name | string | `"github-proxy"` | Name used by resources. Does not affect service names or PVCs. |
 | githubProxy.podSecurityContext | object | `{}` | Security context for the `github-proxy` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | githubProxy.resources | object | `{"limits":{"cpu":"1","memory":"1G"},"requests":{"cpu":"100m","memory":"250M"}}` | Resource requests & limits for the `github-proxy` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | githubProxy.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `github-proxy` |
@@ -148,6 +153,7 @@ In addition to the documented values, all services also support the following va
 | gitserver.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `gitserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | gitserver.image.defaultTag | string | `"3.38.0@sha256:6474be40cbe0a0a2914bc996835e78bf25ee48527312b8800bc0ccb35341c3ec"` | Docker image tag for the `gitserver` image |
 | gitserver.image.name | string | `"gitserver"` | Docker image name for the `gitserver` image |
+| gitserver.name | string | `"gitserver"` | Name used by resources. Does not affect service names or PVCs. |
 | gitserver.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":101,"runAsUser":100}` | Security context for the `gitserver` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | gitserver.replicaCount | int | `1` | Number of `gitserver` pod |
 | gitserver.resources | object | `{"limits":{"cpu":"4","memory":"8G"},"requests":{"cpu":"4","memory":"8G"}}` | Resource requests & limits for the `gitserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -159,6 +165,7 @@ In addition to the documented values, all services also support the following va
 | grafana.existingConfig | string | `""` | Name of existing ConfigMap for `grafana`. It must contain a `datasources.yml` key. |
 | grafana.image.defaultTag | string | `"3.38.0@sha256:7b1fa3a4848eea68627a1c69695024a6e35e32749f02d326715933878f78ce67"` | Docker image tag for the `grafana` image |
 | grafana.image.name | string | `"grafana"` | Docker image name for the `grafana` image |
+| grafana.name | string | `"grafana"` | Name used by resources. Does not affect service names or PVCs. |
 | grafana.podSecurityContext | object | `{"fsGroup":472,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":472,"runAsUser":472}` | Security context for the `grafana` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | grafana.replicaCount | int | `1` | Number of `grafana` pod |
 | grafana.resources | object | `{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"100m","memory":"512Mi"}}` | Resource requests & limits for the `grafana` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -168,6 +175,7 @@ In addition to the documented values, all services also support the following va
 | indexedSearch.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `zoekt-webserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | indexedSearch.image.defaultTag | string | `"3.38.0@sha256:0c2b31f1b5be6e851676c6df678dee74fd51733a4c230942a52876384f263e6b"` | Docker image tag for the `zoekt-webserver` image |
 | indexedSearch.image.name | string | `"indexed-searcher"` | Docker image name for the `zoekt-webserver` image |
+| indexedSearch.name | string | `"indexed-search"` | Name used by resources. Does not affect service names or PVCs. |
 | indexedSearch.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch"}` | Security context for the `indexed-search` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | indexedSearch.replicaCount | int | `1` | Number of `indexed-search` pod |
 | indexedSearch.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `zoekt-webserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -192,6 +200,7 @@ In addition to the documented values, all services also support the following va
 | minio.enabled | bool | `true` | Enable `minio` (S3 compatible storage) |
 | minio.image.defaultTag | string | `"3.38.0@sha256:0daf4c0c821634eeefbf90f48d467eece09597aff5d9f582685c8c875f03e6fa"` | Docker image tag for the `minio` image |
 | minio.image.name | string | `"minio"` | Docker image tag for the `minio` image |
+| minio.name | string | `"minio"` | Name used by resources. Does not affect service names or PVCs. |
 | minio.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":101,"runAsUser":100}` | Security context for the `minio` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | minio.resources | object | `{"limits":{"cpu":"1","memory":"500M"},"requests":{"cpu":"1","memory":"500M"}}` | Resource requests & limits for the `minio` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | minio.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `minio` |
@@ -203,6 +212,7 @@ In addition to the documented values, all services also support the following va
 | pgsql.existingConfig | string | `""` | Name of existing ConfigMap for `pgsql`. It must contain a `postgresql.conf` key |
 | pgsql.image.defaultTag | string | `"3.38.0@sha256:f5329a359f74670eaa2148c72841f7a15323de3eabd9cb8107e4ddda7a457e7f"` | Docker image tag for the `pgsql` image |
 | pgsql.image.name | string | `"postgres-12-alpine"` | Docker image name for the `pgsql` image |
+| pgsql.name | string | `"pgsql"` | Name used by resources. Does not affect service names or PVCs. |
 | pgsql.podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsUser":999}` | Security context for the `pgsql` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | pgsql.postgresExporter.env | object | `{"DATA_SOURCE_NAME":{"value":"postgres://sg:@localhost:5432/?sslmode=disable"}}` | Environment variables for the `pgsql-exporter` sidecar container |
 | pgsql.resources | object | `{"limits":{"cpu":"4","memory":"4Gi"},"requests":{"cpu":"4","memory":"4Gi"}}` | Resource requests & limits for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -216,6 +226,7 @@ In addition to the documented values, all services also support the following va
 | preciseCodeIntel.env | object | `{"NUM_WORKERS":{"value":"4"}}` | Environment variables for the `precise-code-intel-worker` container |
 | preciseCodeIntel.image.defaultTag | string | `"3.38.0@sha256:f1e4ce16b5fffbc1270765886aaecebb18a80568a815163f3ea2c36174db119a"` | Docker image tag for the `precise-code-intel-worker` image |
 | preciseCodeIntel.image.name | string | `"precise-code-intel-worker"` | Docker image name for the `precise-code-intel-worker` image |
+| preciseCodeIntel.name | string | `"precise-code-intel-worker"` | Name used by resources. Does not affect service names or PVCs. |
 | preciseCodeIntel.podSecurityContext | object | `{}` | Security context for the `precise-code-intel-worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | preciseCodeIntel.replicaCount | int | `2` | Number of `precise-code-intel-worker` pod |
 | preciseCodeIntel.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `precise-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -226,6 +237,7 @@ In addition to the documented values, all services also support the following va
 | prometheus.existingConfig | string | `""` | Name of existing ConfigMap for `pgsql`. It must contain a `prometheus.yml` key |
 | prometheus.image.defaultTag | string | `"3.38.0@sha256:4fcd8a2469b5d57e3b75e5adbb9b068d2013c6392307790cf69681a6dd7663d5"` | Docker image tag for the `prometheus` image |
 | prometheus.image.name | string | `"prometheus"` | Docker image name for the `prometheus` image |
+| prometheus.name | string | `"prometheus"` | Name used by resources. Does not affect service names or PVCs. |
 | prometheus.podSecurityContext | object | `{"fsGroup":100,"fsGroupChangePolicy":"OnRootMismatch"}` | Security context for the `prometheus` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | prometheus.privileged | bool | `true` | Enable RBAC for `prometheus` |
 | prometheus.replicaCount | int | `1` | Number of `prometheus` pod |
@@ -237,6 +249,7 @@ In addition to the documented values, all services also support the following va
 | redisCache.enabled | bool | `true` | Enable `redis-cache` Redis server |
 | redisCache.image.defaultTag | string | `"3.38.0@sha256:f922a4f88c051537767e401c5a601923491e7021cf285aecec1276ebdca83949"` | Docker image tag for the `redis-cache` image |
 | redisCache.image.name | string | `"redis-cache"` | Docker image name for the `redis-cache` image |
+| redisCache.name | string | `"redis-cache"` | Name used by resources. Does not affect service names or PVCs. |
 | redisCache.podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch"}` | Security context for the `redis-cache` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | redisCache.resources | object | `{"limits":{"cpu":"1","memory":"7Gi"},"requests":{"cpu":"1","memory":"7Gi"}}` | Resource requests & limits for the `redis-cache` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | redisCache.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `redis-cache` |
@@ -250,6 +263,7 @@ In addition to the documented values, all services also support the following va
 | redisStore.enabled | bool | `true` | Enable `redis-store` Redis server |
 | redisStore.image.defaultTag | string | `"3.38.0@sha256:6da998b9b6642ab330bed143b4998a9e8d16d81585035ed1b726311b5708d557"` | Docker image tag for the `redis-store` image |
 | redisStore.image.name | string | `"redis-store"` | Docker image name for the `redis-store` image |
+| redisStore.name | string | `"redis-store"` | Name used by resources. Does not affect service names or PVCs. |
 | redisStore.podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch"}` | Security context for the `redis-store` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | redisStore.resources | object | `{"limits":{"cpu":"1","memory":"7Gi"},"requests":{"cpu":"1","memory":"7Gi"}}` | Resource requests & limits for the `redis-store` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | redisStore.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `redis-store` |
@@ -258,6 +272,7 @@ In addition to the documented values, all services also support the following va
 | repoUpdater.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `repo-updater` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | repoUpdater.image.defaultTag | string | `"3.38.0@sha256:98c8c45504611d2a2affcb884e639a1217e6786e5441a2daf91e9eea9070cbf5"` | Docker image tag for the `repo-updater` image |
 | repoUpdater.image.name | string | `"repo-updater"` | Docker image name for the `repo-updater` image |
+| repoUpdater.name | string | `"repo-updater"` | Name used by resources. Does not affect service names or PVCs. |
 | repoUpdater.podSecurityContext | object | `{}` | Security context for the `repo-updater` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | repoUpdater.resources | object | `{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"1","memory":"500Mi"}}` | Resource requests & limits for the `repo-updater` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | repoUpdater.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `repo-updater` |
@@ -265,6 +280,7 @@ In addition to the documented values, all services also support the following va
 | searcher.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | searcher.image.defaultTag | string | `"3.38.0@sha256:9fd1c8f3dd4ff7d9f791c9a9b0e1666f7649a9379f2d16457cc9f8c9f7251a8a"` | Docker image tag for the `searcher` image |
 | searcher.image.name | string | `"searcher"` | Docker image name for the `searcher` image |
+| searcher.name | string | `"searcher"` | Name used by resources. Does not affect service names or PVCs. |
 | searcher.podSecurityContext | object | `{}` | Security context for the `searcher` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | searcher.replicaCount | int | `2` | Number of `searcher` pod |
 | searcher.resources | object | `{"limits":{"cpu":"2","ephemeral-storage":"26G","memory":"2G"},"requests":{"cpu":"500m","ephemeral-storage":"25G","memory":"500M"}}` | Resource requests & limits for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -293,6 +309,7 @@ In addition to the documented values, all services also support the following va
 | symbols.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `symbols` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | symbols.image.defaultTag | string | `"3.38.0@sha256:0d42271300254876b5a587fb07441a131368cd34b3f0b373299b96d4be4963ce"` | Docker image tag for the `symbols` image |
 | symbols.image.name | string | `"symbols"` | Docker image name for the `symbols` image |
+| symbols.name | string | `"symbols"` | Name used by resources. Does not affect service names or PVCs. |
 | symbols.podSecurityContext | object | `{}` | Security context for the `symbols` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | symbols.replicaCount | int | `1` | Number of `symbols` pod |
 | symbols.resources | object | `{"limits":{"cpu":"2","ephemeral-storage":"12G","memory":"2G"},"requests":{"cpu":"500m","ephemeral-storage":"10G","memory":"500M"}}` | Resource requests & limits for the `symbols` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -301,6 +318,7 @@ In addition to the documented values, all services also support the following va
 | syntectServer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | syntectServer.image.defaultTag | string | `"3.38.0@sha256:05a3ccdca334e1f198ee3a8f3c5492c1dffb8f3254f9b43d248f0fc64c95beb6"` | Docker image tag for the `syntect-server` image |
 | syntectServer.image.name | string | `"syntax-highlighter"` | Docker image name for the `syntect-server` image |
+| syntectServer.name | string | `"syntect-server"` | Name used by resources. Does not affect service names or PVCs. |
 | syntectServer.podSecurityContext | object | `{}` | Security context for the `syntect-server` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | syntectServer.replicaCount | int | `1` | Number of `syntect-server` pod |
 | syntectServer.resources | object | `{"limits":{"cpu":"4","memory":"6G"},"requests":{"cpu":"250m","memory":"2G"}}` | Resource requests & limits for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -314,6 +332,7 @@ In addition to the documented values, all services also support the following va
 | tracing.enabled | bool | `true` | Enable `jaeger` |
 | tracing.image.defaultTag | string | `"3.38.0@sha256:7c3505a6702435e2aba88987dbd4795e0f87acc602310df78dcb9581e3ad868f"` | Docker image tag for the `jaeger` image |
 | tracing.image.name | string | `"jaeger-all-in-one"` | Docker image name for the `jaeger` image |
+| tracing.name | string | `"jaeger"` | Name used by resources. Does not affect service names or PVCs. |
 | tracing.podSecurityContext | object | `{}` | Security context for the `jaeger` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | tracing.query.name | string | `""` | Name of jaeger `query` service  |
 | tracing.query.serviceAnnotations | object | `{}` | Add extra annotations to jaeger `query` service |
@@ -331,6 +350,7 @@ In addition to the documented values, all services also support the following va
 | worker.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | worker.image.defaultTag | string | `"3.38.0@sha256:9180a8740dc3523d39918349a9640a6551f17c0b6ad5a19856efbec4261ae510"` | Docker image tag for the `worker` image |
 | worker.image.name | string | `"worker"` | Docker image name for the `worker` image |
+| worker.name | string | `"worker"` | Name used by resources. Does not affect service names or PVCs. |
 | worker.podSecurityContext | object | `{}` | Security context for the `worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | worker.replicaCount | int | `1` | Number of `worker` pod |
 | worker.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -41,7 +41,7 @@ Create the name of the service account to use
 {{- define "sourcegraph.serviceAccountName" -}}
 {{- $top := index . 0 }}
 {{- $service := index . 1 }}
-{{- $defaultServiceAccountName := ((snakecase $service) | replace "_" "-") }}
+{{- $defaultServiceAccountName := (index $top.Values $service "name") }}
 {{- default $defaultServiceAccountName (index $top.Values $service "serviceAccount" "name") }}
 {{- end }}
 

--- a/charts/sourcegraph/templates/cadvisor/cadvisor.ClusterRole.yaml
+++ b/charts/sourcegraph/templates/cadvisor/cadvisor.ClusterRole.yaml
@@ -7,11 +7,11 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: cadvisor
-  name: cadvisor
+  name: {{ .Values.cadvisor.name }}
 rules:
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs:     ['use']
     resourceNames:
-    - {{ default "cadvisor" .Values.cadvisor.name }}
+    - {{ .Values.cadvisor.name }}
 {{- end }}

--- a/charts/sourcegraph/templates/cadvisor/cadvisor.ClusterRoleBinding.yaml
+++ b/charts/sourcegraph/templates/cadvisor/cadvisor.ClusterRoleBinding.yaml
@@ -7,11 +7,11 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: cadvisor
-  name: cadvisor
+  name: {{ .Values.cadvisor.name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cadvisor
+  name: {{ .Values.cadvisor.name }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "sourcegraph.serviceAccountName" (list . "cadvisor") }}

--- a/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: cadvisor
-  name: {{ default "cadvisor" .Values.cadvisor.name }}
+  name: {{ .Values.cadvisor.name }}
 spec:
   selector:
     matchLabels:

--- a/charts/sourcegraph/templates/cadvisor/cadvisor.PodSecurityPolicy.yaml
+++ b/charts/sourcegraph/templates/cadvisor/cadvisor.PodSecurityPolicy.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cadvisor
     deploy: sourcegraph
     app.kubernetes.io/component: cadvisor
-  name: cadvisor
+  name: {{ .Values.cadvisor.name }}
 spec:
   seLinux:
     rule: RunAsAny

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.ConfigMap.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
-  name: codeinsights-db-conf
+  name: {{ .Values.codeInsightsDB.name }}-conf
 data:
   postgresql.conf: |
     # -----------------------------

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
-  name: {{ default "codeinsights-db" .Values.codeInsightsDB.name }}
+  name: {{ .Values.codeInsightsDB.name }}
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
@@ -100,7 +100,7 @@ spec:
       - name: codeinsights-conf
         configMap:
           defaultMode: 0777
-          name: {{ default "codeinsights-db-conf" .Values.codeInsightsDB.existingConfig }}
+          name: {{ default (print .Values.codeInsightsDB.name "-conf") .Values.codeInsightsDB.existingConfig }}
       - name: lockdir
         emptyDir: {}
       {{- if .Values.codeInsightsDB.extraVolumes }}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.ConfigMap.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/component: codeintel-db
     deploy: sourcegraph
-  name: codeintel-db-conf
+  name: {{ .Values.codeIntelDB.name }}-conf
 data:
   postgresql.conf: |
     # -----------------------------

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
     app.kubernetes.io/component: codeintel-db
     deploy: sourcegraph
-  name: {{ default "codeintel-db" .Values.codeIntelDB.name }}
+  name: {{ .Values.codeIntelDB.name }}
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
@@ -133,7 +133,7 @@ spec:
       - name: pgsql-conf
         configMap:
           defaultMode: 0777
-          name: {{ default "codeintel-db-conf" .Values.codeIntelDB.existingConfig .Values.codeIntelDB.name }}
+          name: {{ default (print .Values.codeIntelDB.name "-conf") .Values.codeIntelDB.existingConfig }}
       - name: lockdir
         emptyDir: {}
       {{- if .Values.codeIntelDB.extraVolumes }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: frontend
-  name: {{ default "sourcegraph-frontend" .Values.frontend.name }}
+  name: {{ .Values.frontend.name }}
 spec:
   minReadySeconds: 10
   replicas: {{ .Values.frontend.replicaCount }}
@@ -90,12 +90,12 @@ spec:
           valueFrom:
             secretKeyRef:
               key: user
-              name: {{ default "minio-auth" .Values.minio.auth.existingSecret }}
+              name: {{ default (print .Values.minio.name "-auth") .Values.minio.auth.existingSecret }}
         - name: PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
               key: password
-              name: {{ default "minio-auth" .Values.minio.auth.existingSecret }}
+              name: {{ default (print .Values.minio.name "-auth") .Values.minio.auth.existingSecret }}
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- if .Values.frontend.ingress.labels}}
       {{- toYaml .Values.frontend.ingress.labels | nindent 4 }}
     {{- end }}
-  name: sourcegraph-frontend
+  name: {{ .Values.frontend.name }}
 spec:
   {{- if and .Values.frontend.ingress.host .Values.frontend.ingress.tlsSecret }}
   tls:

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -7,7 +7,7 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: frontend
-  name: sourcegraph-frontend
+  name: {{ .Values.frontend.name }}
 rules:
 - apiGroups:
   - ""

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: frontend
-  name: sourcegraph-frontend
+  name: {{ .Values.frontend.name }}
 roleRef:
 {{- if .Values.frontend.privileged }}
   apiGroup: "rbac.authorization.k8s.io"
   kind: Role
-  name: sourcegraph-frontend
+  name: {{ .Values.frontend.name }}
 {{- else }}
   apiGroup: ""
   kind: ClusterRole

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: github-proxy
-  name: {{ default "github-proxy" .Values.githubProxy.name }}
+  name: {{ .Values.githubProxy.name }}
 spec:
   minReadySeconds: 10
   replicas: 1

--- a/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: gitserver
-  name: {{ default "gitserver" .Values.gitserver.name }}
+  name: {{ .Values.gitserver.name }}
 spec:
   replicas: {{ .Values.gitserver.replicaCount }}
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}

--- a/charts/sourcegraph/templates/grafana/grafana.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.ConfigMap.yaml
@@ -20,5 +20,5 @@ metadata:
   labels:
     deploy: sourcegraph
     app.kubernetes.io/component: grafana
-  name: grafana
+  name: {{ .Values.grafana.name }}
 {{- end }}

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: grafana
-  name: {{ default "grafana" .Values.grafana.name }}
+  name: {{ .Values.grafana.name }}
 spec:
   replicas: {{ .Values.grafana.replicaCount }}
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
@@ -94,7 +94,7 @@ spec:
       - name: config
         configMap:
           defaultMode: 0777
-          name: {{ default "grafana" .Values.grafana.existingConfig }}
+          name: {{ default .Values.grafana.name .Values.grafana.existingConfig }}
       {{- if .Values.grafana.extraVolumes }}
       {{- toYaml .Values.grafana.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- if .Values.indexedSearch.labels }}
       {{- toYaml .Values.indexedSearch.labels | nindent 4 }}
     {{- end }}
-  name: {{ default "indexed-search" .Values.indexedSearch.name }}
+  name: {{ .Values.indexedSearch.name }}
 spec:
   replicas: {{ .Values.indexedSearch.replicaCount }}
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}

--- a/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ default "jaeger" .Values.tracing.name }}
+  name: {{ .Values.tracing.name }}
   labels:
     {{- include "sourcegraph.jaeger.labels" . | nindent 4 }}
     {{- if .Values.tracing.labels }}

--- a/charts/sourcegraph/templates/minio/minio.Deployment.yaml
+++ b/charts/sourcegraph/templates/minio/minio.Deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: minio
-  name: {{ default "minio" .Values.minio.name }}
+  name: {{ .Values.minio.name }}
 spec:
   minReadySeconds: 10
   replicas: 1
@@ -51,12 +51,12 @@ spec:
           valueFrom:
             secretKeyRef:
               key: user
-              name: {{ default "minio-auth" .Values.minio.auth.existingSecret }}
+              name: {{ default (print .Values.minio.name "-auth") .Values.minio.auth.existingSecret }}
         - name: MINIO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               key: password
-              name: {{ default "minio-auth" .Values.minio.auth.existingSecret }}
+              name: {{ default (print .Values.minio.name "-auth") .Values.minio.auth.existingSecret }}
         {{- range $name, $item := .Values.minio.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}

--- a/charts/sourcegraph/templates/minio/minio.Secret.yaml
+++ b/charts/sourcegraph/templates/minio/minio.Secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: minio-auth
+  name: {{ .Values.minio.name }}-auth
   labels:
     app: minio
     deploy: sourcegraph

--- a/charts/sourcegraph/templates/pgsql/pgsql.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.ConfigMap.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     deploy: sourcegraph
     app.kubernetes.io/component: pgsql
-  name: pgsql-conf
+  name: {{ .Values.pgsql.name }}-conf
 data:
   postgresql.conf: |
     # -----------------------------

--- a/charts/sourcegraph/templates/pgsql/pgsql.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.StatefulSet.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- if .Values.pgsql.labels }}
       {{- toYaml .Values.pgsql.labels | nindent 4 }}
     {{- end }}
-  name: {{ default "pgsql" .Values.pgsql.name }}
+  name: {{ .Values.pgsql.name }}
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
@@ -137,7 +137,7 @@ spec:
       - name: pgsql-conf
         configMap:
           defaultMode: 0777
-          name: {{ default "pgsql-conf" .Values.pgsql.existingConfig }}
+          name: {{ default (print .Values.pgsql.name "-conf") .Values.pgsql.existingConfig }}
       - name: dshm # Allocate shared memory to match the shared_buffers value
         emptyDir:
           medium: Memory

--- a/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: precise-code-intel
-  name: {{ default "precise-code-intel-worker" .Values.preciseCodeIntel.name }}
+  name: {{ .Values.preciseCodeIntel.name }}
 spec:
   minReadySeconds: 10
   replicas: {{ .Values.preciseCodeIntel.replicaCount }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: prometheus
-  name: prometheus
+  name: {{ .Values.prometheus.name }}
 rules:
 - apiGroups:
   - ""

--- a/charts/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -6,11 +6,11 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: prometheus
-  name: prometheus
+  name: {{ .Values.prometheus.name }}
 roleRef:
   apiGroup: "rbac.authorization.k8s.io"
   kind: ClusterRole
-  name: prometheus
+  name: {{ .Values.prometheus.name }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "sourcegraph.serviceAccountName" (list . "prometheus") }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
@@ -281,5 +281,5 @@ metadata:
   labels:
     deploy: sourcegraph
     app.kubernetes.io/component: prometheus
-  name: prometheus
+  name: {{ .Values.prometheus.name }}
 {{- end }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: prometheus
-  name: {{ default "prometheus" .Values.prometheus.name }}
+  name: {{ .Values.prometheus.name }}
 spec:
   minReadySeconds: 10
   replicas: {{ .Values.prometheus.replicaCount }}
@@ -101,7 +101,7 @@ spec:
           claimName: prometheus
       - configMap:
           defaultMode: 0777
-          name: {{ default "prometheus" .Values.prometheus.existingConfig }}
+          name: {{ default .Values.prometheus.name .Values.prometheus.existingConfig }}
         name: config
       {{- if .Values.prometheus.extraVolumes }}
       {{- toYaml .Values.prometheus.extraVolumes | nindent 6 }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.RoleBinding.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.RoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: prometheus
-  name: prometheus
+  name: {{ .Values.prometheus.name }}
 roleRef:
   apiGroup: ""
   kind: ClusterRole

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: redis
-  name: {{ default "redis-cache" .Values.redisCache.name }}
+  name: {{ .Values.redisCache.name }}
 spec:
   minReadySeconds: 10
   replicas: 1

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: redis
-  name: {{ default "redis-store" .Values.redisStore.name }}
+  name: {{ .Values.redisStore.name }}
 spec:
   minReadySeconds: 10
   replicas: 1

--- a/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: repo-updater
-  name: {{ default "repo-updater" .Values.repoUpdater.name }}
+  name: {{ .Values.repoUpdater.name }}
 spec:
   minReadySeconds: 10
   replicas: 1

--- a/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: searcher
-  name: {{ default "searcher" .Values.searcher.name }}
+  name: {{ .Values.searcher.name }}
 spec:
   minReadySeconds: 10
   replicas: {{ .Values.searcher.replicaCount }}

--- a/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: symbols
-  name: {{ default "symbols" .Values.symbols.name }}
+  name: {{ .Values.symbols.name }}
 spec:
   minReadySeconds: 10
   replicas: {{ .Values.symbols.replicaCount }}

--- a/charts/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: syntect-server
-  name: {{ default "syntect-server" .Values.syntectServer.name }}
+  name: {{ .Values.syntectServer.name }}
 spec:
   minReadySeconds: 10
   replicas: {{ .Values.syntectServer.replicaCount }}

--- a/charts/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
     deploy: sourcegraph
     app.kubernetes.io/component: worker
-  name: {{ default "worker" .Values.worker.name }}
+  name: {{ .Values.worker.name }}
 spec:
   minReadySeconds: 10
   replicas: {{ .Values.worker.replicaCount }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -58,8 +58,6 @@ sourcegraph:
 #   podAnnotations: {}
 #   serviceLabels: {}
 #   serviceAnnotations: {}
-#   # Override default service/deployment names
-#   name: ""
 #   # Provide custom environment variables
 #   env: {}
 #   # Set resource requests / limits
@@ -117,6 +115,7 @@ cadvisor:
     defaultTag: 3.38.0@sha256:246c3d82072511f376049762056a3c82fce5dbc4a00f29f10f64373b5fe0a9a9
     # -- Docker image name for the `cadvisor` image
     name: "cadvisor"
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "cadvisor"
   podSecurityPolicy:
     # -- Enable [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for `cadvisor` pods
@@ -165,6 +164,7 @@ codeInsightsDB:
     runAsUser: 70
     runAsGroup: 70
     readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "codeinsights-db"
   # -- Resource requests & limits for the `codeinsights-db` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
@@ -215,6 +215,7 @@ codeIntelDB:
     env:
       DATA_SOURCE_NAME:
         value: postgres://sg:@localhost:5432/?sslmode=disable
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "codeintel-db"
   # -- Resource requests & limits for the `codeintel-db` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
@@ -301,6 +302,7 @@ frontend:
   privileged: true
   # -- Number of `frontend` pod
   replicaCount: 2
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "sourcegraph-frontend"
   # -- Resource requests & limits for the `frontend` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
@@ -360,6 +362,7 @@ githubProxy:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "github-proxy"
   # -- Security context for the `github-proxy` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
@@ -403,6 +406,7 @@ gitserver:
     requests:
       cpu: "4"
       memory: 8G
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "gitserver"
   # -- Security context for the `gitserver` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
@@ -436,6 +440,7 @@ grafana:
     runAsUser: 472
     runAsGroup: 472
     readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "grafana"
   # -- Number of `grafana` pod
   replicaCount: 1
@@ -476,6 +481,7 @@ indexedSearch:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "indexed-search"
   # -- Number of `indexed-search` pod
   replicaCount: 1
@@ -554,6 +560,7 @@ minio:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "minio"
   # -- Resource requests & limits for the `minio` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
@@ -605,6 +612,7 @@ pgsql:
     env:
       DATA_SOURCE_NAME:
         value: postgres://sg:@localhost:5432/?sslmode=disable
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "pgsql"
   # -- Resource requests & limits for the `pgsql` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
@@ -664,6 +672,7 @@ preciseCodeIntel:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "precise-code-intel-worker"
   # -- Security context for the `precise-code-intel-worker` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
@@ -702,6 +711,7 @@ prometheus:
     runAsUser: 100
     runAsGroup: 100
     readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "prometheus"
   # -- Enable RBAC for `prometheus`
   privileged: true
@@ -760,6 +770,7 @@ redisCache:
     requests:
       cpu: "1"
       memory: 7Gi
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "redis-cache"
   # -- Security context for the `redis-cache` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
@@ -821,6 +832,7 @@ redisStore:
     requests:
       cpu: "1"
       memory: 7Gi
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "redis-store"
   # -- Security context for the `redis-store` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
@@ -848,6 +860,7 @@ repoUpdater:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "repo-updater"
   # -- Security context for the `repo-updater` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
@@ -883,6 +896,7 @@ searcher:
   # -- Security context for the `searcher` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "searcher"
   # -- Number of `searcher` pod
   replicaCount: 2
@@ -937,6 +951,7 @@ symbols:
   # -- Security context for the `symbols` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "symbols"
   # -- Number of `symbols` pod
   replicaCount: 1
@@ -970,6 +985,7 @@ syntectServer:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "syntect-server"
   # -- Security context for the `syntect-server` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
@@ -1010,6 +1026,7 @@ tracing:
     defaultTag: 3.38.0@sha256:7c3505a6702435e2aba88987dbd4795e0f87acc602310df78dcb9581e3ad868f
     # -- Docker image name for the `jaeger` image
     name: "jaeger-all-in-one"
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "jaeger"
   # -- Security context for the `jaeger` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
@@ -1087,6 +1104,7 @@ worker:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
   name: "worker"
   # -- Security context for the `worker` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -117,6 +117,7 @@ cadvisor:
     defaultTag: 3.38.0@sha256:246c3d82072511f376049762056a3c82fce5dbc4a00f29f10f64373b5fe0a9a9
     # -- Docker image name for the `cadvisor` image
     name: "cadvisor"
+  name: "cadvisor"
   podSecurityPolicy:
     # -- Enable [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for `cadvisor` pods
     enabled: false
@@ -164,6 +165,7 @@ codeInsightsDB:
     runAsUser: 70
     runAsGroup: 70
     readOnlyRootFilesystem: true
+  name: "codeinsights-db"
   # -- Resource requests & limits for the `codeinsights-db` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -213,6 +215,7 @@ codeIntelDB:
     env:
       DATA_SOURCE_NAME:
         value: postgres://sg:@localhost:5432/?sslmode=disable
+  name: "codeintel-db"
   # -- Resource requests & limits for the `codeintel-db` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -298,6 +301,7 @@ frontend:
   privileged: true
   # -- Number of `frontend` pod
   replicaCount: 2
+  name: "sourcegraph-frontend"
   # -- Resource requests & limits for the `frontend` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -356,6 +360,7 @@ githubProxy:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  name: "github-proxy"
   # -- Security context for the `github-proxy` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
@@ -398,6 +403,7 @@ gitserver:
     requests:
       cpu: "4"
       memory: 8G
+  name: "gitserver"
   # -- Security context for the `gitserver` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext:
@@ -430,6 +436,7 @@ grafana:
     runAsUser: 472
     runAsGroup: 472
     readOnlyRootFilesystem: true
+  name: "grafana"
   # -- Number of `grafana` pod
   replicaCount: 1
   # -- Resource requests & limits for the `grafana` container,
@@ -469,6 +476,7 @@ indexedSearch:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  name: "indexed-search"
   # -- Number of `indexed-search` pod
   replicaCount: 1
   # -- Resource requests & limits for the `zoekt-webserver` container,
@@ -546,6 +554,7 @@ minio:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
+  name: "minio"
   # -- Resource requests & limits for the `minio` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -596,6 +605,7 @@ pgsql:
     env:
       DATA_SOURCE_NAME:
         value: postgres://sg:@localhost:5432/?sslmode=disable
+  name: "pgsql"
   # -- Resource requests & limits for the `pgsql` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -654,6 +664,7 @@ preciseCodeIntel:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  name: "precise-code-intel-worker"
   # -- Security context for the `precise-code-intel-worker` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
@@ -691,6 +702,7 @@ prometheus:
     runAsUser: 100
     runAsGroup: 100
     readOnlyRootFilesystem: true
+  name: "prometheus"
   # -- Enable RBAC for `prometheus`
   privileged: true
   # -- Number of `prometheus` pod
@@ -748,6 +760,7 @@ redisCache:
     requests:
       cpu: "1"
       memory: 7Gi
+  name: "redis-cache"
   # -- Security context for the `redis-cache` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext:
@@ -808,6 +821,7 @@ redisStore:
     requests:
       cpu: "1"
       memory: 7Gi
+  name: "redis-store"
   # -- Security context for the `redis-store` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext:
@@ -834,6 +848,7 @@ repoUpdater:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  name: "repo-updater"
   # -- Security context for the `repo-updater` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
@@ -868,6 +883,7 @@ searcher:
   # -- Security context for the `searcher` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
+  name: "searcher"
   # -- Number of `searcher` pod
   replicaCount: 2
   # -- Resource requests & limits for the `searcher` container,
@@ -921,6 +937,7 @@ symbols:
   # -- Security context for the `symbols` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
+  name: "symbols"
   # -- Number of `symbols` pod
   replicaCount: 1
   # -- Resource requests & limits for the `symbols` container,
@@ -953,6 +970,7 @@ syntectServer:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  name: "syntect-server"
   # -- Security context for the `syntect-server` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
@@ -992,6 +1010,7 @@ tracing:
     defaultTag: 3.38.0@sha256:7c3505a6702435e2aba88987dbd4795e0f87acc602310df78dcb9581e3ad868f
     # -- Docker image name for the `jaeger` image
     name: "jaeger-all-in-one"
+  name: "jaeger"
   # -- Security context for the `jaeger` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
   containerSecurityContext:
@@ -1068,6 +1087,7 @@ worker:
     runAsUser: 100
     runAsGroup: 101
     readOnlyRootFilesystem: true
+  name: "worker"
   # -- Security context for the `worker` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}


### PR DESCRIPTION
Alternate implementation of https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/94 - sets a default name for all services so that we can easily reference resources.

The second commit updates most resources to use this default name, instead of a hardcoded version. I'm on the fence about how valuable this is.

**Not included**: service names and persistentVolumeClaim names remain hardcoded, instead of referencing the variable. I'm unclear what impact changing a service name would have on Sourcegraph's service discovery (most likely we can work around it by setting environment variables, but it's easier to avoid creating this problem). For PVC's, it seems risky to change the name if it had previously been created.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
No change to rendered output before/after using default values.