### PR TITLE
Fix mount path used by codeinsights-db initContainer

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -5,6 +5,7 @@ Use `**BREAKING**:` to denote a breaking change
 # Changelog
 
 <!-- START CHANGELOG -->
+- Fixed mountPath and permissions used by codeinsights-db initContainer [#138](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/138)
 
 ## 3.40.2-rev.1
 

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -51,6 +51,7 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.existingConfig | string | `""` | Name of existing ConfigMap for `codeinsights-db`. It must contain a `postgresql.conf` key. |
 | codeInsightsDB.image.defaultTag | string | `"3.40.1@sha256:36475b0d2b3ccc5d4c5eab6c5c0c6e5dc0b41f8775fc5174c754645b73e78d62"` | Docker image tag for the `codeinsights-db` image |
 | codeInsightsDB.image.name | string | `"codeinsights-db"` | Docker image name for the `codeinsights-db` image |
+| codeInsightsDB.init.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":70,"runAsUser":70}` | Security context for the `alpine` initContainer, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeInsightsDB.name | string | `"codeinsights-db"` | Name used by resources. Does not affect service names or PVCs. |
 | codeInsightsDB.podSecurityContext | object | `{"fsGroup":70,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":70}` | Security context for the `codeinsights-db` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | codeInsightsDB.postgresExporter | object | `{}` | Configuration for the `pgsql-exporter` sidecar container |

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -52,7 +52,7 @@ spec:
         - mountPath: /var/lib/postgresql/data/
           name: disk
         securityContext:
-        {{- toYaml .Values.codeInsightsDB.containerSecurityContext | nindent 10 }}
+        {{- toYaml .Values.codeInsightsDB.init.containerSecurityContext | nindent 10 }}
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.alpine.resources | nindent 10 }}

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -49,7 +49,7 @@ spec:
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         command: ["sh", "-c", "if [ -d /var/lib/postgresql/data/pgdata ]; then chmod 750 /var/lib/postgresql/data/pgdata; fi"]
         volumeMounts:
-        - mountPath: /data
+        - mountPath: /var/lib/postgresql/data/
           name: disk
         securityContext:
         {{- toYaml .Values.alpine.containerSecurityContext | nindent 10 }}

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -52,7 +52,7 @@ spec:
         - mountPath: /var/lib/postgresql/data/
           name: disk
         securityContext:
-        {{- toYaml .Values.alpine.containerSecurityContext | nindent 10 }}
+        {{- toYaml .Values.codeInsightsDB.containerSecurityContext | nindent 10 }}
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.alpine.resources | nindent 10 }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -185,6 +185,14 @@ codeInsightsDB:
     runAsUser: 70
     runAsGroup: 70
     readOnlyRootFilesystem: true
+  init:
+    # -- Security context for the `alpine` initContainer,
+    # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      runAsUser: 70
+      runAsGroup: 70
+      readOnlyRootFilesystem: true
   # -- Configuration for the `pgsql-exporter` sidecar container
   postgresExporter: {}
   # -- Name used by resources. Does not affect service names or PVCs.


### PR DESCRIPTION
The codeinsights-db data volumes mount at a different path than pgsql / codeintel-db. The initContainer was pointed at the wrong path, so the file permission adjustment was unable to run.

There is also a problem with the initContainer permissions - the securityContext settings are shared between all alpine images, but the user associated with pgsql / codeintel-db is different. As a quick fix I've added an override for codeinsights, but we'll want to roll this change out everywhere.

### Checklist

- [X] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Confirmed initContainer actually changes file permissions after this change