### PR TITLE
ci: fix helm test

### DIFF
--- a/.github/workflows/helm_lint_test.yml
+++ b/.github/workflows/helm_lint_test.yml
@@ -33,20 +33,21 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
-      - run: |
-          echo "no change is detected. exiting..."
-          exit 0
-        if: steps.list-changed.outputs.changed == 'true'
       - name: Helm lint
         run:  |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           echo $changed | xargs helm lint
+        if: steps.list-changed.outputs.changed == 'true'
       - name: Create kind cluster
         uses: helm/kind-action@v1.3.0
+        if: steps.list-changed.outputs.changed == 'true'
       - name: Install Helm charts
         run: helm install --debug -f ./ci/override.yaml test-sg ./charts/sourcegraph/
+        if: steps.list-changed.outputs.changed == 'true'
       - name: Wait for frontend to come up
         run: sleep 60s && kubectl wait --for=condition=Ready -l app=sourcegraph-frontend pod --timeout=300s
         shell: bash
+        if: steps.list-changed.outputs.changed == 'true'
       - name: Run Helm Testing
         run: helm test test-sg
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/helm_lint_test.yml
+++ b/.github/workflows/helm_lint_test.yml
@@ -33,15 +33,16 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
+      - run: |
+          echo "no change is detected. exiting..."
+          exit 0
+        if: steps.list-changed.outputs.changed == 'true'
       - name: Helm lint
         run:  |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           echo $changed | xargs helm lint
-        if: steps.list-changed.outputs.changed == 'true'
       - name: Create kind cluster
         uses: helm/kind-action@v1.3.0
-        if: steps.list-changed.outputs.changed == 'true'
-
       - name: Install Helm charts
         run: helm install --debug -f ./ci/override.yaml test-sg ./charts/sourcegraph/
       - name: Wait for frontend to come up


### PR DESCRIPTION
When no change is made to the chart, the CI will fail because it tried to install the chart without setting up the kind cluster

this change ensures these tests are only run when helm chart is changed to avoid running unnecessary test

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

ci should pass
