### PR TITLE
ci: update the github action name to match its title

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -1,19 +1,18 @@
 name: pr-auditor
 on:
   pull_request:
-    types: [ closed, edited, opened ]
-
+    types: [ closed, edited, opened, synchronize ]
 jobs:
-  run:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with: { repository: 'sourcegraph/sourcegraph' }
-      - uses: actions/setup-go@v2
-        with: { go-version: '1.18' }
-
-      - run: ./dev/pr-auditor/check-pr.sh
-        env:
-          GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
-          GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
-          GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    pr-auditor:
+      runs-on: ubuntu-latest
+      name: pr-auditor
+      steps:
+        - uses: actions/checkout@v2
+          with: { repository: 'sourcegraph/sourcegraph' }
+        - uses: actions/setup-go@v2
+          with: { go-version: '1.18' }
+        - run: ./dev/pr-auditor/check-pr.sh
+          env:
+            GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
+            GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
+            GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Updates the job name to match its title in all steps trying to fix sourcegraph/sourcegraph#35635

### Test plan
https://github.com/sourcegraph/infrastructure/pull/3409
a green run on this PR

[_Created by Sourcegraph batch change `dave/change_action_name`._](https://k8s.sgdev.org/users/dave/batch-changes/change_action_name)