### PR TITLE
Convert codeintel-db and codeinsights-db to use secrets for credentials

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -100,9 +100,15 @@ In addition to the documented values, all services also support the following va
 | cadvisor.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `cadvisor` |
 | cadvisor.serviceAccount.name | string | `"cadvisor"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeInsightsDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
+| codeInsightsDB.auth.database | string | `"postgres"` | Sets codeinsights-db database name |
+| codeInsightsDB.auth.existingSecret | string | `""` | Name of existing secret to use for Code Insights credentials The secret must contain the keys `user`, `password`, `database`, `host` and `port`. `auth.user`, `auth.password`, etc. are ignored if this is enabled |
+| codeInsightsDB.auth.host | string | `"codeinsights-db"` | Sets codeinsights-db host |
+| codeInsightsDB.auth.password | string | `"password"` | Sets codeinsights-db password |
+| codeInsightsDB.auth.port | string | `"5432"` | Sets codeinsights-db port |
+| codeInsightsDB.auth.user | string | `"postgres"` | Sets codeinsights-db username |
 | codeInsightsDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":70,"runAsUser":70}` | Security context for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeInsightsDB.enabled | bool | `true` | Enable `codeinsights-db` PostgreSQL server |
-| codeInsightsDB.env | object | `{"POSTGRES_DB":{"value":"postgres"},"POSTGRES_PASSWORD":{"value":"password"},"POSTGRES_USER":{"value":"postgres"}}` | Environment variables for the `codeinsights-db` container |
+| codeInsightsDB.env | object | `{}` | Environment variables for the `codeinsights-db` container |
 | codeInsightsDB.existingConfig | string | `""` | Name of existing ConfigMap for `codeinsights-db`. It must contain a `postgresql.conf` key. |
 | codeInsightsDB.image.defaultTag | string | `"3.38.0@sha256:4f971b00939ebbf7d9d622f40fc84a4fde994c67ebd023ed49ccad066aae2044"` | Docker image tag for the `codeinsights-db` image |
 | codeInsightsDB.image.name | string | `"codeinsights-db"` | Docker image name for the `codeinsights-db` image |
@@ -113,6 +119,12 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeInsightsDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeinsights-db` data volume |
 | codeIntelDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from the [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
+| codeIntelDB.auth.database | string | `"sg"` | Sets codeintel-db database name |
+| codeIntelDB.auth.existingSecret | string | `""` | Name of existing secret to use for CodeIntel credentials The secret must contain the keys `user`, `password`, `database`, `host` and `port`. `auth.user`, `auth.password`, etc. are ignored if this is enabled |
+| codeIntelDB.auth.host | string | `"codeintel-db"` | Sets codeintel-db host |
+| codeIntelDB.auth.password | string | `"password"` | Sets codeintel-db password |
+| codeIntelDB.auth.port | string | `"5432"` | Sets codeintel-db port |
+| codeIntelDB.auth.user | string | `"sg"` | Sets codeintel-db username |
 | codeIntelDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `codeintel-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeIntelDB.enabled | bool | `true` | Enable `codeintel-db` PostgreSQL server |
 | codeIntelDB.existingConfig | string | `""` | Name of existing ConfigMap for `codeintel-db`. It must contain a `postgresql.conf` key |
@@ -120,7 +132,7 @@ In addition to the documented values, all services also support the following va
 | codeIntelDB.image.name | string | `"codeintel-db"` | Docker image name for the `codeintel-db` image |
 | codeIntelDB.name | string | `"codeintel-db"` | Name used by resources. Does not affect service names or PVCs. |
 | codeIntelDB.podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":999}` | Security context for the `codeintel-db` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| codeIntelDB.postgresExporter.env | object | `{"DATA_SOURCE_NAME":{"value":"postgres://sg:@localhost:5432/?sslmode=disable"}}` | Environment variables for the `pgsql-exporter` sidecar container |
+| codeIntelDB.postgresExporter | object | `{}` | Configuration for the `pgsql-exporter` sidecar container |
 | codeIntelDB.resources | object | `{"limits":{"cpu":"4","memory":"4Gi"},"requests":{"cpu":"4","memory":"4Gi"}}` | Resource requests & limits for the `codeintel-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | codeIntelDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeintel-db` |
 | codeIntelDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Secret.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Secret.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.codeInsightsDB.auth.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.codeInsightsDB.name }}-auth
+  labels:
+    app: codeinsights-db
+    deploy: sourcegraph
+    app.kubernetes.io/component: codeinsights-db
+type: Opaque
+data:
+  database: {{ .Values.codeInsightsDB.auth.database | toString | b64enc | quote }}
+  host: {{ .Values.codeInsightsDB.auth.host | toString | b64enc | quote }}
+  password: {{ .Values.codeInsightsDB.auth.password | toString | b64enc | quote }}
+  port: {{ .Values.codeInsightsDB.auth.port | toString | b64enc | quote }}
+  user: {{ .Values.codeInsightsDB.auth.user | toString | b64enc | quote }}
+{{- end -}}

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -24,6 +24,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: codeinsights
+        checksum/codeinsights-db.secret: {{ include (print $.Template.BasePath "/codeinsights-db/codeinsights-db.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}
@@ -51,6 +52,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
         env:
+        {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "POSTGRES_") | nindent 8 }}
+        - name: POSTGRES_DB
+          value: $(POSTGRES_DATABASE)
         {{- range $name, $item := .Values.codeInsightsDB.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.Secret.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.Secret.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.codeIntelDB.auth.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.codeIntelDB.name }}-auth
+  labels:
+    app: codeintel-db
+    deploy: sourcegraph
+    app.kubernetes.io/component: codeintel-db
+type: Opaque
+data:
+  database: {{ .Values.codeIntelDB.auth.database | toString | b64enc | quote }}
+  host: {{ .Values.codeIntelDB.auth.host | toString | b64enc | quote }}
+  password: {{ .Values.codeIntelDB.auth.password | toString | b64enc | quote }}
+  port: {{ .Values.codeIntelDB.auth.port | toString | b64enc | quote }}
+  user: {{ .Values.codeIntelDB.auth.user | toString | b64enc | quote }}
+{{- end -}}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.Service.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.Service.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- if .Values.codeIntelDB.serviceLabels }}
       {{- toYaml .Values.codeIntelDB.serviceLabels | nindent 4 }}
     {{- end }}
-  name: {{ default "codeintel-db" .Values.codeIntelDB.name }}
+  name: codeintel-db
 spec:
   ports:
   - name: pgsql

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -24,6 +24,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: pgsql
+        checksum/codeintel-db.secret: {{ include (print $.Template.BasePath "/codeintel-db/codeintel-db.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}
@@ -66,6 +67,9 @@ spec:
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         env:
+        {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "POSTGRES_") | nindent 8 }}
+        - name: POSTGRES_DB
+          value: $(POSTGRES_DATABASE)
         {{- range $name, $item := .Values.codeIntelDB.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}
@@ -102,6 +106,7 @@ spec:
         {{- toYaml .Values.codeIntelDB.extraContainers | nindent 6 }}
       {{- end }}
       - env:
+        {{- include "sourcegraph.dataSource" (list . "codeIntelDB" ) | nindent 8 }}
         {{- range $name, $item := .Values.codeIntelDB.postgresExporter.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -30,6 +30,8 @@ spec:
         kubectl.kubernetes.io/default-container: frontend
         checksum/minio.secret: {{ include (print $.Template.BasePath "/minio/minio.Secret.yaml") . | sha256sum }}
         checksum/pgsql.secret: {{ include (print $.Template.BasePath "/pgsql/pgsql.Secret.yaml") . | sha256sum }}
+        checksum/codeintel-db.secret: {{ include (print $.Template.BasePath "/codeintel-db/codeintel-db.Secret.yaml") . | sha256sum }}
+        checksum/codeinsights-db.secret: {{ include (print $.Template.BasePath "/codeinsights-db/codeinsights-db.Secret.yaml") . | sha256sum }}
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}
@@ -55,6 +57,8 @@ spec:
         args: {{- default (list "up") .Values.migrator.args | toYaml | nindent 8 }}
         env:
         {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
+        {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "CODEINTEL_PG") | nindent 8 }}
+        {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "CODEINSIGHTS_PG") | nindent 8 }}
         {{- range $name, $item := .Values.frontend.env }}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}
@@ -79,6 +83,8 @@ spec:
           {{- $item | toYaml | nindent 10 }}
         {{- end }}
         {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
+        {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "CODEINTEL_PG") | nindent 8 }}
+        {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "CODEINSIGHTS_PG") | nindent 8 }}
         # POD_NAME is used by CACHE_DIR
         - name: POD_NAME
           valueFrom:

--- a/charts/sourcegraph/templates/pgsql/pgsql.Secret.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: pgsql-auth
+  name: {{ .Values.pgsql.name }}-auth
   labels:
     app: pgsql
     deploy: sourcegraph
@@ -12,6 +12,6 @@ data:
   database: {{ .Values.pgsql.auth.database | toString | b64enc | quote }}
   host: {{ .Values.pgsql.auth.host | toString | b64enc | quote }}
   password: {{ .Values.pgsql.auth.password | toString | b64enc | quote }}
-  user: {{ .Values.pgsql.auth.user | toString | b64enc | quote }}
   port: {{ .Values.pgsql.auth.port | toString | b64enc | quote }}
+  user: {{ .Values.pgsql.auth.user | toString | b64enc | quote }}
 {{- end -}}

--- a/charts/sourcegraph/tests/affinity_test.yaml
+++ b/charts/sourcegraph/tests/affinity_test.yaml
@@ -2,6 +2,8 @@ suite: affinity
 templates:
 - minio/minio.Secret.yaml
 - pgsql/pgsql.Secret.yaml
+- codeintel-db/codeintel-db.Secret.yaml
+- codeinsights-db/codeinsights-db.Secret.yaml
 - frontend/sourcegraph-frontend.Deployment.yaml
 release:
   name: sourcegraph

--- a/charts/sourcegraph/tests/localDevMode_test.yaml
+++ b/charts/sourcegraph/tests/localDevMode_test.yaml
@@ -2,6 +2,8 @@ suite: localDevMode
 templates:
   - minio/minio.Secret.yaml
   - pgsql/pgsql.Secret.yaml
+  - codeintel-db/codeintel-db.Secret.yaml
+  - codeinsights-db/codeinsights-db.Secret.yaml
   - frontend/sourcegraph-frontend.Deployment.yaml
 tests:
   - it: should not have a resource block when localDevMode=true

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -138,14 +138,23 @@ cadvisor:
 codeInsightsDB:
   # -- Enable `codeinsights-db` PostgreSQL server
   enabled: true
+  auth:
+    # -- Name of existing secret to use for Code Insights credentials
+    # The secret must contain the keys `user`, `password`, `database`, `host` and `port`.
+    # `auth.user`, `auth.password`, etc. are ignored if this is enabled
+    existingSecret: ""
+    # -- Sets codeinsights-db database name
+    database: "postgres"
+    # -- Sets codeinsights-db host
+    host: "codeinsights-db"
+    # -- Sets codeinsights-db username
+    user: "postgres"
+    # -- Sets codeinsights-db password
+    password: "password"
+    # -- Sets codeinsights-db port
+    port: "5432"
   # -- Environment variables for the `codeinsights-db` container
-  env:
-    POSTGRES_DB:
-      value: postgres
-    POSTGRES_PASSWORD: # Accessible by Sourcegraph applications on the network only, so password auth is not used.
-      value: password
-    POSTGRES_USER:
-      value: postgres
+  env: {}
   # -- Name of existing ConfigMap for `codeinsights-db`. It must contain a `postgresql.conf` key.
   existingConfig: "" # Name of an existing configmap
   # -- Additional PostgreSQL configuration. This will override or extend our default configuration.
@@ -192,6 +201,21 @@ codeInsightsDB:
 codeIntelDB:
   # -- Enable `codeintel-db` PostgreSQL server
   enabled: true
+  auth:
+    # -- Name of existing secret to use for CodeIntel credentials
+    # The secret must contain the keys `user`, `password`, `database`, `host` and `port`.
+    # `auth.user`, `auth.password`, etc. are ignored if this is enabled
+    existingSecret: ""
+    # -- Sets codeintel-db database name
+    database: "sg"
+    # -- Sets codeintel-db host
+    host: "codeintel-db"
+    # -- Sets codeintel-db username
+    user: "sg"
+    # -- Sets codeintel-db password
+    password: "password"
+    # -- Sets codeintel-db port
+    port: "5432"
   # -- Name of existing ConfigMap for `codeintel-db`. It must contain a `postgresql.conf` key
   existingConfig: ""
   # -- Additional PostgreSQL configuration. This will override or extend our default configuration.
@@ -210,11 +234,8 @@ codeIntelDB:
     runAsUser: 999
     runAsGroup: 999
     readOnlyRootFilesystem: true
-  postgresExporter:
-    # -- Environment variables for the `pgsql-exporter` sidecar container
-    env:
-      DATA_SOURCE_NAME:
-        value: postgres://sg:@localhost:5432/?sslmode=disable
+  # -- Configuration for the `pgsql-exporter` sidecar container
+  postgresExporter: {}
   # -- Name used by resources. Does not affect service names or PVCs.
   name: "codeintel-db"
   # -- Resource requests & limits for the `codeintel-db` container,
@@ -244,18 +265,6 @@ frontend:
   # -- Environment variables for the `frontend` container
   # @default -- the chart will add some default environment values
   env:
-    CODEINSIGHTS_PGDATASOURCE:
-      value: postgres://postgres:password@codeinsights-db:5432/postgres
-    CODEINTEL_PGDATABASE:
-      value: sg
-    CODEINTEL_PGHOST:
-      value: codeintel-db
-    CODEINTEL_PGPORT:
-      value: "5432"
-    CODEINTEL_PGSSLMODE:
-      value: disable
-    CODEINTEL_PGUSER:
-      value: sg
     DEPLOY_TYPE:
       value: helm
     GRAFANA_SERVER_URL:


### PR DESCRIPTION
Same as https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/86, but for codeintel / codeinsights.

**Note**: customizing the database name for codeinsights doesn't work with the 3.38 images, but it will work with 3.39 when we swap over to the pgsql docker container.

There will be a separate PR to update the migrator chart.

### Checklist

- [X] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Tested with default values, custom values for all, and providing a secret. Upgrade from previous version worked without a problem.