### PR TITLE
add node exporter daemonset

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -12,7 +12,19 @@ helm lint charts/sourcegraph/.
 
 ## Unit testing
 
-We utilize [helm-unittest], a BDD styled unit test framework, to validate our helm chart.
+We utilize [helm-unittest](https://github.com/quintush/helm-unittest/), a BDD styled unit test framework, to validate our helm chart.
+
+helm-unittest can be installed with:
+
+```bash
+helm plugin install https://github.com/quintush/helm-unittest
+```
+
+Once the plugin is installed, you can run the unit tests using the following:
+
+```bash
+helm unittest --helm3 ./charts/sourcegraph/.
+```
 
 We currently do not have testing best practices or require unit tests for new changes, so add test cases at your best judgement if possible.
 

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -11,6 +11,14 @@ Use `**BREAKING**:` to denote a breaking change
 ### Added
 
 - Added `allowedTopologies` support to storageclass [#188](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/188). This is useful to restrict provisioning of PV in specific zones or regions. In some cloud providers (e.g. GCP), this can be used to provision regional disks with only one worker node present.
+- Added a node-exporter daemonset, which collects crucial machine-level metrics that help Sourcegraph scale your deployment. See [#194](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/194) for more information
+
+🚨 **WARNING**: Similarly to cadvisor,  `node-exporter`:
+  - runs as a daemonset 
+  - needs to mount various read-only directories from the host machine (`/`, `/proc`, and `/sys`)
+  - ideally shares the machine's PID and Network namespaces
+
+If necessary, node-exporter can be disabled by setting `nodeExporter.enabled: false` in your `override.yaml` configuration file.
 
 ## 4.0.1
 

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -186,7 +186,7 @@ In addition to the documented values, all services also support the following va
 | nodeExporter.extraArgs | list | `[]` |  |
 | nodeExporter.hostNetwork | bool | `true` |  |
 | nodeExporter.hostPID | bool | `true` |  |
-| nodeExporter.image.defaultTag | string | `"4.0.1@sha256:03e4cd2183e454261c2bba0ff89192f661591ebfbc856e7c81ca6bbd4aaf1df8"` | Docker image tag for the `node-exporter` image |
+| nodeExporter.image.defaultTag | string | `"179720_2022-10-25_4d925e87cfb8@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f"` | Docker image tag for the `node-exporter` image |
 | nodeExporter.image.name | string | `"node-exporter"` | Docker image name for the `node-exporter` image |
 | nodeExporter.name | string | `"node-exporter"` | Name used by resources. Does not affect service names or PVCs. |
 | nodeExporter.podSecurityContext | object | `{"fsGroup":65534,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Security context for the `node-exporter` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -181,6 +181,19 @@ In addition to the documented values, all services also support the following va
 | minio.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `minio` |
 | minio.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | minio.storageSize | string | `"100Gi"` | PVC Storage Request for `minio` data volume |
+| nodeExporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsUser":65534}` | Security context for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| nodeExporter.enabled | bool | `true` | Enable `node-exporter` |
+| nodeExporter.extraArgs | list | `[]` |  |
+| nodeExporter.hostNetwork | bool | `true` |  |
+| nodeExporter.hostPID | bool | `true` |  |
+| nodeExporter.image.defaultTag | string | `"4.0.1@sha256:03e4cd2183e454261c2bba0ff89192f661591ebfbc856e7c81ca6bbd4aaf1df8"` | Docker image tag for the `node-exporter` image |
+| nodeExporter.image.name | string | `"node-exporter"` | Docker image name for the `node-exporter` image |
+| nodeExporter.name | string | `"node-exporter"` | Name used by resources. Does not affect service names or PVCs. |
+| nodeExporter.podSecurityContext | object | `{"fsGroup":65534,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Security context for the `node-exporter` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| nodeExporter.podSecurityPolicy.enabled | bool | `false` | Enable [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for `node-exporter` pods |
+| nodeExporter.resources | object | `{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":".2","memory":"100Mi"}}` | Resource requests & limits for the `node-exporter` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| nodeExporter.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `node-exporter` |
+| nodeExporter.serviceAccount.name | string | `"node-exporter"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | openTelemetry.agent.name | string | `"otel-agent"` | Name used by resources. Does not affect service names or PVCs. |
 | openTelemetry.agent.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resource requests & limits for the `otel-agent` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | openTelemetry.enabled | bool | `true` |  |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -181,7 +181,7 @@ In addition to the documented values, all services also support the following va
 | minio.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `minio` |
 | minio.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | minio.storageSize | string | `"100Gi"` | PVC Storage Request for `minio` data volume |
-| nodeExporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsUser":65534}` | Security context for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| nodeExporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsUser":65534}` | Security context for the `node-exporter` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | nodeExporter.enabled | bool | `true` | Enable `node-exporter` |
 | nodeExporter.extraArgs | list | `[]` |  |
 | nodeExporter.hostNetwork | bool | `true` |  |
@@ -189,7 +189,7 @@ In addition to the documented values, all services also support the following va
 | nodeExporter.image.defaultTag | string | `"4.0.1@sha256:03e4cd2183e454261c2bba0ff89192f661591ebfbc856e7c81ca6bbd4aaf1df8"` | Docker image tag for the `node-exporter` image |
 | nodeExporter.image.name | string | `"node-exporter"` | Docker image name for the `node-exporter` image |
 | nodeExporter.name | string | `"node-exporter"` | Name used by resources. Does not affect service names or PVCs. |
-| nodeExporter.podSecurityContext | object | `{"fsGroup":65534,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Security context for the `node-exporter` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| nodeExporter.podSecurityContext | object | `{"fsGroup":65534,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Security context for the `node-exporter` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | nodeExporter.podSecurityPolicy.enabled | bool | `false` | Enable [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for `node-exporter` pods |
 | nodeExporter.resources | object | `{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":".2","memory":"100Mi"}}` | Resource requests & limits for the `node-exporter` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | nodeExporter.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `node-exporter` |

--- a/charts/sourcegraph/templates/NOTES.txt
+++ b/charts/sourcegraph/templates/NOTES.txt
@@ -29,3 +29,37 @@ If you would like to bring your own infrastructure monitoring & alerting solutio
 you may want to disable the `cadvisor` DaemonSet completely by setting `cadvisor.enabled=false` in your override file.
 
 {{- end }}
+
+{{- if not .Values.nodeExporter.enabled }}
+
+🚧 Warning 🚧
+
+You have set 'nodeExporter.enabled' to 'false', which completely disables node exporter. Node exporter provides 
+critical machine-level metrics that help you scale your Sourcegraph deployments. Without node-exporter, you might have 
+to rely on the (possibility limited) tooling that your cloud provider provides to have insight into your machines.
+
+{{- end }}
+
+{{- if not .Values.nodeExporter.hostPID }}
+
+🚧 Warning 🚧
+
+You have set 'nodeExporter.hostPID' to 'false' which greatly limits the metrics that node-exporter is able to provide. Many of the 
+metrics that Sourcegraph uses to help you scale your deployment might be broken as a result.
+
+If you would like to bring your own infrastructure monitoring & alerting solution,
+you may want to disable the `node-exporter` DaemonSet completely by setting `nodeExporter.enabled=false` in your override file.
+
+{{- end }}
+
+{{- if not .Values.nodeExporter.hostNetwork }}
+
+🚧 Warning 🚧
+
+You have set 'nodeExporter.hostNetwork' to 'false' which greatly limits the metrics that node-exporter is able to provide. Many of the 
+metrics that Sourcegraph uses to help you scale your deployment might be broken as a result.
+
+If you would like to bring your own infrastructure monitoring & alerting solution,
+you may want to disable the `node-exporter` DaemonSet completely by setting `nodeExporter.enabled=false` in your override file.
+
+{{- end }}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.ClusterRole.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.ClusterRole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.nodeExporter.enabled -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: node-exporter
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: node-exporter
+  name: {{ .Values.nodeExporter.name }}
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - {{ .Values.nodeExporter.name }}
+{{- end }}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.ClusterRoleBinding.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.ClusterRoleBinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.nodeExporter.enabled -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: node-exporter
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: node-exporter
+  name: {{ .Values.nodeExporter.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.nodeExporter.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "sourcegraph.serviceAccountName" (list . "nodeExporter") }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
@@ -11,6 +11,7 @@ metadata:
       {{- toYaml .Values.nodeExporter.labels | nindent 4 }}
     {{- end }}
     deploy: sourcegraph
+    app: node-exporter
     app.kubernetes.io/component: node-exporter
   name: {{ .Values.nodeExporter.name }}
 spec:
@@ -40,10 +41,10 @@ spec:
         deploy: sourcegraph
         app: node-exporter
     spec:
-      {{- include "sourcegraph.renderServiceAccountName" (list . "node-exporter") | trim | nindent 6 }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "nodeExporter") | trim | nindent 6 }}
       containers:
       - name: node-exporter
-        image: {{ include "sourcegraph.image" (list . "node-exporter" ) }}
+        image: {{ include "sourcegraph.image" (list . "nodeExporter" ) }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         args:
           - --web.listen-address=:9100
@@ -55,6 +56,9 @@ spec:
           - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
           - --collector.netclass.ignored-devices=^(veth.*)$
           - --collector.netdev.device-exclude=^(veth.*)$
+{{- if .Values.nodeExporter.extraArgs }}
+{{ toYaml .Values.nodeExporter.extraArgs | indent 12 }}
+{{- end }}
         env:
         {{- range $name, $item := .Values.nodeExporter.env}}
         - name: {{ $name }}
@@ -79,8 +83,6 @@ spec:
           mountPath: /host/proc
           mountPropagation: HostToContainer
           readOnly: true
-        {{- if .Values.nodeExporter.containerSecurityContext.privileged }}
-        {{- end }}
         {{- if .Values.nodeExporter.extraVolumeMounts }}
         {{- toYaml .Values.nodeExporter.extraVolumeMounts | nindent 8 }}
         {{- end }}
@@ -88,6 +90,23 @@ spec:
         - name: metrics
           containerPort: 9100
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders: []
+            scheme: http
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            scheme: http
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
       terminationMessagePolicy: FallbackToLogsOnError
@@ -96,13 +115,15 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.nodeExporter.podSecurityContext | nindent 8 }}
-      {{- include "sourcegraph.nodeSelector" (list . "node-exporter" ) | trim | nindent 6 }}
-      {{- include "sourcegraph.affinity" (list . "node-exporter" ) | trim | nindent 6 }}
-      {{- include "sourcegraph.tolerations" (list . "node-exporter" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.nodeSelector" (list . "nodeExporter" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "nodeExporter" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "nodeExporter" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      hostNetwork: {{ .Values.nodeExporter.hostNetwork }}
+      hostPID: {{ .Values.nodeExporter.hostPID }}
       volumes:
       - name: rootfs
         hostPath:
@@ -113,8 +134,6 @@ spec:
       - name: proc
         hostPath:
           path: /proc
-      {{- if .Values.nodeExporter.containerSecurityContext.privileged }}
-      {{- end }}
       {{- if .Values.nodeExporter.extraVolumes }}
       {{- toYaml .Values.nodeExporter.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
@@ -93,7 +93,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            scheme: http
+            scheme: HTTP
             port: metrics
           initialDelaySeconds: 0
           periodSeconds: 10
@@ -102,7 +102,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            scheme: http
+            scheme: HTTP
             port: metrics
           initialDelaySeconds: 0
           periodSeconds: 10

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
@@ -57,7 +57,7 @@ spec:
           - --collector.netclass.ignored-devices=^(veth.*)$
           - --collector.netdev.device-exclude=^(veth.*)$
 {{- if .Values.nodeExporter.extraArgs }}
-{{ toYaml .Values.nodeExporter.extraArgs | indent 12 }}
+{{ toYaml .Values.nodeExporter.extraArgs | indent 10 }}
 {{- end }}
         env:
         {{- range $name, $item := .Values.nodeExporter.env}}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
@@ -107,9 +107,9 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+        terminationMessagePolicy: FallbackToLogsOnError
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
-      terminationMessagePolicy: FallbackToLogsOnError
       {{- if .Values.nodeExporter.extraContainers }}
         {{- toYaml .Values.nodeExporter.extraContainers | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.nodeExporter.enabled -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    description: DaemonSet to ensure all nodes run a node-exporter pod.
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+  labels:
+    {{- include "sourcegraph.labels" . | nindent 4 }}
+    {{- if .Values.nodeExporter.labels }}
+      {{- toYaml .Values.nodeExporter.labels | nindent 4 }}
+    {{- end }}
+    deploy: sourcegraph
+    app.kubernetes.io/component: node-exporter
+  name: {{ .Values.nodeExporter.name }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: node-exporter
+  template:
+    metadata:
+      annotations:
+        description: Collects and exports machine metrics.
+        kubectl.kubernetes.io/default-container: node-exporter
+      {{- if .Values.sourcegraph.podAnnotations }}
+      {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeExporter.podAnnotations }}
+      {{- toYaml .Values.nodeExporter.podAnnotations | nindent 8 }}
+      {{- end }}
+      labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
+      {{- if .Values.sourcegraph.podLabels }}
+      {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeExporter.podLabels }}
+      {{- toYaml .Values.nodeExporter.podLabels | nindent 8 }}
+      {{- end }}
+        deploy: sourcegraph
+        app: node-exporter
+    spec:
+      {{- include "sourcegraph.renderServiceAccountName" (list . "node-exporter") | trim | nindent 6 }}
+      containers:
+      - name: node-exporter
+        image: {{ include "sourcegraph.image" (list . "node-exporter" ) }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        args:
+          - --web.listen-address=:9100
+          - --path.sysfs=/host/sys
+          - --path.rootfs=/host/root
+          - --path.procfs=/host/proc
+          - --no-collector.wifi
+          - --no-collector.hwmon
+          - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+          - --collector.netclass.ignored-devices=^(veth.*)$
+          - --collector.netdev.device-exclude=^(veth.*)$
+        env:
+        {{- range $name, $item := .Values.nodeExporter.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if not .Values.sourcegraph.localDevMode }}
+        resources:
+          {{- toYaml .Values.nodeExporter.resources | nindent 10 }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.nodeExporter.containerSecurityContext | nindent 10 }}
+        volumeMounts:
+        - name: rootfs
+          mountPath: /host/root
+          mountPropagation: HostToContainer
+          readOnly: true
+        - name: sys
+          mountPath: /host/sys
+          mountPropagation: HostToContainer
+          readOnly: true
+        - name: proc
+          mountPath: /host/proc
+          mountPropagation: HostToContainer
+          readOnly: true
+        {{- if .Values.nodeExporter.containerSecurityContext.privileged }}
+        {{- end }}
+        {{- if .Values.nodeExporter.extraVolumeMounts }}
+        {{- toYaml .Values.nodeExporter.extraVolumeMounts | nindent 8 }}
+        {{- end }}
+        ports:
+        - name: metrics
+          containerPort: 9100
+          protocol: TCP
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      terminationMessagePolicy: FallbackToLogsOnError
+      {{- if .Values.nodeExporter.extraContainers }}
+        {{- toYaml .Values.nodeExporter.extraContainers | nindent 6 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.nodeExporter.podSecurityContext | nindent 8 }}
+      {{- include "sourcegraph.nodeSelector" (list . "node-exporter" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "node-exporter" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "node-exporter" ) | trim | nindent 6 }}
+      {{- with .Values.sourcegraph.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: proc
+        hostPath:
+          path: /proc
+      {{- if .Values.nodeExporter.containerSecurityContext.privileged }}
+      {{- end }}
+      {{- if .Values.nodeExporter.extraVolumes }}
+      {{- toYaml .Values.nodeExporter.extraVolumes | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
@@ -93,8 +93,8 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            httpHeaders: []
             scheme: http
+            port: metrics
           initialDelaySeconds: 0
           periodSeconds: 10
           successThreshold: 1
@@ -103,6 +103,7 @@ spec:
           failureThreshold: 3
           httpGet:
             scheme: http
+            port: metrics
           initialDelaySeconds: 0
           periodSeconds: 10
           successThreshold: 1

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.PodSecurityPolicy.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.PodSecurityPolicy.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   privileged: false
   hostIPC: false
-  hostNetwork: true
-  hostPid: true
+  hostNetwork: {{ .Values.nodeExporter.hostNetwork }}
+  hostPID: {{ .Values.nodeExporter.hostPID }}
   seLinux:
     rule: RunAsAny
   supplementalGroups:

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.PodSecurityPolicy.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.PodSecurityPolicy.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.nodeExporter.enabled .Values.nodeExporter.podSecurityPolicy.enabled  -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: node-exporter
+    deploy: sourcegraph
+    app.kubernetes.io/component: node-exporter
+  name: {{ .Values.nodeExporter.name }}
+spec:
+  privileged: false
+  hostNetwork: true
+  hostPid: true
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - '*'
+  allowedHostPaths:
+  - pathPrefix: "/"
+  - pathPrefix: "/sys"
+  - pathPrefix: "/proc"
+{{- end }}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.PodSecurityPolicy.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.PodSecurityPolicy.yaml
@@ -9,6 +9,7 @@ metadata:
   name: {{ .Values.nodeExporter.name }}
 spec:
   privileged: false
+  hostIPC: false
   hostNetwork: true
   hostPid: true
   seLinux:
@@ -25,4 +26,5 @@ spec:
   - pathPrefix: "/"
   - pathPrefix: "/sys"
   - pathPrefix: "/proc"
+  readOnlyRootFilesystem: true
 {{- end }}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.Service.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.Service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.nodeExporter.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: Prometheus exporter for hardware and OS metrics.
+    url: https://github.com/prometheus/node_exporter
+    prometheus.io/port: "9100"
+    sourcegraph.prometheus/scrape: "true"
+    {{- if .Values.nodeExporter.serviceAnnotations }}
+    {{- toYaml .Values.nodeExporter.serviceAnnotations | nindent 4 }}
+    {{- end }}
+  labels:
+    app.kubernetes.io/component: node-exporter
+    app: node-exporter
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    {{- if .Values.nodeExporter.serviceLabels }}
+      {{- toYaml .Values.nodeExporter.serviceLabels | nindent 4 }}
+    {{- end }}
+  name: node-exporter
+spec:
+  ports:
+  - name: metrics
+    port: 9100
+    targetPort: meterics
+  selector:
+    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
+    app: node-exporter
+  type: {{ .Values.nodeExporter.serviceType | default "ClusterIP" }}
+{{- end }}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.Service.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.Service.yaml
@@ -23,7 +23,7 @@ spec:
   ports:
   - name: metrics
     port: 9100
-    targetPort: meterics
+    targetPort: metrics
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: node-exporter

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.ServiceAccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.nodeExporter.enabled .Values.nodeExporter.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: node-exporter
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: node-exporter
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "nodeExporter") | trim | nindent 2 }}
+  name: {{ include "sourcegraph.serviceAccountName" (list . "nodeExporter") }}
+{{- end }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
@@ -171,6 +171,11 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: instance
+      # Sourcegraph specific customization. We want to add a label to every 
+      # metric that indicates the node it came from.
+      - source_labels: [__meta_kubernetes_endpoint_node_name]
+        action: replace
+        target_label: nodename
 
     # Example scrape config for probing services via the Blackbox Exporter.
     #
@@ -242,6 +247,11 @@ data:
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: ns
+      # Sourcegraph specific customization. We want to add a label to every 
+      # metric that indicates the node it came from.
+      - source_labels: [__meta_kubernetes_endpoint_node_name]
+        action: replace
+        target_label: nodename
 
       metric_relabel_configs:
       # cAdvisor-specific customization. Drop container metrics exported by cAdvisor

--- a/charts/sourcegraph/tests/nodeExporter_test.yaml
+++ b/charts/sourcegraph/tests/nodeExporter_test.yaml
@@ -1,0 +1,173 @@
+suite: nodeExporter
+templates:
+  - NOTES.txt
+  - node-exporter/node-exporter.ClusterRole.yaml
+  - node-exporter/node-exporter.ClusterRoleBinding.yaml
+  - node-exporter/node-exporter.DaemonSet.yaml
+  - node-exporter/node-exporter.PodSecurityPolicy.yaml
+  - node-exporter/node-exporter.Service.yaml
+  - node-exporter/node-exporter.ServiceAccount.yaml
+tests:
+  - it: should render the DaemonSet, Service, and ClusterRoles if node-exporter is enabled
+    set: 
+      nodeExporter:
+        enabled: true
+    asserts:
+      - containsDocument:
+          kind: DaemonSet
+          apiVersion: apps/v1
+          name: node-exporter
+        template: node-exporter/node-exporter.DaemonSet.yaml
+      - containsDocument:
+          kind: Service
+          apiVersion: v1
+          name: node-exporter
+        template: node-exporter/node-exporter.Service.yaml
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: node-exporter
+        template: node-exporter/node-exporter.ClusterRole.yaml
+      - containsDocument:
+          kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: node-exporter
+        template: node-exporter/node-exporter.ClusterRoleBinding.yaml
+
+  - it: should not render any resources if node-exporter is disabled
+    set: 
+      nodeExporter:
+        enabled: false
+    asserts:
+      - hasDocuments: 
+          count: 0
+    templates:
+      - node-exporter/node-exporter.ClusterRole.yaml
+      - node-exporter/node-exporter.ClusterRoleBinding.yaml
+      - node-exporter/node-exporter.DaemonSet.yaml
+      - node-exporter/node-exporter.PodSecurityPolicy.yaml
+      - node-exporter/node-exporter.Service.yaml
+      - node-exporter/node-exporter.ServiceAccount.yaml
+
+  - it: should render the podSecurityPolicy if enabled
+    set: 
+      nodeExporter:
+        podSecurityPolicy: 
+          enabled: true
+    asserts:
+      - containsDocument:
+          kind: PodSecurityPolicy
+          apiVersion: policy/v1beta1
+          name: node-exporter
+        template: node-exporter/node-exporter.PodSecurityPolicy.yaml
+
+  - it: should not render the podSecurityPolicy if disabled 
+    set: 
+      nodeExporter:
+        podSecurityPolicy: 
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: node-exporter/node-exporter.PodSecurityPolicy.yaml
+  
+  - it: should ensure that the namespace is properly propagated to the cluster role binding 
+    release:
+      namespace: "my-test-namespace"
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: "my-test-namespace"
+    template: node-exporter/node-exporter.ClusterRoleBinding.yaml
+
+  - it: should have host Network and PID enabled by default
+    set:
+      nodeExporter:
+        podSecurityPolicy: # (unrelated to host network/pid defaults, just for ensuring that PodSecurityPolicy gets rendered so that we can check them in same test)
+          enabled: true
+    asserts:  
+      - equal: 
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: node-exporter/node-exporter.DaemonSet.yaml
+      - equal: 
+          path: spec.template.spec.hostPID
+          value: true
+        template: node-exporter/node-exporter.DaemonSet.yaml
+      - equal: 
+          path: spec.hostNetwork
+          value: true
+        template: node-exporter/node-exporter.PodSecurityPolicy.yaml
+      - equal: 
+          path: spec.hostPID
+          value: true
+        template: node-exporter/node-exporter.PodSecurityPolicy.yaml
+  
+  - it: should propagate host PID/network settings to both the daemonset and podSecurityPolicy
+    set:
+      nodeExporter:
+        hostNetwork: false 
+        hostPID: false
+        podSecurityPolicy: # (unrelated to host network/pid settings, just for ensuring that PodSecurityPolicy gets rendered so that we can check them in same test)
+          enabled: true
+    asserts:  
+      - equal: 
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: node-exporter/node-exporter.DaemonSet.yaml
+      - equal: 
+          path: spec.template.spec.hostPID
+          value: false
+        template: node-exporter/node-exporter.DaemonSet.yaml
+      - equal: 
+          path: spec.hostNetwork
+          value: false
+        template: node-exporter/node-exporter.PodSecurityPolicy.yaml
+      - equal: 
+          path: spec.hostPID
+          value: false
+        template: node-exporter/node-exporter.PodSecurityPolicy.yaml
+
+  - it: should not generate warnings if node-exporter is enabled
+    set:
+      nodeExporter:
+        enabled: true
+    asserts:  
+      - notMatchRegexRaw:
+          pattern: You have set 'nodeExporter.enabled' to 'false'
+        template: NOTES.txt
+  
+  - it: should generate warnings if node-exporter is disabled
+    set:
+      nodeExporter:
+        enabled: false
+    asserts:  
+      - matchRegexRaw:
+          pattern: You have set 'nodeExporter.enabled' to 'false'
+        template: NOTES.txt
+
+  - it: should not generate warnings if hostPID or hostNetwork are true
+    set:
+      nodeExporter:
+        hostNetwork: true 
+        hostPID: true
+    asserts:  
+      - notMatchRegexRaw:
+          pattern: You have set 'nodeExporter.hostPID' to 'false'
+        template: NOTES.txt
+      - notMatchRegexRaw:
+          pattern: You have set 'nodeExporter.hostNetwork' to 'false'
+        template: NOTES.txt
+
+  - it: should generate warnings if hostPID or hostNetwork are false 
+    set:
+      nodeExporter:
+        hostNetwork: false 
+        hostPID: false
+    asserts:  
+      - matchRegexRaw:
+          pattern: You have set 'nodeExporter.hostPID' to 'false'
+        template: NOTES.txt
+      - matchRegexRaw:
+          pattern: You have set 'nodeExporter.hostNetwork' to 'false'
+        template: NOTES.txt

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -704,8 +704,8 @@ nodeExporter:
     runAsUser: 65534
     runAsGroup: 65534
     readOnlyRootFilesystem: true
-  # -- Security context for the `node-exporter` container,
-  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  # -- Security context for the `node-exporter` pod,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext:
     fsGroup: 65534
     runAsGroup: 65534

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -697,7 +697,7 @@ nodeExporter:
   extraArgs: []
   #   - --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v)d[a-z]|nvme\\d+n\\d+p)\\d+$
   #   - --collector.textfile.directory=/run/prometheus
-  # -- Security context for the `pgsql` container,
+  # -- Security context for the `node-exporter` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
   containerSecurityContext:
     allowPrivilegeEscalation: false

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -661,6 +661,44 @@ openTelemetry:
       requests:
         cpu: "100m"
         memory: 100Mi
+
+nodeExporter:
+  # -- Enable `node-exporter`
+  enabled: true
+  image:
+    # -- Docker image tag for the `node-exporter` image
+    defaultTag: 4.0.1@sha256:03e4cd2183e454261c2bba0ff89192f661591ebfbc856e7c81ca6bbd4aaf1df8
+    # -- Docker image name for the `node-exporter` image
+    name: "node-exporter"
+  # -- Name used by resources. Does not affect service names or PVCs.
+  name: "node-exporter"
+  podSecurityPolicy:
+    # -- Enable [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for `node-exporter` pods
+    enabled: false
+  # -- Resource requests & limits for the `node-exporter` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  resources:
+    limits:
+      cpu: 200m
+      memory: 100Mi
+    requests:
+      cpu: '1'
+      memory: 1Gi
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `node-exporter`
+    create: true
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: node-exporter
+
+  # Share the host process ID namespace. 
+  hostPID: true
+  # -- Security context for the `node-exporter` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  podSecurityContext:
+    fsGroup: 65534
+    runAsGroup: 65534
+    runAsNonRoot: true
+    runAsUser: 65534
     
 pgsql:
   # -- Enable `pgsql` PostgreSQL server

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -679,11 +679,11 @@ nodeExporter:
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
     limits:
-      cpu: 200m
-      memory: 100Mi
-    requests:
       cpu: '1'
       memory: 1Gi
+    requests:
+      cpu: '.2'
+      memory: 100Mi
   serviceAccount:
     # -- Enable creation of ServiceAccount for `node-exporter`
     create: true

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -689,9 +689,21 @@ nodeExporter:
     create: true
     # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: node-exporter
-
   # Share the host process ID namespace. 
   hostPID: true
+  # Expose the service to the host network
+  hostNetwork: true
+  ## Additional container arguments for the node-exporter container
+  extraArgs: []
+  #   - --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v)d[a-z]|nvme\\d+n\\d+p)\\d+$
+  #   - --collector.textfile.directory=/run/prometheus
+  # -- Security context for the `pgsql` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
+    runAsGroup: 65534
+    readOnlyRootFilesystem: true
   # -- Security context for the `node-exporter` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
   podSecurityContext:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -667,7 +667,7 @@ nodeExporter:
   enabled: true
   image:
     # -- Docker image tag for the `node-exporter` image
-    defaultTag: 4.0.1@sha256:03e4cd2183e454261c2bba0ff89192f661591ebfbc856e7c81ca6bbd4aaf1df8
+    defaultTag: 179720_2022-10-25_4d925e87cfb8@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f
     # -- Docker image name for the `node-exporter` image
     name: "node-exporter"
   # -- Name used by resources. Does not affect service names or PVCs.


### PR DESCRIPTION
### Overview 

_See https://github.com/sourcegraph/sourcegraph/pull/43107 for more context._

This PR adds [node-exporter](https://github.com/prometheus/node_exporter) to our kubernetes deployment.  Node-exporter is a Prometheus exporter that exposes machine-level metrics (as opposed to [cadvisor](https://github.com/google/cadvisor), which exposes _container_-level metrics). Node-exporter can expose metrics like [disk i/o stats](https://github.com/sourcegraph/sourcegraph/pull/43070), which can help us scale Sourcegraph deployments for our larger customers. 


---


Overall Node-exporter's deployement is quite similar to our existing [cadvisor](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/templates/cadvisor) configuraion:
- It needs to **run as a daemonset** (where each node-exporter instance is scraping a different node in the cluster)
- In order to gather stats from the node, node-exporter needs to mount special directories from the host such as `/`, `/proc`, and `/sys` (as readonly):
	https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/5607d33260534d5e13ce73dcd9370b5a6ea05fc8/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml#L128-L137 
- In order to gather some metrics from the host, it needs to share the host's PID and Network namespaces:
	- https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/5607d33260534d5e13ce73dcd9370b5a6ea05fc8/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml#L126-L127

However, unlike cadvisor, node exporter:
- Does **not need to run as root**: 
	https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/5607d33260534d5e13ce73dcd9370b5a6ea05fc8/charts/sourcegraph/values.yaml#L702-L713 
- Does **not** need to read the kernel logs (/`dev/kmsg`)
- Does **not** need to mount the host's `/var/lib/docker`
-  Uses a do-nothing services so that Prometheus can scrape all of its endpoints: https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/node-exporter/charts/sourcegraph/templates/node-exporter/node-exporter.Service.yaml


---

Node-exporter is enabled by default since it'll help us collect crucial machine-level statistics. 

However, I realize that there are users that don't want to run a daemonset of any sort / are unwilling to run services that mount `/`, `/proc`, and `/sys`. For those users, they can disable node exporter (and all of its associated resources) by setting `nodeExporter.enabled: false` in their override file.  This is documented in the changelog. 


### Other miscellaneous changes

- I tweaked the default prometheus configuration to add a new label, "nodename" to all of our metrics. This allows us to know which node in the cluster a given metric is coming from. 

### Checklist

- [ ] figure out what to do with image tag
- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan


#### unit tests

 I wrote some unit tests here: https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/node-exporter/charts/sourcegraph/tests/nodeExporter_test.yaml

 I also some wrote some "rote" unit tests that check to see if simple substitutions (such as specifying container resources) were working properly. I ended up removing these since I wasn't sure if they were high-value tests (and no other unit tests were testing these kinds of things). I can add some of them back if you think they're worth it, however). 

<details>
<summary>Example of rote test</summary>

```yaml
 - it: should propagate any set resources 
    set:
      nodeExporter:
        resources:
          limits:
            cpu: '9999'
          requests:
            memory: '1Ki'
    asserts:
      - equal:
          path: spec.template.spec.containers[0].resources.limits.cpu
          value: '9999'
      - equal:
          path: spec.template.spec.containers[0].resources.requests.memory
          value: '1Ki'
    templates: 
      - node-exporter/node-exporter.DaemonSet.yaml
```

</details>

#### local smoke test 

- I also smoke-tested this change by deploying this helm chart locally (using the instructions in [TEST.md](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/node-exporter/TEST.md) with the following override file):

```yaml
nodeExporter:
  enabled: true
  image:
    defaultTag: 179720_2022-10-25_4d925e87cfb8@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f
  # extraArgs: [
  #   "--help",
  #   ]
# Disable SC creation
storageClass:
  create: false
  name: standard

# Disable resources requests/limits
sourcegraph:
  localDevMode: true
```

I then port-forwarded the grafana service and verified that I was able to pull up a metric that node-exporter provides:

<img width="1677" alt="image" src="https://user-images.githubusercontent.com/9022011/198137423-b5bcd168-5e61-4278-a222-5bcedb8f1e3a.png">
