### PR TITLE
Don't include `annotations:` key when there are no annotations

### DIFF
--- a/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
+++ b/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
@@ -15,16 +15,14 @@ spec:
   backoffLimit: 5
   template:
     metadata:
-      {{- if or .Values.sourcegraph.podAnnotations .Values.migrator.podAnnotations }}
       annotations:
-        {{- if .Values.sourcegraph.podAnnotations }}
-        {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
-        {{- end }}
-        {{- if .Values.migrator.podAnnotations }}
-        {{- toYaml .Values.migrator.podAnnotations | nindent 8 }}
-        {{- end }}
-      {{- end }}
         kubectl.kubernetes.io/default-container: migrator
+      {{- if .Values.sourcegraph.podAnnotations }}
+      {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.migrator.podAnnotations }}
+      {{- toYaml .Values.migrator.podAnnotations | nindent 8 }}
+      {{- end }}
       labels:
       {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}

--- a/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
+++ b/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
@@ -15,12 +15,14 @@ spec:
   backoffLimit: 5
   template:
     metadata:
+      {{- if or .Values.sourcegraph.podAnnotations .Values.migrator.podAnnotations }}
       annotations:
-      {{- if .Values.sourcegraph.podAnnotations }}
-      {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
-      {{- end }}
-      {{- if .Values.migrator.podAnnotations }}
-      {{- toYaml .Values.migrator.podAnnotations | nindent 8 }}
+        {{- if .Values.sourcegraph.podAnnotations }}
+        {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.migrator.podAnnotations }}
+        {{- toYaml .Values.migrator.podAnnotations | nindent 8 }}
+        {{- end }}
       {{- end }}
         kubectl.kubernetes.io/default-container: migrator
       labels:

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- (lint) Don't emit `annotations` key on k8s objects if the value is empty [#163](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/163)
 
 ## 3.43.0
 

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.frontend.serviceAnnotations }}
   annotations:
-    {{- if .Values.frontend.serviceAnnotations }}
     {{- toYaml .Values.frontend.serviceAnnotations | nindent 4 }}
-    {{- end }}
+  {{- end }}
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
@@ -2,10 +2,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  {{- if .Values.frontend.ingress.annotations}}
   annotations:
-    {{- if .Values.frontend.ingress.annotations}}
     {{- toYaml .Values.frontend.ingress.annotations | nindent 4 }}
-    {{- end }}
+  {{- end }}
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph

--- a/charts/sourcegraph/templates/grafana/grafana.Service.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.Service.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
   {{- if .Values.grafana.serviceAnnotations }}
+  annotations:
   {{- toYaml .Values.grafana.serviceAnnotations | nindent 4 }}
   {{- end }}
   labels:

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -21,12 +21,14 @@ spec:
   serviceName: indexed-search
   template:
     metadata:
+      {{- if or .Values.sourcegraph.podAnnotations .Values.indexedSearch.podAnnotations }}
       annotations:
-      {{- if .Values.sourcegraph.podAnnotations }}
-      {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
-      {{- end }}
-      {{- if .Values.indexedSearch.podAnnotations }}
-      {{- toYaml .Values.indexedSearch.podAnnotations | nindent 8 }}
+        {{- if .Values.sourcegraph.podAnnotations }}
+        {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.indexedSearch.podAnnotations }}
+        {{- toYaml .Values.indexedSearch.podAnnotations | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
       {{- include "sourcegraph.selectorLabels" . | nindent 8 }}

--- a/charts/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
   {{- if .Values.tracing.collector.serviceAnnotations }}
+  annotations:
   {{- toYaml .Values.tracing.collector.serviceAnnotations | nindent 4 }}
   {{- end }}
   labels:

--- a/charts/sourcegraph/templates/jaeger/jaeger-query.Service.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger-query.Service.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
   {{- if .Values.tracing.query.serviceAnnotations }}
+  annotations:
   {{- toYaml .Values.tracing.query.serviceAnnotations | nindent 4 }}
   {{- end }}
   labels:

--- a/charts/sourcegraph/templates/prometheus/prometheus.Service.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.Service.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.prometheus.serviceAnnotations }}
   annotations:
-    {{- if .Values.prometheus.serviceAnnotations }}
     {{- toYaml .Values.prometheus.serviceAnnotations | nindent 4 }}
-    {{- end }}
+  {{- end }}
   labels:
     app: prometheus
     deploy: sourcegraph

--- a/charts/sourcegraph/templates/storageclass.yaml
+++ b/charts/sourcegraph/templates/storageclass.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     {{- include "sourcegraph.labels" . | nindent 4 }}
     deploy: sourcegraph-storage
+  {{- if .Values.storageClass.annotations}}
   annotations:
-    {{- if .Values.storageClass.annotations}}
     {{- toYaml .Values.storageClass.annotations | nindent 4 }}
-    {{- end }}
+  {{- end }}
 provisioner: {{ .Values.storageClass.provisioner }}
 parameters:
   {{- with .Values.storageClass.type }}

--- a/charts/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/charts/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.syntectServer.serviceAnnotations }}
   annotations:
-    {{- if .Values.syntectServer.serviceAnnotations }}
     {{- toYaml .Values.syntectServer.serviceAnnotations | nindent 4 }}
-    {{- end }}
+  {{- end }}
   labels:
     app: syntect-server
     deploy: sourcegraph


### PR DESCRIPTION
A [customer reported lint warnings](https://sourcegraph.slack.com/archives/C03SBTYH3S9/p1661186892313959?thread_ts=1659985666.766349&cid=C03SBTYH3S9) in the output yaml from kube yaml plugin for IntellilJ because `annotation:` keys were set with no value.

This PR updates the chart to not emit the annotations key if no values are going to be set.

I am not sure how to enforce this in unit tests. `helm unittest` seems to only be capable of checking values, not the existence of keys, so tests can't tell the difference between the `annotations:` key not being present or simply empty.

Alternatively, we could just require that every entity has a description annotation.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

Ran `helm template ./charts/sourcegraph` and ensured all `annotations:` keys had values.