### PR TITLE
Add envoy filter override

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -3,9 +3,14 @@ Use `**BREAKING**:` to denote a breaking change
 -->
 
 # Changelog
+
 <!-- START CHANGELOG -->
 
 ## Unreleased
+
+### Added
+
+- Add new example `envoy` to enable HTTP trailers using Envoy Filter [#148](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/148)
 
 ## 3.41.0
 

--- a/charts/sourcegraph/examples/envoy/README.md
+++ b/charts/sourcegraph/examples/envoy/README.md
@@ -1,8 +1,8 @@
 # Envoy Filter
 
-This override file creates a new resource called `EnvoyFilter` to enable trailers on evoy for gitserver.
+This override file creates a new resource called `EnvoyFilter` to enable HTTP trailers on envoy for gitserver.
 
-It is an example on how to add use an override file to apply a new envoy filter to resolve the following error message in gitserver caused by service mesh (ex. istio):
+It is an example override file to apply a new envoy filter to resolve the following error message in gitserver caused by service mesh (ex. istio):
 
 ```
 "git command [git rev-parse HEAD] failed (stderr: \"\"): strconv.Atoi: parsing \"\"

--- a/charts/sourcegraph/examples/envoy/README.md
+++ b/charts/sourcegraph/examples/envoy/README.md
@@ -1,0 +1,9 @@
+# Envoy Filter
+
+This override file creates a new resource called `EnvoyFilter` to enable trailers on evoy for gitserver.
+
+It is an example on how to add use an override file to apply a new envoy filter to resolve the following error message in gitserver caused by service mesh (ex. istio):
+
+```
+"git command [git rev-parse HEAD] failed (stderr: \"\"): strconv.Atoi: parsing \"\"
+```

--- a/charts/sourcegraph/examples/envoy/override.yaml
+++ b/charts/sourcegraph/examples/envoy/override.yaml
@@ -1,0 +1,36 @@
+extraResources:
+  - apiVersion: networking.istio.io/v1alpha3
+    kind: EnvoyFilter
+    metadata:
+      name: enable-trailers
+      labels:
+        deploy: sourcegraph
+    spec:
+      workloadSelector:
+        labels:
+          app: gitserver
+      configPatches:
+        - applyTo: NETWORK_FILTER
+          match:
+            listener:
+              filterChain:
+                filter:
+                  name: "envoy.filters.network.http_connection_manager"
+          patch:
+            operation: MERGE
+            value:
+              name: "envoy.filters.network.http_connection_manager"
+              typed_config:
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+                http_protocol_options:
+                  enable_trailers: true
+        - applyTo: CLUSTER
+          patch:
+            operation: MERGE
+            value:
+              typed_extension_protocol_options:
+                envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                  "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+                  explicit_http_config:
+                    http_protocol_options:
+                      enable_trailers: true


### PR DESCRIPTION
### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

Helm version of https://github.com/sourcegraph/deploy-sourcegraph/pull/4150

This PR adds a new envoy filter overlay as an example to resolve the following error for instances that are running service mesh (ex. istio):

```
Strconv.Atoi: parsing "": invalid syntax
```

This error occurs when the service mesh like istio drops trailers for http1 by default. Enable trailers using this overlay resolves the issue.


![image](https://user-images.githubusercontent.com/68532117/178390668-65ba8c5f-6b34-4371-a398-6fff0ef52ca3.png)


### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Tested on a minikube instance 
