### PR TITLE
Give ctags a writable temp dir

### DIFF
--- a/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        - name: TMP_DIR
+        - name: TMPDIR
           value: /mnt/cache/$(POD_NAME)-tmp
         image: {{ include "sourcegraph.image" (list . "symbols" ) }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}

--- a/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -66,6 +66,8 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
+        - name: TMP_DIR
+          value: /mnt/cache/$(POD_NAME)-tmp
         image: {{ include "sourcegraph.image" (list . "symbols" ) }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         {{- with .Values.symbols.args }}

--- a/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -67,7 +67,7 @@ spec:
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
         - name: TMPDIR
-          value: /mnt/cache/$(POD_NAME)-tmp
+          value: /mnt/tmp
         image: {{ include "sourcegraph.image" (list . "symbols" ) }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         {{- with .Values.symbols.args }}
@@ -97,6 +97,8 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
+        - mountPath: /mnt/tmp
+          name: tmp
         {{- if .Values.symbols.extraVolumeMounts }}
         {{- toYaml .Values.symbols.extraVolumeMounts | nindent 8 }}
         {{- end }}
@@ -123,6 +125,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: cache-ssd
+      - emptyDir: {}
+        name: tmp
       {{- if .Values.symbols.extraVolumes }}
       {{- toYaml .Values.symbols.extraVolumes | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
Because the `symbols` container's processes run as user 100 (`sourcegraph`):

https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/b6d554e3f594b9c43951f84520f174fae29114ab/charts/sourcegraph/values.yaml#L997

ctags doesn't have write permission to `/tmp`.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

Tested in https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/pull/4594
