### PR TITLE
Fixed creation frontend rolebinding when privileged is false

### DIFF
--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.frontend.privileged -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -21,3 +22,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "sourcegraph.serviceAccountName" (list . "frontend") }}
   namespace: {{ .Release.Namespace }}
+{{ end }}


### PR DESCRIPTION
### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

I have K8s cluster which I'm using as a client without some permissions like "Creating RoleBindings". I found that prometheus, when you using 
```
prometheus:
    privileged: false
```
doesn't create roleBindings and it's working perfectly. So I did same for frontend part of chart and everything works perfectly on my own dev cluster and deployed on staging, so I can use sourcegraph without any troubles with my changes. 
