### PR TITLE
Update alpine-3.12 references

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - **IMPORTANT** `cadvisor` now defaults to run in `privileged` mode. This allows `cadvisor` to collect out of memory events happening to containers which can be used to discover underprovisoned resources. If you have your own monitoring infrastructure, you may choose to disable `cadvisor` or set `cadvisor.containerSecurityContext.privileged=false` in your override file. [#121](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/121)
+- The alpine-3.12 docker image has been updated to use alpine-3.14 [#124](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/124/)
 
 <!-- START CHANGELOG -->
 

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - **IMPORTANT** `cadvisor` now defaults to run in `privileged` mode. This allows `cadvisor` to collect out of memory events happening to containers which can be used to discover underprovisoned resources. If you have your own monitoring infrastructure, you may choose to disable `cadvisor` or set `cadvisor.containerSecurityContext.privileged=false` in your override file. [#121](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/121)
-- The alpine-3.12 docker image has been updated to use alpine-3.14 [#124](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/124/)
+- Uses of alpine-3.12 docker image have been updated to use alpine-3.14 [#124](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/124/)
 
 <!-- START CHANGELOG -->
 

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -26,8 +26,8 @@ In addition to the documented values, all services also support the following va
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | alpine.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `alpine` initContainer, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
-| alpine.image.defaultTag | string | `"3.39.1@sha256:66b1e40aede9860c7e7e570aca6a41e551db33f44b944ce102bc5b658b1be5a6"` | Docker image tag for the `alpine` image |
-| alpine.image.name | string | `"alpine-3.12"` | Docker image name for the `alpine` image |
+| alpine.image.defaultTag | string | `"insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1"` | Docker image tag for the `alpine` image |
+| alpine.image.name | string | `"alpine-3.14"` | Docker image name for the `alpine` image |
 | alpine.resources | object | `{"limits":{"cpu":"10m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Resource requests & limits for the `alpine` initContainer, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | cadvisor.containerSecurityContext | object | `{"privileged":true}` | Security context for the `cadvisor` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | cadvisor.enabled | bool | `true` | Enable `cadvisor` |

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -87,9 +87,9 @@ sourcegraph:
 alpine: # Used in init containers
   image:
     # -- Docker image tag for the `alpine` image
-    defaultTag: 3.39.1@sha256:66b1e40aede9860c7e7e570aca6a41e551db33f44b944ce102bc5b658b1be5a6
+    defaultTag: insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
     # -- Docker image name for the `alpine` image
-    name: "alpine-3.12"
+    name: "alpine-3.14"
   # -- Security context for the `alpine` initContainer,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
   containerSecurityContext:


### PR DESCRIPTION
The alpine-3.12 image was removed in https://github.com/sourcegraph/sourcegraph/pull/34906 (as a followup to https://github.com/sourcegraph/sourcegraph/pull/34508). We directly reference the alpine-3.12 image here to run init commands, so the reference needs to be updated.

Note: the insiders reference will be updated as part of the next release.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Not tested directly apart from verifying the image reference - however, the same change has already been made in https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/pull/4336 and has been working fine.