### PR TITLE
sourcegraph: Add new worker prometheus scrape target

### DIFF
--- a/charts/sourcegraph/templates/worker/worker-executors.Service.yaml
+++ b/charts/sourcegraph/templates/worker/worker-executors.Service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "6996"
+    sourcegraph.prometheus/scrape: "true"
+    {{- if .Values.worker.serviceAnnotations }}
+    {{- toYaml .Values.worker.serviceAnnotations | nindent 4 }}
+    {{- end }}
+  labels:
+    app: worker
+    deploy: sourcegraph
+    app.kubernetes.io/component: worker
+    {{- if .Values.worker.serviceLabels }}
+      {{- toYaml .Values.worker.serviceLabels | nindent 4 }}
+    {{- end }}
+  name: worker-executors
+spec:
+  ports:
+  - name: prom
+    port: 6996
+    targetPort: prom
+  selector:
+    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
+    app: worker
+  type: {{ .Values.worker.serviceType | default "ClusterIP" }}

--- a/charts/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -84,6 +84,8 @@ spec:
           name: http
         - containerPort: 6060
           name: debug
+        - containerPort: 6996
+          name: prom
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.worker.resources | nindent 10 }}


### PR DESCRIPTION
This adds a scrape config for a new port exposed by the worker service that serves the collected executor metrics.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

Will have to test it once https://github.com/sourcegraph/sourcegraph/pull/36969 landed, otherwise we'll revert.