### PR TITLE
fix: cadvisor can pickup oom events

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -6,6 +6,10 @@ Use `**BREAKING**:` to denote a breaking change
 
 All notable changes to Sourcegraph are documented in this file.
 
+### Changed
+
+- **IMPORTANT** `cadvisor` can collect out of memory events happening to containers and it can be used to discover underprovisoned resources. As a result, `cadvisor` now has to run in `privileged` mode. If you have your own monitoring infrastructure, you may choose to disable `cadvisor` or set `cadvisor.containerSecurityContext.privileged=false` in your override file. [#121](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/121)
+
 <!-- START CHANGELOG -->
 
 ## 3.39.1

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- **IMPORTANT** `cadvisor` can collect out of memory events happening to containers and it can be used to discover underprovisoned resources. As a result, `cadvisor` now has to run in `privileged` mode. If you have your own monitoring infrastructure, you may choose to disable `cadvisor` or set `cadvisor.containerSecurityContext.privileged=false` in your override file. [#121](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/121)
+- **IMPORTANT** `cadvisor` now defaults to run in `privileged` mode. This allows `cadvisor` to collect out of memory events happening to containers which can be used to discover underprovisoned resources. If you have your own monitoring infrastructure, you may choose to disable `cadvisor` or set `cadvisor.containerSecurityContext.privileged=false` in your override file. [#121](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/121)
 
 <!-- START CHANGELOG -->
 

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -29,6 +29,7 @@ In addition to the documented values, all services also support the following va
 | alpine.image.defaultTag | string | `"3.39.1@sha256:66b1e40aede9860c7e7e570aca6a41e551db33f44b944ce102bc5b658b1be5a6"` | Docker image tag for the `alpine` image |
 | alpine.image.name | string | `"alpine-3.12"` | Docker image name for the `alpine` image |
 | alpine.resources | object | `{"limits":{"cpu":"10m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Resource requests & limits for the `alpine` initContainer, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| cadvisor.containerSecurityContext | object | `{"privileged":true}` | Security context for the `cadvisor` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | cadvisor.enabled | bool | `true` | Enable `cadvisor` |
 | cadvisor.image.defaultTag | string | `"3.39.1@sha256:e3d69d30b16629f7e3fa3b6d6a3a8270e3beec389b02b1cc36c8d4c43b06876b"` | Docker image tag for the `cadvisor` image |
 | cadvisor.image.name | string | `"cadvisor"` | Docker image name for the `cadvisor` image |

--- a/charts/sourcegraph/templates/NOTES.txt
+++ b/charts/sourcegraph/templates/NOTES.txt
@@ -18,3 +18,14 @@ Provisioning metrics can be restored by assigning elevated permissions to Servic
 Consult https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml for the necessary permissions.
 
 {{- end }}
+
+{{- if not .Values.cadvisor.containerSecurityContext.privileged }}
+🚧 Warning 🚧
+
+You have set 'cadvisor.containerSecurityContext.privileged' to 'false' and cadvisor will run with reduced privileges.
+Our observability stack requires to be run in privileged mode to display a provisioning metric, out of memory events.
+Such metric provides critical information to help you scale the Sourcegraph deployment.
+If you would like to bring your own infrastructure monitoring & alerting solution,
+you may want to disable the `cadvisor` DaemonSet completely by setting `cadvisor.enabled=false` in your override file.
+
+{{- end }}

--- a/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml
@@ -82,6 +82,11 @@ spec:
         - name: disk
           mountPath: /dev/disk
           readOnly: true
+        {{- if .Values.cadvisor.containerSecurityContext.privileged }}
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
+        {{- end }}
         {{- if .Values.cadvisor.extraVolumeMounts }}
         {{- toYaml .Values.cadvisor.extraVolumeMounts | nindent 8 }}
         {{- end }}
@@ -119,6 +124,11 @@ spec:
       - name: disk
         hostPath:
           path: /dev/disk
+      {{- if .Values.cadvisor.containerSecurityContext.privileged }}
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
+      {{- end }}
       {{- if .Values.cadvisor.extraVolumes }}
       {{- toYaml .Values.cadvisor.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/tests/cadvisorPrivileged_test.yaml
+++ b/charts/sourcegraph/tests/cadvisorPrivileged_test.yaml
@@ -1,0 +1,63 @@
+suite: cadvisorPrivileged
+templates:
+  - NOTES.txt
+  - cadvisor/cadvisor.DaemonSet.yaml
+tests:
+  - it: should not have the warning text when cadvisor.containerSecurityContext.privileged=true
+    set:
+      cadvisor:
+        containerSecurityContext:
+          privileged: true
+    asserts:
+      - notMatchRegexRaw:
+          pattern: You have set 'cadvisor.containerSecurityContext.privileged' to 'false'
+        template: NOTES.txt
+  - it: should have the warning text when prometheus.privileged=false
+    set:
+      cadvisor:
+        containerSecurityContext:
+          privileged: false
+    asserts:
+      - matchRegexRaw:
+          pattern: You have set 'cadvisor.containerSecurityContext.privileged' to 'false'
+        template: NOTES.txt
+  - it: should render /dev/kmsg in volumes and volumeMounts when cadvisor.containerSecurityContext.privileged=true
+    set:
+      cadvisor:
+        containerSecurityContext:
+          privileged: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: kmsg
+            hostPath:
+              path: /dev/kmsg
+        template: cadvisor/cadvisor.DaemonSet.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: kmsg
+            mountPath: /dev/kmsg
+            readOnly: true
+        template: cadvisor/cadvisor.DaemonSet.yaml
+  - it: should not render /dev/kmsg in volumes and volumeMounts when cadvisor.containerSecurityContext.privileged=false
+    set:
+      cadvisor:
+        containerSecurityContext:
+          privileged: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: kmsg
+            hostPath:
+              path: /dev/kmsg
+        template: cadvisor/cadvisor.DaemonSet.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: kmsg
+            mountPath: /dev/kmsg
+            readOnly: true
+        template: cadvisor/cadvisor.DaemonSet.yaml

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -134,6 +134,18 @@ cadvisor:
     create: true
     # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: cadvisor
+  # -- Security context for the `cadvisor` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  containerSecurityContext:
+    # You may set `privileged` to `false and `cadvisor` will run with reduced privileges.
+    # `cadvisor` requires root privileges in order to display provisioning metrics.
+    # These metrics provide critical information to help you scale the Sourcegraph deployment.
+    # If you would like to bring your own infrastructure monitoring & alerting solution,
+    # you may want to disable the `cadvisor` DaemonSet completely
+    # by setting `cadvisor.enabled=false` in your override file
+    # You may also run `cadvisor` with reduced privileges by setting
+    # `cadvisor.containerSecurityContext.privileged=false` in your override file
+    privileged: true
 
 codeInsightsDB:
   # -- Enable `codeinsights-db` PostgreSQL server


### PR DESCRIPTION
Follow up https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/804

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->


tested on a live gke cluster

deploy sourcegraph as usual

deploy a stress test pod
```sh
apiVersion: v1
kind: Pod
metadata:
  name: stress
  namespace: sourcegraph
spec:
  containers:
    - name: stress
      image: progrium/stress
      command:
        - sleep
        - infinity
      resources:
        requests:
          memory: 100Mi
        limits:
          memory: 128Mi
```

exec into the pod and run
```sh
stress --cpu 1 --vm-bytes 300M --timeout 10s
```

oom events show up as expected

![CleanShot 2022-05-05 at 15 48 49](https://user-images.githubusercontent.com/8373004/167040740-0a8ce23e-7bcd-4b39-a66a-a1593fcd88ac.png)
