### PR TITLE
Set public url when pushing to GCS

### DIFF
--- a/.github/workflows/gcs_chart_publish_insiders.yml
+++ b/.github/workflows/gcs_chart_publish_insiders.yml
@@ -62,6 +62,6 @@ jobs:
             if gsutil ls gs://${{ env.BUCKET_NAME }}/${{ env.BUCKET_PATH }}/$i 2>/dev/null; then
               echo "Chart already published"
             else
-              helm gcs push $i sg
+              helm gcs push --public --publicUrl https://${{ env.BUCKET_NAME }}/${{ env.BUCKET_PATH }} $i sg
             fi;
           done

--- a/.github/workflows/gcs_chart_publish_release.yml
+++ b/.github/workflows/gcs_chart_publish_release.yml
@@ -53,6 +53,6 @@ jobs:
             if gsutil ls gs://${{ env.BUCKET_NAME }}/${{ env.BUCKET_PATH }}/$i 2>/dev/null; then
               echo "Chart already published"
             else
-              helm gcs push $i sg
+              helm gcs push --public --publicUrl https://${{ env.BUCKET_NAME }}/${{ env.BUCKET_PATH }} $i sg
             fi;
           done


### PR DESCRIPTION
By default, helm-gcs uses `gs://<bucket name>` as the public URL for the index.yaml, and downloading the chart requires installing the helm-gcs plugin.

To avoid adding this dependency (and actually use Cloudflare), configure the https public url during pushes.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
helm chart install succeeds without the helm-gcs plugin.