### PR TITLE
Update migrator chart to reference database secrets

### DIFF
--- a/charts/sourcegraph-migrator/README.md
+++ b/charts/sourcegraph-migrator/README.md
@@ -28,9 +28,9 @@ helm repo add sourcegraph https://sourcegraph.github.io/deploy-sourcegraph-helm/
 
 ## Usage
 
-> If you are not using external databases, the chart has to be installed in the same namespace as the parent [sourcegraph/sourcegraph] chart
+> The chart has to be installed in the same namespace as the parent [sourcegraph/sourcegraph] chart
 
-[sourcegraph/sourcegraph-migrator] chart requires the correct `PG*`, `CODEINTEL_PG*`, and `CODEINSIGHTS_PG*` environment variables to be configured at `migrator.env`. Learn more about [using your own PostgreSQL server]. `PG*` and `CODEINTEL_PG*` environment variables are compatible with the `frontend.env` values from the parent [sourcegraph/sourcegraph] chart.
+By default, the [sourcegraph/sourcegraph-migrator] chart references database credentials from a Kubernetes `Secret` created by the parent [sourcegraph/sourcegraph] chart. If you provide your own `Secret` resources, update the `codeInsightsDB.auth.existingSecret`, `codeIntelDB.auth.existingSecret` and `pgsql.auth.existingSecret` settings in values.yaml to match. Learn more about [using your own PostgreSQL server].
 
 You should consult the list of available [migrator commands]. Below is some example usage.
 
@@ -73,12 +73,18 @@ In addition to the documented values, the `migrator` service also supports the f
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| codeInsightsDB.auth.existingSecret | string | `""` | Name of existing secret to use for codeinsights-db credentials This should match the setting in the sourcegraph chart values |
+| codeInsightsDB.name | string | `"codeinsights-db"` |  |
+| codeIntelDB.auth.existingSecret | string | `""` | Name of existing secret to use for codeintel-db credentials This should match the setting in the sourcegraph chart values |
+| codeIntelDB.name | string | `"codeintel-db"` |  |
 | migrator.args | list | `["up","-db=all"]` | Override default `migrator` container args Available commands can be found at https://docs.sourcegraph.com/admin/how-to/manual_database_migrations |
 | migrator.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `migrator` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
-| migrator.env | object | the chart will add some default environment values | Environment variables for the `migrator` container |
-| migrator.image.defaultTag | string | `"3.37.0@sha256:404df69cfee90eaa9a3ab8b540a2d9affd22605caa5326a8ac4ba016e1d6d815"` | Docker image tag for the `migrator` image |
+| migrator.env | object | `{}` | Environment variables for the `migrator` container |
+| migrator.image.defaultTag | string | `"3.38.0@sha256:16b3cebb1447fce75a8cb3acd6b6640294c70ab96adbfbcbc8da565ffffc5a4e"` | Docker image tag for the `migrator` image |
 | migrator.image.name | string | `"migrator"` | Docker image name for the `migrator` image |
 | migrator.resources | object | `{"limits":{"cpu":"500m","memory":"100M"},"requests":{"cpu":"100m","memory":"50M"}}` | Resource requests & limits for the `migrator` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| pgsql.auth.existingSecret | string | `""` | Name of existing secret to use for pgsql credentials This should match the setting in the sourcegraph chart values |
+| pgsql.name | string | `"pgsql"` |  |
 | sourcegraph.affinity | object | `{}` | Affinity, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | sourcegraph.image.defaultTag | string | `"{{ .Chart.AppVersion }}"` | Global docker image tag |
 | sourcegraph.image.pullPolicy | string | `"IfNotPresent"` | Global docker image pull policy |

--- a/charts/sourcegraph-migrator/README.md.gotmpl
+++ b/charts/sourcegraph-migrator/README.md.gotmpl
@@ -1,6 +1,6 @@
-<!-- 
-  DO NOT EDIT README.md directly. 
-  README.md is automatically generated from README.md.gotmpl 
+<!--
+  DO NOT EDIT README.md directly.
+  README.md is automatically generated from README.md.gotmpl
 -->
 
 # Sourcegraph Migrator Helm Chart
@@ -28,9 +28,9 @@ helm repo add sourcegraph https://sourcegraph.github.io/deploy-sourcegraph-helm/
 
 ## Usage
 
-> If you are not using external databases, the chart has to be installed in the same namespace as the parent [sourcegraph/sourcegraph] chart
+> The chart has to be installed in the same namespace as the parent [sourcegraph/sourcegraph] chart
 
-[sourcegraph/sourcegraph-migrator] chart requires the correct `PG*`, `CODEINTEL_PG*`, and `CODEINSIGHTS_PG*` environment variables to be configured at `migrator.env`. Learn more about [using your own PostgreSQL server]. `PG*` and `CODEINTEL_PG*` environment variables are compatible with the `frontend.env` values from the parent [sourcegraph/sourcegraph] chart.
+By default, the [sourcegraph/sourcegraph-migrator] chart references database credentials from a Kubernetes `Secret` created by the parent [sourcegraph/sourcegraph] chart. If you provide your own `Secret` resources, update the `codeInsightsDB.auth.existingSecret`, `codeIntelDB.auth.existingSecret` and `pgsql.auth.existingSecret` settings in values.yaml to match. Learn more about [using your own PostgreSQL server].
 
 You should consult the list of available [migrator commands]. Below is some example usage.
 

--- a/charts/sourcegraph-migrator/templates/_helpers.tpl
+++ b/charts/sourcegraph-migrator/templates/_helpers.tpl
@@ -58,3 +58,37 @@ useGlobalTagAsDefault configuration
 
 {{- $top.Values.sourcegraph.image.repository }}/{{ $imageName }}:{{ default $defaultTag (index $top.Values $service "image" "tag") }}
 {{- end }}
+
+{{- define "sourcegraph.databaseAuth" -}}
+{{- $top := index . 0 -}}
+{{- $service := index . 1 -}}
+{{- $prefix := index . 2 -}}
+{{- $secretName := (index $top.Values $service "name") -}}
+{{- $secretName := printf "%s-auth" $secretName -}}
+{{- if (index $top.Values $service "auth" "existingSecret") }}{{- $secretName = (index $top.Values $service "auth" "existingSecret") }}{{- end -}}
+- name: {{ printf "%sDATABASE" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: database
+      name: {{ $secretName }}
+- name: {{ printf "%sHOST" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: host
+      name: {{ $secretName }}
+- name: {{ printf "%sPASSWORD" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: password
+      name: {{ $secretName }}
+- name: {{ printf "%sPORT" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: port
+      name: {{ $secretName }}
+- name: {{ printf "%sUSER" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: user
+      name: {{ $secretName }}
+{{- end }}

--- a/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
+++ b/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
@@ -40,6 +40,9 @@ spec:
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         args: {{- default (list "up") .Values.migrator.args | toYaml | nindent 8 }}
         env:
+        {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
+        {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "CODEINTEL_PG") | nindent 8 }}
+        {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "CODEINSIGHTS_PG") | nindent 8 }}
         {{- range $name, $item := .Values.migrator.env }}
         - name: {{ $name }}
         {{- $item | toYaml | nindent 10 }}

--- a/charts/sourcegraph-migrator/values.yaml
+++ b/charts/sourcegraph-migrator/values.yaml
@@ -78,33 +78,35 @@ sourcegraph:
 #   # Toggle deployment of applications on/off. Applies to databases and third-party applications
 #   enabled: true
 
+codeInsightsDB:
+  name: "codeinsights-db"
+  auth:
+    # -- Name of existing secret to use for codeinsights-db credentials
+    # This should match the setting in the sourcegraph chart values
+    existingSecret: ""
+
+codeIntelDB:
+  name: "codeintel-db"
+  auth:
+    # -- Name of existing secret to use for codeintel-db credentials
+    # This should match the setting in the sourcegraph chart values
+    existingSecret: ""
+
+pgsql:
+  name: "pgsql"
+  auth:
+    # -- Name of existing secret to use for pgsql credentials
+    # This should match the setting in the sourcegraph chart values
+    existingSecret: ""
+
 migrator:
   image:
     # -- Docker image tag for the `migrator` image
-    defaultTag: 3.37.0@sha256:404df69cfee90eaa9a3ab8b540a2d9affd22605caa5326a8ac4ba016e1d6d815
+    defaultTag: 3.38.0@sha256:16b3cebb1447fce75a8cb3acd6b6640294c70ab96adbfbcbc8da565ffffc5a4e
     # -- Docker image name for the `migrator` image
     name: "migrator"
   # -- Environment variables for the `migrator` container
-  # @default -- the chart will add some default environment values
-  env:
-    CODEINSIGHTS_PGDATASOURCE:
-      value: postgres://postgres:password@codeinsights-db:5432/postgres
-    CODEINTEL_PGDATABASE:
-      value: sg
-    CODEINTEL_PGHOST:
-      value: codeintel-db
-    CODEINTEL_PGPORT:
-      value: "5432"
-    CODEINTEL_PGSSLMODE:
-      value: disable
-    CODEINTEL_PGUSER:
-      value: sg
-    PGDATABASE:
-      value: sg
-    PGHOST:
-      value: pgsql
-    PGUSER:
-      value: sg
+  env: {}
   # -- Resource requests & limits for the `migrator` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:


### PR DESCRIPTION
Updates the migrator chart to use the same secret references as #86, #98.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Rendered manifest matches the migrator structure from the parent chart.