### PR TITLE
Fix storage class `type` parameter

### DIFF
--- a/charts/sourcegraph/templates/storageclass.yaml
+++ b/charts/sourcegraph/templates/storageclass.yaml
@@ -12,7 +12,9 @@ metadata:
     {{- end }}
 provisioner: {{ .Values.storageClass.provisioner }}
 parameters:
-  type: {{ .Values.storageClass.type }}
+  {{- with .Values.storageClass.type }}
+  type: {{ . }}
+  {{- end }}
   {{- if .Values.storageClass.parameters}}
   {{- toYaml .Values.storageClass.parameters | nindent 2 }}
   {{- end }}

--- a/charts/sourcegraph/tests/storageClass_test.yaml
+++ b/charts/sourcegraph/tests/storageClass_test.yaml
@@ -12,3 +12,11 @@ tests:
   - equal:
       path: parameters.zones
       value: us-central1-f
+- it: should not have 'type' when storageClass.type=null
+  set:
+    storageClass:
+      create: true
+      type: null
+  asserts:
+  - isNull:
+      path: parameters


### PR DESCRIPTION
We ask customer to unset `storageClass.type=null` when using AKS, but this breaks the template https://sourcegraph.slack.com/archives/C02E4HE42BX/p1655238677152839

```yaml
# Source: sourcegraph/templates/storageclass.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name:  sourcegraph
  labels:
    helm.sh/chart: sourcegraph-3.40.1
    app.kubernetes.io/name: sourcegraph
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "3.40.1"
    app.kubernetes.io/managed-by: Helm
    deploy: sourcegraph-storage
  annotations:
provisioner: disk.csi.azure.com
parameters:
  type:
  storageaccounttype: Premium_LRS
allowVolumeExpansion: true
reclaimPolicy: Retain
volumeBindingMode: WaitForFirstConsumer
```
This PR prevent the rendering of `type: <>` completely

### Notes

we should probably run `kubeval` on all example overrides

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

```sh
helm template --values <>
```

no `type`

```yaml
# Source: sourcegraph/templates/storageclass.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name:  sourcegraph
  labels:
    helm.sh/chart: sourcegraph-3.40.1
    app.kubernetes.io/name: sourcegraph
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "3.40.1"
    app.kubernetes.io/managed-by: Helm
    deploy: sourcegraph-storage
  annotations:
provisioner: disk.csi.azure.com
parameters:
  storageaccounttype: Premium_LRS
allowVolumeExpansion: true
reclaimPolicy: Retain
volumeBindingMode: WaitForFirstConsumer
```