### PR TITLE
Add quotes to chart version replacement

### DIFF
--- a/.github/workflows/gcs_chart_publish_insiders.yml
+++ b/.github/workflows/gcs_chart_publish_insiders.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Update chart versions
         run: |
           sed -i 's/appVersion:.*/appVersion: insiders/g' charts/*/Chart.yaml
-          sed -i '/^version:/ s/$/-insiders.${{ steps.metadata.outputs.shortSHA }}/' charts/*/Chart.yaml
+          sed -i '/^version:/ s/"$/-insiders.${{ steps.metadata.outputs.shortSHA }}"/' charts/*/Chart.yaml
 
       - name: Package helm charts
         run: for i in charts/*; do helm package -u $i; done


### PR DESCRIPTION
The release batch change added quotes around the chart version, so the sed used for insiders releases no longer works.

Probably this could be done in a more elegant / graceful way but adding the quotes is pretty easy to unblock us for now.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Chart publish should work this time