### PR TITLE
WIP: Ci integration tests

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -33,7 +33,8 @@ steps:
       - "[[ -z $(git status -s) ]]"
     agents: { queue: standard }
 
-  - label: ":merge: Helm Integration"
+  - label: ":jigsaw: Helm Integration"
     commands:
-      - "which kind"
+      - "./scripts/ci/install-helm-env.sh"
+      - "./scripts/ci/helm-integration.sh" 
     agents: { queue: standard }

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -35,6 +35,6 @@ steps:
 
   - label: ":jigsaw: Helm Integration"
     commands:
-      - "./scripts/ci/install-helm-env.sh"
+      #      - "./scripts/ci/install-helm-env.sh"
       - "./scripts/ci/helm-integration.sh" 
     agents: { queue: standard }

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -37,4 +37,4 @@ steps:
     commands:
       #      - "./scripts/ci/install-helm-env.sh"
       - "./scripts/ci/helm-integration.sh" 
-    agents: { queue: standard }
+    agents: { queue: baremetal }

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -37,4 +37,4 @@ steps:
     commands:
       #      - "./scripts/ci/install-helm-env.sh"
       - "./scripts/ci/helm-integration.sh" 
-    agents: { queue: baremetal }
+    agents: { queue: standard }

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -25,3 +25,15 @@ steps:
       - "echo \"checking for uncommitted changes\""
       - "[[ -z $(git status -s) ]]"
     agents: { queue: standard }
+
+  - label: ":book: Verify helm-docs is up-to-date"
+    commands:
+      - "./scripts/helm-docs.sh"
+      - "echo \"checking for uncommitted changes\""
+      - "[[ -z $(git status -s) ]]"
+    agents: { queue: standard }
+
+  - label: ":merge: Helm Integration"
+    commands:
+      - "which kind"
+    agents: { queue: standard }

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/*
+kind

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target/*
 kind
+*.terraform/**
+*.tfstat
+*.terraform.lock.hcl

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.1.9

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
-terraform 1.1.9
+helm 3.7.2
 kubectl 1.22.5
+terraform 1.1.9

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 terraform 1.1.9
+kubectl 1.22.5

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1,3 +1,4 @@
+# sample test
 # To customize these values, use an override file:
 # https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph-helm/-/blob/charts/sourcegraph/README.md#customizations
 

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -9,7 +9,20 @@ set -euf -o pipefail
 # Install kind via asdf
 # TBD
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.12.0/kind-darwin-amd64
+KIND_VERSION=0.12.0
+
+if [[ `uname -a | grep -i "Linux"` && `uname -a | grep -i "x86"` ]]
+then
+	DOWNLOADABLE=kind-linux-amd64
+elif [[ `uname -a | grep -i "Darwin"` && `uname -a | grep -i "x86"` ]]
+then
+	DOWNLOADABLE=kind-darwin-amd64
+elif [[ `uname -a | grep -i "Darwin"` && `uname -a | grep -i "arm64"` ]]
+then
+	DOWNLOADABLE=kind-darwin-amd64
+fi
+
+curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/${DOWNLOADABLE}"
 chmod +x ./kind
 
-./kind cluster create
+./kind create cluster

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -30,10 +30,10 @@ helm upgrade \
 kubectl config set-context --current --namespace sourcegraph
 
 # Wait for frontend pods to stabilize
-kubectl wait --for=condition=Ready --timeout=5m pod -l app=sourcegraph-frontend || true
+kubectl wait --for=condition=Ready --timeout=5m pod -l app=sourcegraph-frontend
 
 # We would want to do actual tests here ... 
-kubectl get pods -n sourcegraph || true
+kubectl get pods -n sourcegraph
 
 # Cleanup
 cd scripts/ci/terraform

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -3,12 +3,8 @@
 set -euf -o pipefail
 
 
-# Install asdf terraform plugin
-#asdf plugin add kind https://github.com/virtualstaticvoid/asdf-kind.git 
-TERRAFORM_CHECK=$(asdf which terraform)
-if [[ $? -ne 0 ]]; then
-  asdf plugin-add terraform https://github.com/asdf-community/asdf-hashicorp.git
-fi
+# Install asdf terraform plugin - managed by stateless agent configuration
+# asdf plugin-add terraform https://github.com/asdf-community/asdf-hashicorp.git
 
 # Install terraform via asdf
 asdf install

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -23,7 +23,7 @@ popd
 helm upgrade \
   --install \
   --create-namespace -n sourcegraph-${BUILDKITE_BUILD_NUMBER} \
-  --set sourcegraph.localDevMode \
+  --set sourcegraph.localDevMode=true \
   sourcegraph charts/sourcegraph/. || true
 
 # Cleanup

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -5,7 +5,10 @@ set -euf -o pipefail
 
 # Install asdf terraform plugin
 #asdf plugin add kind https://github.com/virtualstaticvoid/asdf-kind.git 
-asdf plugin-add terraform https://github.com/asdf-community/asdf-hashicorp.git
+TERRAFORM_CHECK=$(asdf which terraform)
+if [[ $? -ne 0 ]]; then
+  asdf plugin-add terraform https://github.com/asdf-community/asdf-hashicorp.git
+fi
 
 # Install terraform via asdf
 asdf install

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -22,15 +22,21 @@ popd
 # Smoke test, replaces manual testing
 helm upgrade \
   --install \
-  --create-namespace -n sourcegraph-${BUILDKITE_BUILD_NUMBER} \
+  --create-namespace -n sourcegraph \
   --set sourcegraph.localDevMode=true \
   sourcegraph charts/sourcegraph/. || true
 
+# Set the default namespace
+kubectl config set-context --current --namespace sourcegraph
+
+# Add a delay for registration to occur
+sleep 5
 
 # Wait for frontend pods to stabilize
 kubectl wait --for=condition=Ready --timeout=5m pod -l app=sourcegraph-frontend
 
-kubectl get pods -n sourcegraph-${BUILDKITE_BUILD_NUMBER}
+# We would want to do actual tests here ... 
+kubectl get pods -n sourcegraph
 
 # Cleanup
 cd scripts/ci/terraform

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euf -o pipefail
+
+
+# Install asdf kind plugin
+#asdf plugin add kind https://github.com/virtualstaticvoid/asdf-kind.git 
+
+# Install kind via asdf
+# TBD
+
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.12.0/kind-darwin-amd64
+chmod +x ./kind
+
+./kind cluster create

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -29,14 +29,11 @@ helm upgrade \
 # Set the default namespace
 kubectl config set-context --current --namespace sourcegraph
 
-# Add a delay for registration to occur
-sleep 5
-
 # Wait for frontend pods to stabilize
-kubectl wait --for=condition=Ready --timeout=5m pod -l app=sourcegraph-frontend
+kubectl wait --for=condition=Ready --timeout=5m pod -l app=sourcegraph-frontend || true
 
 # We would want to do actual tests here ... 
-kubectl get pods -n sourcegraph
+kubectl get pods -n sourcegraph || true
 
 # Cleanup
 cd scripts/ci/terraform

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -26,6 +26,14 @@ helm upgrade \
   --set sourcegraph.localDevMode=true \
   sourcegraph charts/sourcegraph/. || true
 
+sleep 10
+
+kubectl get pods -n sourcegraph-${BUILDKITE_BUILD_NUMBER}
+
+sleep 10
+
+kubectl get pods -n sourcegraph-${BUILDKITE_BUILD_NUMBER}
+
 # Cleanup
 cd scripts/ci/terraform
 terraform destroy -auto-approve || true

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -12,4 +12,4 @@ asdf install
 cd scripts/ci/terraform
 
 asdf exec terraform init
-asdf exec terraform plan
+asdf exec terraform apply -auto-approve

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -20,7 +20,7 @@ terraform apply -auto-approve || true
 popd
 
 # checkout main branch
-git checkout main
+git checkout main charts/sourcegraph
 
 # integration test: install chart at main branch ref
 helm upgrade \
@@ -36,7 +36,7 @@ kubectl config set-context --current --namespace sourcegraph
 kubectl wait --for=condition=Ready --timeout=5m pod -l app=sourcegraph-frontend
 
 # checkout current branch
-git checkout HEAD 
+git checkout .
 
 # verify git-fu 
 git status

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -26,11 +26,9 @@ helm upgrade \
   --set sourcegraph.localDevMode=true \
   sourcegraph charts/sourcegraph/. || true
 
-sleep 10
 
-kubectl get pods -n sourcegraph-${BUILDKITE_BUILD_NUMBER}
-
-sleep 10
+# Wait for frontend pods to stabilize
+kubectl wait --for=condition=Ready --timeout=5m pod -l app=app=sourcegraph-frontend
 
 kubectl get pods -n sourcegraph-${BUILDKITE_BUILD_NUMBER}
 

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -8,3 +8,7 @@ set -euf -o pipefail
 
 # Install terraform via asdf
 asdf install
+
+
+asdf terraform init
+asdf terraform plan

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -37,7 +37,7 @@ kubectl config set-context --current --namespace sourcegraph
 kubectl wait --for=condition=Ready --timeout=5m pod -l app=sourcegraph-frontend
 
 # checkout current branch
-git reset HEAD --hard
+git checkout HEAD charts/sourcegraph
 
 # verify git-fu 
 git status

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -26,7 +26,7 @@ curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v${KI
 chmod +x ./kind
 
 # Rootless Docker
-export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock
+#export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock
 
 # Create integration cluster
 ./kind create cluster

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -26,6 +26,7 @@ git checkout main charts/sourcegraph
 helm upgrade \
   --install \
   --create-namespace -n sourcegraph \
+  --wait \
   --set sourcegraph.localDevMode=true \
   sourcegraph charts/sourcegraph/. || true
 
@@ -36,7 +37,7 @@ kubectl config set-context --current --namespace sourcegraph
 kubectl wait --for=condition=Ready --timeout=5m pod -l app=sourcegraph-frontend
 
 # checkout current branch
-git checkout .
+git reset HEAD --hard
 
 # verify git-fu 
 git status
@@ -45,6 +46,7 @@ git status
 helm upgrade \
   --install \
   --create-namespace -n sourcegraph \
+  --wait \
   --set sourcegraph.localDevMode=true \
   sourcegraph charts/sourcegraph/. || true
 

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -5,11 +5,17 @@ set -euf -o pipefail
 
 # Install asdf terraform plugin - managed by stateless agent configuration
 # asdf plugin-add terraform https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin-add kubectl https://github.com/asdf-community/asdf-kubectl.git
 
 # Install terraform via asdf
 asdf install
+asdf reshim
 
 cd scripts/ci/terraform
 
-asdf exec terraform init
-asdf exec terraform apply -auto-approve
+terraform init
+terraform apply -auto-approve
+
+echo "TESTS would happen here"
+
+terraform destroy -auto-approve

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -28,7 +28,7 @@ helm upgrade \
 
 
 # Wait for frontend pods to stabilize
-kubectl wait --for=condition=Ready --timeout=5m pod -l app=app=sourcegraph-frontend
+kubectl wait --for=condition=Ready --timeout=5m pod -l app=sourcegraph-frontend
 
 kubectl get pods -n sourcegraph-${BUILDKITE_BUILD_NUMBER}
 

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -25,4 +25,8 @@ fi
 curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/${DOWNLOADABLE}"
 chmod +x ./kind
 
+# Rootless Docker
+export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock
+
+# Create integration cluster
 ./kind create cluster

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -5,7 +5,7 @@ set -euf -o pipefail
 
 # Install asdf terraform plugin - managed by stateless agent configuration
 # asdf plugin-add terraform https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add kubectl https://github.com/asdf-community/asdf-kubectl.git
+#asdf plugin-add kubectl https://github.com/asdf-community/asdf-kubectl.git
 
 # Install terraform via asdf
 asdf install

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -9,6 +9,7 @@ set -euf -o pipefail
 # Install terraform via asdf
 asdf install
 
+cd scripts/ci/terraform
 
 asdf exec terraform init
 asdf exec terraform plan

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -3,30 +3,9 @@
 set -euf -o pipefail
 
 
-# Install asdf kind plugin
+# Install asdf terraform plugin
 #asdf plugin add kind https://github.com/virtualstaticvoid/asdf-kind.git 
+asdf plugin-add terraform https://github.com/asdf-community/asdf-hashicorp.git
 
-# Install kind via asdf
-# TBD
-
-KIND_VERSION=0.12.0
-
-if [[ `uname -a | grep -i "Linux"` && `uname -a | grep -i "x86"` ]]
-then
-	DOWNLOADABLE=kind-linux-amd64
-elif [[ `uname -a | grep -i "Darwin"` && `uname -a | grep -i "x86"` ]]
-then
-	DOWNLOADABLE=kind-darwin-amd64
-elif [[ `uname -a | grep -i "Darwin"` && `uname -a | grep -i "arm64"` ]]
-then
-	DOWNLOADABLE=kind-darwin-amd64
-fi
-
-curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/${DOWNLOADABLE}"
-chmod +x ./kind
-
-# Rootless Docker
-#export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock
-
-# Create integration cluster
-./kind create cluster
+# Install terraform via asdf
+asdf install

--- a/scripts/ci/helm-integration.sh
+++ b/scripts/ci/helm-integration.sh
@@ -10,5 +10,5 @@ set -euf -o pipefail
 asdf install
 
 
-asdf terraform init
-asdf terraform plan
+asdf exec terraform init
+asdf exec terraform plan

--- a/scripts/ci/terraform/main.tf
+++ b/scripts/ci/terraform/main.tf
@@ -47,13 +47,13 @@ resource "null_resource" "kubectl" {
   triggers = {
     cluster_id   = "${google_container_cluster.cluster.id}"
     cluster_name = "${google_container_cluster.cluster.name}"
-    project = var.project
+    project      = var.project
   }
 
   # On creation, we want to setup the kubectl credentials. The easiest way
   # to do this is to shell out to gcloud.
   provisioner "local-exec" {
-    command = "gcloud container clusters get-credentials --zone=${var.zone} ${self.triggers.cluster_name} --project ${self.project}"
+    command = "gcloud container clusters get-credentials --zone=${var.zone} ${self.triggers.cluster_name} --project=${self.triggers.project}"
   }
 
   # On destroy we want to try to clean up the kubectl credentials. This

--- a/scripts/ci/terraform/main.tf
+++ b/scripts/ci/terraform/main.tf
@@ -1,0 +1,72 @@
+provider "google" {
+  project = "${var.project}"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+data "google_container_engine_versions" "main" {
+  location = "${var.zone}"
+  version_prefix = "1.20."
+}
+
+data "google_service_account" "gcpapi" {
+  account_id = "${var.gcp_service_account}"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "vault-helm-dev-${random_id.suffix.dec}"
+  project            = "${var.project}"
+  enable_legacy_abac = true
+  initial_node_count = 1
+  location           = "${var.zone}"
+  min_master_version = "${data.google_container_engine_versions.main.latest_master_version}"
+  node_version       = "${data.google_container_engine_versions.main.latest_node_version}"
+
+  node_config {
+    #service account for nodes to use
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_write",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append",
+    ]
+
+    service_account = "${data.google_service_account.gcpapi.email}"
+  }
+}
+
+resource "null_resource" "kubectl" {
+  count = "${var.init_cli ? 1 : 0 }"
+
+  triggers = {
+    cluster = "${google_container_cluster.cluster.id}"
+  }
+
+  # On creation, we want to setup the kubectl credentials. The easiest way
+  # to do this is to shell out to gcloud.
+  provisioner "local-exec" {
+    command = "gcloud container clusters get-credentials --zone=${var.zone} ${google_container_cluster.cluster.name}"
+  }
+
+  # On destroy we want to try to clean up the kubectl credentials. This
+  # might fail if the credentials are already cleaned up or something so we
+  # want this to continue on failure. Generally, this works just fine since
+  # it only operates on local data.
+  provisioner "local-exec" {
+    when       = "destroy"
+    on_failure = "continue"
+    command    = "kubectl config get-clusters | grep ${google_container_cluster.cluster.name} | xargs -n1 kubectl config delete-cluster"
+  }
+
+  provisioner "local-exec" {
+    when       = "destroy"
+    on_failure = "continue"
+    command    = "kubectl config get-contexts | grep ${google_container_cluster.cluster.name} | xargs -n1 kubectl config delete-context"
+  }
+}

--- a/scripts/ci/terraform/main.tf
+++ b/scripts/ci/terraform/main.tf
@@ -19,7 +19,7 @@ resource "google_container_cluster" "cluster" {
   name               = "vault-helm-dev-${random_id.suffix.dec}"
   project            = var.project
   enable_legacy_abac = true
-  initial_node_count = 1
+  initial_node_count = 3
   location           = "${var.zone}"
   min_master_version = "${data.google_container_engine_versions.main.latest_master_version}"
   node_version       = "${data.google_container_engine_versions.main.latest_node_version}"

--- a/scripts/ci/terraform/main.tf
+++ b/scripts/ci/terraform/main.tf
@@ -47,13 +47,13 @@ resource "null_resource" "kubectl" {
   triggers = {
     cluster_id   = "${google_container_cluster.cluster.id}"
     cluster_name = "${google_container_cluster.cluster.name}"
-
+    project = var.project
   }
 
   # On creation, we want to setup the kubectl credentials. The easiest way
   # to do this is to shell out to gcloud.
   provisioner "local-exec" {
-    command = "gcloud container clusters get-credentials --zone=${var.zone} ${self.triggers.cluster_name}"
+    command = "gcloud container clusters get-credentials --zone=${var.zone} ${self.triggers.cluster_name} --project ${self.project}"
   }
 
   # On destroy we want to try to clean up the kubectl credentials. This

--- a/scripts/ci/terraform/outputs.tf
+++ b/scripts/ci/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_id" {
+  value = "${google_container_cluster.cluster.id}"
+}
+
+output "cluster_name" {
+  value = "${google_container_cluster.cluster.name}"
+}

--- a/scripts/ci/terraform/variables.tf
+++ b/scripts/ci/terraform/variables.tf
@@ -1,0 +1,28 @@
+variable "project" {
+  default = "sourcegraph-ci"
+
+  description = <<EOF
+Google Cloud Project to launch resources in. This project must have GKE
+enabled and billing activated. We can't use the GOOGLE_PROJECT environment
+variable since we need to access the project for other uses.
+EOF
+}
+
+variable "zone" {
+  default     = "us-central1-a"
+  description = "The zone to launch all the GKE nodes in."
+}
+
+variable "init_cli" {
+  default     = true
+  description = "Whether to init kubectl or not."
+}
+
+variable "gcp_service_account" {
+  default = "sourcegraph-deploy-helm-ci"
+
+  description = <<EOF
+Service account used on the nodes to manage/use the API, specifically needed
+for using auto-unseal
+EOF
+}


### PR DESCRIPTION
### Current Status
This was a proof-of-concept to put together automated integration tests for the helm chart. This demonstrates a technique on how to use Hashicorp Terraform to create a GKE cluster, install the helm chart at the HEAD of the main branch, and then apply the upgrade, and run some tests. 

This is largely incomplete as any failure in the bash script will leave a GKE cluster running and abandoned within the Sourcegraph CI project. 

We hope to revisit this soon as it becomes more relevant to our prioritization.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
