### PR TITLE
Add insiders release

### DIFF
--- a/.github/workflows/chart_publish_insiders.yml
+++ b/.github/workflows/chart_publish_insiders.yml
@@ -1,9 +1,9 @@
-name: Release Charts
+name: Release Charts (Insiders)
 
 on:
   push:
     branches:
-      - release/**
+      - main
 
 jobs:
   release:
@@ -23,8 +23,21 @@ jobs:
         uses: azure/setup-helm@v1
         with:
           version: v3.8.0
+      
+      - name: Get metadata
+        id: metadata
+        uses: contiamo/git-metadata-action@main
+
+      - run: |
+          sed -i 's/appVersion:.*/appVersion: insiders/g' charts/*/Chart.yaml
+          sed -i '/^version:/ s/$/-insiders.${{ steps.metadata.outputs.shortSHA }}/' charts/*/Chart.yaml
+
+          # hack: otherwise chart-releaser will fail because we nest index.yaml inside the `insiders` directory
+          mkdir -p insiders
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0
         env:
           CR_TOKEN: "${{ secrets.CR_PUBLISH_TOKEN }}"
+        with:
+          config: ./insiders-config.yaml

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,11 +4,13 @@
 
 Hotfixes not associated with a Sourcegraph release may be released by following the below process:
 
-## 1. Commit the hotfix against the main branch
+## Howfix release
+
+### 1. Commit the hotfix against the main branch
 
 Follow the normal PR and testing process.
 
-## 2. Create a new `publish-x.y.z-rev.a` branch off the last `release/x.y` branch
+### 2. Create a new `publish-x.y.z-rev.a` branch off the last `release/x.y` branch
 
 Hotfix releases will use a suffix to indicate they are a special type of release. This is necessary because semver only supports patch-level versioning, and we cannot overwrite a published version.
 
@@ -16,13 +18,20 @@ The version should look similar to `3.38.1-rev.1`.
 
 Cherry-pick the change from step 1 to this branch and follow the normal testing process to confirm an upgrade from the released version is safe.
 
-## 3. Bump the `version` in `Chart.yaml` and update changelog
+### 3. Bump the `version` in `Chart.yaml` and update changelog
 
 Update Chart.yaml to use the new version. Update the Changelog to reflect the new version.
 
-## 3. Create a Pull Request
+### 3. Create a Pull Request
 
 Commit all changes and open a Pull Request. The destination branch for your PR should be `release/x.y`, not main.
+
+## Insiders release
+
+Whenever a change is merged onto the `main` branch, GitHub Actions will release an insiders release. The insiders release will have the following convention
+
+- `version`: suffix with `-insiders.<shortSha>`, e.g. `0.7.0-insiders.67ec611`
+- `appVersion`: it will always be `insiders`
 
 [semver]: https://semver.org/
 [sourcegraph release]: https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/releases/

--- a/insiders-config.yaml
+++ b/insiders-config.yaml
@@ -1,0 +1,4 @@
+owner: sourcegraph
+git-repo: deploy-sourcegraph-helm
+index-path: insiders/index.yaml
+pages-index-path: insiders/index.yaml


### PR DESCRIPTION
This is currently live at https://github.com/sourcegraph/deploy-sourcegraph-helm-fork/tree/gh-pages/insiders

try it out

```sh
helm repo add sg-fork-nightly https://sourcegraph.github.io/deploy-sourcegraph-helm-fork/insiders
helm search repo -l sg-fork --devel
```

## Notes

Ideally, we want to publish insiders build in a different git repo, but it's currently not possible with `chart-releaser`. Its implementation does not respect the configured `git-repo` and `owner` when interacting with `index.yaml` in `cr index`, these two flags are only used during the `cr upload` process.

Also, prior to merging this PR, we need to manually upload the initial `index.yaml`. I think something must change recently and caused such weird behaviour. Follow the step below

```sh
cr package charts/sourcegraph --config insiders-config.yaml
cr package charts/sourcegraph-migrator --config insiders-config.yaml
export CR_TOKEN="<GH_TOKEN>" # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=7s46bqcnl5hxzbutupu44va7gu&h=team-sourcegraph.1password.com
cr upload --config insiders-config.yaml
mkdir -p insiders
cr index --config insiders-config.yaml
```

Manually upload the `insiders/index.yaml` to the `gh-pages` branch.

## More notes

I really don't like this approach and feel really hacky to me. Also, the release page is not pretty https://github.com/sourcegraph/deploy-sourcegraph-helm-fork/releases

An alternative would be moving the chart repo to a GCS bucket, and we can just copy and paste whatever linked is doing

- https://github.com/linkerd/linkerd2/blob/main/.github/workflows/release.yml#L353
- https://github.com/linkerd/linkerd2/blob/main/.github/actions/helm-publish/action.yml

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

see pr description