### PR TITLE
frontend: remove unused CACHE_DIR

### DIFF
--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -84,15 +84,6 @@ spec:
         {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "CODEINTEL_PG") | nindent 8 }}
         {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "CODEINSIGHTS_PG") | nindent 8 }}
         {{- include "sourcegraph.redisConnection" .| nindent 8 }}
-        # POD_NAME is used by CACHE_DIR
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        # CACHE_DIR stores larger items we cache. Majority of it is zip
-        # archives of repositories at a commit.
-        - name: CACHE_DIR
-          value: /mnt/cache/$(POD_NAME)
         {{- if .Values.minio.enabled }}
         - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID
           valueFrom:
@@ -134,8 +125,6 @@ spec:
         securityContext:
           {{- toYaml .Values.frontend.containerSecurityContext | nindent 10 }}
         volumeMounts:
-        - mountPath: /mnt/cache
-          name: cache-ssd
         - mountPath: /home/sourcegraph
           name: home-dir
         {{- if .Values.frontend.extraVolumeMounts }}
@@ -156,8 +145,6 @@ spec:
       {{- end }}
       {{- include "sourcegraph.renderServiceAccountName" (list . "frontend") | trim | nindent 6 }}
       volumes:
-      - emptyDir: {}
-        name: cache-ssd
       - emptyDir: {}
         name: home-dir
       {{- if .Values.frontend.extraVolumes }}


### PR DESCRIPTION
The code backing this variable has been unused for atleast a year. Removing this also allows us to simplify deployment, since right now we tell customers to assign ephemeral storage to frontend (but that will never be used!)

Test Plan: CI. I previously did a lot of validation that we can remove this (reading code, inspecting prod and dogfood environments for cache dir usage)

Part of https://github.com/sourcegraph/sourcegraph/issues/38934