### PR TITLE
Add pgsql exporter to codeinsights

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -52,6 +52,7 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.image.name | string | `"codeinsights-db"` | Docker image name for the `codeinsights-db` image |
 | codeInsightsDB.name | string | `"codeinsights-db"` | Name used by resources. Does not affect service names or PVCs. |
 | codeInsightsDB.podSecurityContext | object | `{"fsGroup":70,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":70}` | Security context for the `codeinsights-db` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| codeInsightsDB.postgresExporter | object | `{}` | Configuration for the `pgsql-exporter` sidecar container |
 | codeInsightsDB.resources | object | `{"limits":{"cpu":"4","memory":"2Gi"},"requests":{"cpu":"4","memory":"2Gi"}}` | Resource requests & limits for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | codeInsightsDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeinsights-db` |
 | codeInsightsDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -83,6 +83,21 @@ spec:
         {{- if .Values.codeInsightsDB.extraVolumeMounts }}
         {{- toYaml .Values.codeInsightsDB.extraVolumeMounts | nindent 8 }}
         {{- end }}
+      - env:
+        {{- include "sourcegraph.dataSource" (list . "codeInsightsDB" ) | nindent 8 }}
+        {{- range $name, $item := .Values.codeInsightsDB.postgresExporter.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
+        - name: PG_EXPORTER_EXTEND_QUERY_PATH
+          value: /config/code_insights_queries.yaml
+        image: {{ include "sourcegraph.image" (list . "postgresExporter") }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        name: pgsql-exporter
+        {{- if not .Values.sourcegraph.localDevMode }}
+        resources:
+          {{- toYaml .Values.postgresExporter.resources | nindent 10 }}
+        {{- end }}
       {{- if .Values.codeInsightsDB.extraContainers }}
         {{- toYaml .Values.codeInsightsDB.extraContainers | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -173,6 +173,8 @@ codeInsightsDB:
     runAsUser: 70
     runAsGroup: 70
     readOnlyRootFilesystem: true
+  # -- Configuration for the `pgsql-exporter` sidecar container
+  postgresExporter: {}
   # -- Name used by resources. Does not affect service names or PVCs.
   name: "codeinsights-db"
   # -- Resource requests & limits for the `codeinsights-db` container,


### PR DESCRIPTION
Enable exporter on code insights. Won't actually collect metrics until the 3.39 release switches the codeinsights db to postgres.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Confirmed metrics are ingested on Grafana dashboard