### PR TITLE
docs: Don't set both ingress.class and ingressClassName in example

### DIFF
--- a/charts/sourcegraph/examples/ingress/override.yaml
+++ b/charts/sourcegraph/examples/ingress/override.yaml
@@ -5,7 +5,7 @@
 frontend:
   ingress:
     annotations:
-      kubernetes.io/ingress.class: custom-value # Changes value of annotation
+      kubernetes.io/ingress.class: null # Disables annotation since we are setting ingressClassName
       nginx.ingress.kubernetes.io/proxy-body-size: null # Disables annotation
       custom-annotation: custom # Adds a new annotation
     ingressClassName: nginx # Sets the ingressClassname


### PR DESCRIPTION
Fix example to follow docs added in https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/165

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

I ran the following two commands and looked at the diff to verify that `kubernetes.io/ingress.class` was `null`
* `helm template ./charts/sourcegraph > output.yaml`
* `helm template --values ./charts/sourcegraph/examples/ingress/override.yaml ./charts/sourcegraph > ingress.yaml`