### PR TITLE
Add support to set service account annotations

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -11,6 +11,7 @@ Use `**BREAKING**:` to denote a breaking change
 ### Added
 
 - Add new example `envoy` to enable HTTP trailers using Envoy Filter [#148](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/148)
+- Add support to configure service account annotations [#151](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/151)
 
 ## 3.41.0
 

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -22,6 +22,7 @@ In addition to the documented values, all services also support the following va
 - `<serviceName>.podSecurityContext` - [learn more](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
 - `<serviceName>.args` - override default container args
 - `<serviceName>.env` - consult `values.yaml` file
+- `<serviceName>.serviceAccount.annotations` - Annotations for the service-specific service account
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -22,6 +22,7 @@ In addition to the documented values, all services also support the following va
 - `<serviceName>.podSecurityContext` - [learn more](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
 - `<serviceName>.args` - override default container args
 - `<serviceName>.env` - consult `values.yaml` file
+- `<serviceName>.serivceAccount.create` - create service account for service
 - `<serviceName>.serviceAccount.annotations` - Annotations for the service-specific service account
 
 | Key | Type | Default | Description |

--- a/charts/sourcegraph/README.md.gotmpl
+++ b/charts/sourcegraph/README.md.gotmpl
@@ -22,5 +22,6 @@ In addition to the documented values, all services also support the following va
 - `<serviceName>.podSecurityContext` - [learn more](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
 - `<serviceName>.args` - override default container args
 - `<serviceName>.env` - consult `values.yaml` file
+- `<serviceName>.serviceAccount.annotations` - Annotations for the service-specific service account
 
 {{ template "chart.valuesTable" . }}

--- a/charts/sourcegraph/README.md.gotmpl
+++ b/charts/sourcegraph/README.md.gotmpl
@@ -22,6 +22,7 @@ In addition to the documented values, all services also support the following va
 - `<serviceName>.podSecurityContext` - [learn more](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
 - `<serviceName>.args` - override default container args
 - `<serviceName>.env` - consult `values.yaml` file
+- `<serviceName>.serivceAccount.create` - create service account for service
 - `<serviceName>.serviceAccount.annotations` - Annotations for the service-specific service account
 
 {{ template "chart.valuesTable" . }}

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -53,6 +53,15 @@ serviceAccountName: {{ include "sourcegraph.serviceAccountName" (list $top $serv
 {{- end }}
 {{- end }}
 
+{{- define "sourcegraph.serviceAccountAnnotations" -}}
+{{- $top := index . 0 }}
+{{- $service := index . 1 }}
+{{- with (index $top.Values $service "serviceAccount" "annotations") }}
+annotations:
+{{- . | toYaml | trim | nindent 4 }}
+{{- end }}
+{{- end }}
+
 {{/*
 Create the docker image reference and allow it to be overridden on a per-service basis
 Default tags are toggled between a global and service-specific setting by the

--- a/charts/sourcegraph/templates/cadvisor/cadvisor.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/cadvisor/cadvisor.ServiceAccount.yaml
@@ -7,5 +7,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: cadvisor
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "cadvisor") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "cadvisor") }}
 {{- end }}

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: codeinsights-db
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "codeInsightsDB") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "codeInsightsDB") }}
 {{- end }}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: codeintel-db
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "codeIntelDB") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "codeIntelDB") }}
 {{- end }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -10,5 +10,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: frontend
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "frontend") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "frontend") }}
 {{- end }}

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: github-proxy
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "githubProxy") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "githubProxy") }}
 {{- end }}

--- a/charts/sourcegraph/templates/gitserver/gitserver.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: gitserver
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "gitserver") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "gitserver") }}
 {{- end }}

--- a/charts/sourcegraph/templates/grafana/grafana.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.ServiceAccount.yaml
@@ -10,5 +10,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: grafana
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "grafana") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "grafana") }}
 {{- end }}

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: indexed-search
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "indexedSearch") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "indexedSearch") }}
 {{- end }}

--- a/charts/sourcegraph/templates/jaeger/jaeger.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: tracing
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "tracing") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "tracing") }}
 {{- end }}

--- a/charts/sourcegraph/templates/minio/minio.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/minio/minio.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: minio
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "minio") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "minio") }}
 {{- end }}

--- a/charts/sourcegraph/templates/pgsql/pgsql.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: pgsql
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "pgsql") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "pgsql") }}
 {{- end }}

--- a/charts/sourcegraph/templates/precise-code-intel/worker.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: precise-code-intel
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "preciseCodeIntel") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "preciseCodeIntel") }}
 {{- end }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
@@ -1,12 +1,11 @@
 {{- if and .Values.prometheus.enabled .Values.prometheus.serviceAccount.create -}}
 apiVersion: v1
-imagePullSecrets:
-- name: docker-registry
 kind: ServiceAccount
 metadata:
   labels:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: prometheus
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "prometheus") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "prometheus") }}
 {{- end }}

--- a/charts/sourcegraph/templates/redis/redis-cache.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: redis
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "redisCache") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "redisCache") }}
 {{- end }}

--- a/charts/sourcegraph/templates/repo-updater/repo-updater.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: repo-updater
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "repoUpdater") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "repoUpdater") }}
 {{- end }}

--- a/charts/sourcegraph/templates/searcher/searcher.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: searcher
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "searcher") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "searcher") }}
 {{- end }}

--- a/charts/sourcegraph/templates/symbols/symbols.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: symbols
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "symbols") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "symbols") }}
 {{- end }}

--- a/charts/sourcegraph/templates/syntect-server/syntect-server.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/syntect-server/syntect-server.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: syntect-server
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "syntectServer") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "syntectServer") }}
 {{- end }}

--- a/charts/sourcegraph/templates/worker/worker.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/worker/worker.ServiceAccount.yaml
@@ -6,5 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: worker
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "worker") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list . "worker") }}
 {{- end }}

--- a/charts/sourcegraph/tests/serviceAccountAnnotations_test.yaml
+++ b/charts/sourcegraph/tests/serviceAccountAnnotations_test.yaml
@@ -1,16 +1,41 @@
-suite: affinity
-templates:
-- frontend/sourcegraph-frontend.ServiceAccount.yaml
+suite: serviceAccountAnnotations
 release:
   name: sourcegraph
   namespace: sourcegraph
 tests:
-- it: should render service account annotations when $svc.serviceAccount.annotations is defined
+- it: should render service account annotations when frontend.serviceAccount.annotations is defined
   set:
     frontend:
       serviceAccount:
         annotations:
           iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+  template: frontend/sourcegraph-frontend.ServiceAccount.yaml
+  asserts:
+  - equal:
+      path: metadata.annotations
+      value:
+        iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+
+- it: should render service account annotations when cadvisor.serviceAccount.annotations is defined
+  set:
+    cadvisor:
+      serviceAccount:
+        annotations:
+          iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+  template: cadvisor/cadvisor.ServiceAccount.yaml
+  asserts:
+  - equal:
+      path: metadata.annotations
+      value:
+        iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+
+- it: should render service account annotations when prometheus.serviceAccount.annotations is defined
+  set:
+    prometheus:
+      serviceAccount:
+        annotations:
+          iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+  template: prometheus/prometheus.ServiceAccount.yaml
   asserts:
   - equal:
       path: metadata.annotations

--- a/charts/sourcegraph/tests/serviceAccountAnnotations_test.yaml
+++ b/charts/sourcegraph/tests/serviceAccountAnnotations_test.yaml
@@ -1,0 +1,18 @@
+suite: affinity
+templates:
+- frontend/sourcegraph-frontend.ServiceAccount.yaml
+release:
+  name: sourcegraph
+  namespace: sourcegraph
+tests:
+- it: should render service account annotations when $svc.serviceAccount.annotations is defined
+  set:
+    frontend:
+      serviceAccount:
+        annotations:
+          iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+  asserts:
+  - equal:
+      path: metadata.annotations
+      value:
+        iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com


### PR DESCRIPTION
In Cloud, we need to annotate the Kubernetes service account in order to impersonate as a GCP service account

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

unit test

or run

`override.yaml`
```yaml
frontend:
  serviceAccount:
    annotations:
      iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
```

```sh
helm template -f ./override.yaml sourcegraph charts/sourcegraph/.
```