### PR TITLE
docs: set kubernetes.io/ingress.class to null if ingressClassName is set

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -86,9 +86,10 @@ In addition to the documented values, all services also support the following va
 | frontend.image.defaultTag | string | `"3.42.2@sha256:abe3ed2071e9e8020209bf0f4cf5cb4432fb25e60f776fedb9be0423747e259e"` | Docker image tag for the `frontend` image |
 | frontend.image.name | string | `"frontend"` | Docker image name for the `frontend` image |
 | frontend.ingress.annotations | object | `{"kubernetes.io/ingress.class":"nginx","nginx.ingress.kubernetes.io/proxy-body-size":"150m"}` | Annotations for the Sourcegraph server ingress. For example, securing ingress with TLS provided by [cert-manager](https://cert-manager.io/docs/usage/ingress/) |
+| frontend.ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` | [Deprecated annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) for specifing the IngressClass in Kubernetes 1.17 and earlier. If you are using Kubernetes 1.18+, use `ingressClassName` instead and set an override value of `null` for this annotation. |
 | frontend.ingress.enabled | bool | `true` | Enable ingress for the Sourcegraph server |
 | frontend.ingress.host | string | `""` | External hostname for the Sourcegraph server ingress (SSL) |
-| frontend.ingress.ingressClassName | string | `nil` | IngressClassName for the Ingress (Available in Kubernetes 1.18+) |
+| frontend.ingress.ingressClassName | string | `nil` | IngressClassName for the Ingress (Available in Kubernetes 1.18+) If you set this field, set the annotation `kubernetes.io/ingress.class` to `null` |
 | frontend.ingress.tlsSecret | string | `""` | Secret containing SSL cert |
 | frontend.name | string | `"sourcegraph-frontend"` | Name used by resources. Does not affect service names or PVCs. |
 | frontend.podSecurityContext | object | `{}` | Security context for the `frontend` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -89,7 +89,7 @@ In addition to the documented values, all services also support the following va
 | frontend.ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` | [Deprecated annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) for specifing the IngressClass in Kubernetes 1.17 and earlier. If you are using Kubernetes 1.18+, use `ingressClassName` instead and set an override value of `null` for this annotation. |
 | frontend.ingress.enabled | bool | `true` | Enable ingress for the Sourcegraph server |
 | frontend.ingress.host | string | `""` | External hostname for the Sourcegraph server ingress (SSL) |
-| frontend.ingress.ingressClassName | string | `nil` | IngressClassName for the Ingress (Available in Kubernetes 1.18+) If you set this field, set the annotation `kubernetes.io/ingress.class` to `null` |
+| frontend.ingress.ingressClassName | string | `nil` | IngressClassName for the Ingress (Available in Kubernetes 1.18+) If you set this field, set the annotation `frontend.ingress.annotations."kubernetes.io/ingress.class"` to `null` |
 | frontend.ingress.tlsSecret | string | `""` | Secret containing SSL cert |
 | frontend.name | string | `"sourcegraph-frontend"` | Name used by resources. Does not affect service names or PVCs. |
 | frontend.podSecurityContext | object | `{}` | Security context for the `frontend` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -312,7 +312,7 @@ frontend:
     # -- External hostname for the Sourcegraph server ingress (SSL)
     host: ""
     # -- IngressClassName for the Ingress (Available in Kubernetes 1.18+)
-    # If you set this field, set the annotation `kubernetes.io/ingress.class` to `null`
+    # If you set this field, set the annotation `frontend.ingress.annotations."kubernetes.io/ingress.class"` to `null`
     ingressClassName: null
     # -- Secret containing SSL cert
     tlsSecret: ""

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -305,11 +305,14 @@ frontend:
     enabled: true
     # -- Annotations for the Sourcegraph server ingress. For example, securing ingress with TLS provided by [cert-manager](https://cert-manager.io/docs/usage/ingress/)
     annotations:
+      # --  [Deprecated annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) for specifing the IngressClass in Kubernetes 1.17 and earlier.
+      # If you are using Kubernetes 1.18+, use `ingressClassName` instead and set an override value of `null` for this annotation.
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/proxy-body-size: 150m
     # -- External hostname for the Sourcegraph server ingress (SSL)
     host: ""
     # -- IngressClassName for the Ingress (Available in Kubernetes 1.18+)
+    # If you set this field, set the annotation `kubernetes.io/ingress.class` to `null`
     ingressClassName: null
     # -- Secret containing SSL cert
     tlsSecret: ""


### PR DESCRIPTION
A customer reported issues when they tried to set `ingressClassName`:

```
Error: INSTALLATION FAILED: Ingress.extensions "sourcegraph-frontend" is invalid: annotations.kubernetes.io/ingress.class: Invalid value: "nginx": can not be set when the class field is also set
```

The solution is to set `annotations.kubernetes.io/ingress.class` to `null`.

This PR updates the documentation to make this more clear.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

This is just updating the documentation.
