### PR TITLE
Sginn/migrator db env

### DIFF
--- a/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
+++ b/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
@@ -73,3 +73,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Never
+      {{- if .Values.migrator.extraVolumes }}
+      volumes:
+      {{- toYaml .Values.migrator.extraVolumes | nindent 6 }}
+      {{- end }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -54,9 +54,11 @@ spec:
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         args: {{- default (list "up") .Values.migrator.args | toYaml | nindent 8 }}
         env:
+        {{- if not .Values.migrator.databaseAuthOverrideEnvVars }}
         {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
         {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "CODEINTEL_PG") | nindent 8 }}
         {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "CODEINSIGHTS_PG") | nindent 8 }}
+        {{- end }}
         {{- range $name, $item := .Values.frontend.env }}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}

--- a/ci/override.yaml
+++ b/ci/override.yaml
@@ -4,6 +4,3 @@ storageClass:
 
 sourcegraph: 
   localDevMode: true
-  
-migrator:
-  databaseAuthOverrideEnvVars: false

--- a/ci/override.yaml
+++ b/ci/override.yaml
@@ -4,3 +4,6 @@ storageClass:
 
 sourcegraph: 
   localDevMode: true
+  
+migrator:
+  databaseAuthOverrideEnvVars: false


### PR DESCRIPTION
We need to be able to connect to  Cloud SQL Proxy on the service endpoint rather than localhost, but due to the Helm template function we cannot override the env vars (it duplicates it rather than overrides it). This adds a simple boolean flag to disable the function, allowing manual setting of relevant vars.

This is primarily made for spinning up scale testing cluster(s).

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan
`helm template -f ./ci/override.yaml ./charts/sourcegraph`
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
