### PR TITLE
Add initContainer to codeinsights-db

### DIFF
--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -43,6 +43,20 @@ spec:
         app: codeinsights-db
         group: backend
     spec:
+      initContainers:
+      - name: correct-data-dir-permissions
+        image: {{ include "sourcegraph.image" (list . "alpine") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        command: ["sh", "-c", "if [ -d /var/lib/postgresql/data/pgdata ]; then chmod 750 /var/lib/postgresql/data/pgdata; fi"]
+        volumeMounts:
+        - mountPath: /data
+          name: disk
+        securityContext:
+        {{- toYaml .Values.alpine.containerSecurityContext | nindent 10 }}
+        {{- if not .Values.sourcegraph.localDevMode }}
+        resources:
+          {{- toYaml .Values.alpine.resources | nindent 10 }}
+        {{- end }}
       containers:
       - name: codeinsights
         image: {{ include "sourcegraph.image" (list . "codeInsightsDB") }}


### PR DESCRIPTION
Adds the same initContainer from https://github.com/sourcegraph/deploy-sourcegraph/pull/4115 to codeinsights-db. This doesn't seem necessary for pure helm installs but should reduce friction when migrating from kustomize.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Upgraded from previous version to current version.