### PR TITLE
sourcegraph: add `allowedTopologies` support to storageclass

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,10 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+### Added
+
+- Added `allowedTopologies` support to storageclass [#188](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/188)
+
 ## 4.0.1
 
 Sourcegraph 4.0.1 is now available!

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -10,7 +10,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ### Added
 
-- Added `allowedTopologies` support to storageclass [#188](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/188)
+- Added `allowedTopologies` support to storageclass [#188](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/188). This is useful to restrict provisioning of PV in specific zones or regions. In some cloud providers (e.g. GCP), this can be used to provision regional disks with only one worker node present.
 
 ## 4.0.1
 

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -296,6 +296,7 @@ In addition to the documented values, all services also support the following va
 | sourcegraph.revisionHistoryLimit | int | `10` | Global deployment clean up policy, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | sourcegraph.serviceLabels | object | `{}` | Add extra labels to all services |
 | sourcegraph.tolerations | list | `[]` | Global Tolerations, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
+| storageClass.allowedTopologies | object | `{}` | Persistent volumes topology configuration, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies) |
 | storageClass.create | bool | `true` | Enable creation of storageClass. Disable if you have your own existing storage class |
 | storageClass.name | string | `"sourcegraph"` | Name of the storageClass. Use to customize to the existing storage class name |
 | storageClass.parameters | object | `{}` | Extra parameters of storageClass, consult your cloud provider persistent storage documentation |

--- a/charts/sourcegraph/templates/storageclass.yaml
+++ b/charts/sourcegraph/templates/storageclass.yaml
@@ -21,4 +21,8 @@ parameters:
 allowVolumeExpansion: {{ default true .Values.storageClass.allowVolumeExpansion }}
 reclaimPolicy: {{ default "Retain" .Values.storageClass.reclaimPolicy }}
 volumeBindingMode: {{ default "Immediate" .Values.storageClass.volumeBindingMode }}
+{{- if .Values.storageClass.allowedTopologies }}
+allowedTopologies:
+  {{- toYaml .Values.storageClass.allowedTopologies | nindent 2 }}
+{{- end }}
 {{- end -}}

--- a/charts/sourcegraph/tests/storageClass_test.yaml
+++ b/charts/sourcegraph/tests/storageClass_test.yaml
@@ -20,3 +20,24 @@ tests:
   asserts:
   - isNull:
       path: parameters
+- it: should have 'allowedTopologies` when storageClass.allowedTopologies is set
+  set:
+    storageClass:
+      create: true
+      allowedTopologies:
+        - matchLabelExpressions:
+            - key: topology.gke.io/zone
+              values:
+                - us-central1-a
+                - us-central1-b
+                - us-central1-f
+  asserts:
+  - equal:
+      path: allowedTopologies[0]
+      value:
+        matchLabelExpressions:
+        - key: topology.gke.io/zone
+          values:
+          - us-central1-a
+          - us-central1-b
+          - us-central1-f

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1038,6 +1038,9 @@ storageClass:
   # -- Extra parameters of storageClass,
   # consult your cloud provider persistent storage documentation
   parameters: {}
+  # -- Persistent volumes topology configuration,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies)
+  allowedTopologies: {}
 
 symbols:
   image:


### PR DESCRIPTION
context: https://sourcegraph.slack.com/archives/C03LCPCT3SP/p1664966342611049?thread_ts=1664545745.855499&cid=C03LCPCT3SP

Add option to configure https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies

On cloud, adding `allowedTopologies` allow provisioning of regional PD with only one worker node present

For on-prem customer, this would be helpful if they would like to restrict where to run sourcegraph in a shared multi-zone cluster

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->


unit test