### PR TITLE
node-exporter: only render clusterrole if PSP is enabled

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -184,7 +184,6 @@ In addition to the documented values, all services also support the following va
 | nodeExporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsUser":65534}` | Security context for the `node-exporter` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | nodeExporter.enabled | bool | `true` | Enable `node-exporter` |
 | nodeExporter.extraArgs | list | `[]` |  |
-| nodeExporter.hostNetwork | bool | `true` |  |
 | nodeExporter.hostPID | bool | `true` |  |
 | nodeExporter.image.defaultTag | string | `"179720_2022-10-25_4d925e87cfb8@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f"` | Docker image tag for the `node-exporter` image |
 | nodeExporter.image.name | string | `"node-exporter"` | Docker image name for the `node-exporter` image |

--- a/charts/sourcegraph/templates/NOTES.txt
+++ b/charts/sourcegraph/templates/NOTES.txt
@@ -51,15 +51,3 @@ If you would like to bring your own infrastructure monitoring & alerting solutio
 you may want to disable the `node-exporter` DaemonSet completely by setting `nodeExporter.enabled=false` in your override file.
 
 {{- end }}
-
-{{- if not .Values.nodeExporter.hostNetwork }}
-
-🚧 Warning 🚧
-
-You have set 'nodeExporter.hostNetwork' to 'false' which greatly limits the metrics that node-exporter is able to provide. Many of the 
-metrics that Sourcegraph uses to help you scale your deployment might be broken as a result.
-
-If you would like to bring your own infrastructure monitoring & alerting solution,
-you may want to disable the `node-exporter` DaemonSet completely by setting `nodeExporter.enabled=false` in your override file.
-
-{{- end }}

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.DaemonSet.yaml
@@ -125,7 +125,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      hostNetwork: {{ .Values.nodeExporter.hostNetwork }}
       hostPID: {{ .Values.nodeExporter.hostPID }}
       volumes:
       - name: rootfs

--- a/charts/sourcegraph/templates/node-exporter/node-exporter.PodSecurityPolicy.yaml
+++ b/charts/sourcegraph/templates/node-exporter/node-exporter.PodSecurityPolicy.yaml
@@ -15,7 +15,6 @@ metadata:
 spec:
   privileged: false
   hostIPC: false
-  hostNetwork: {{ .Values.nodeExporter.hostNetwork }}
   hostPID: {{ .Values.nodeExporter.hostPID }}
   seLinux:
     rule: RunAsAny

--- a/charts/sourcegraph/tests/nodeExporter_test.yaml
+++ b/charts/sourcegraph/tests/nodeExporter_test.yaml
@@ -143,55 +143,38 @@ tests:
           value: "my-test-namespace"
     template: node-exporter/node-exporter.ClusterRoleBinding.yaml
 
-  - it: should have host Network and PID enabled by default
+  - it: should have hostPID enabled by default
     set:
       nodeExporter:
-        # (these settings are unrelated to host network/pid defaults, they're just for ensuring that PodSecurityPolicy gets rendered so that we can check them in same test)
+        # (these settings are unrelated to host pid defaults, they're just for ensuring that PodSecurityPolicy gets rendered so that we can check them in same test)
         serviceAccount:
           create: true
         podSecurityPolicy:
           enabled: true
     asserts:  
       - equal: 
-          path: spec.template.spec.hostNetwork
-          value: true
-        template: node-exporter/node-exporter.DaemonSet.yaml
-      - equal: 
           path: spec.template.spec.hostPID
           value: true
         template: node-exporter/node-exporter.DaemonSet.yaml
-      - equal: 
-          path: spec.hostNetwork
-          value: true
-        template: node-exporter/node-exporter.PodSecurityPolicy.yaml
       - equal: 
           path: spec.hostPID
           value: true
         template: node-exporter/node-exporter.PodSecurityPolicy.yaml
   
-  - it: should propagate host PID/network settings to both the daemonset and podSecurityPolicy
+  - it: should propagate host PID settings to both the daemonset and podSecurityPolicy
     set:
       nodeExporter:
-        hostNetwork: false 
         hostPID: false
-        # (these settings are unrelated to host network/pid defaults, they're just for ensuring that PodSecurityPolicy gets rendered so that we can check them in same test)
+        # (these settings are unrelated to host pid defaults, they're just for ensuring that PodSecurityPolicy gets rendered so that we can check them in same test)
         serviceAccount:
           create: true
         podSecurityPolicy:
           enabled: true
     asserts:  
       - equal: 
-          path: spec.template.spec.hostNetwork
-          value: false
-        template: node-exporter/node-exporter.DaemonSet.yaml
-      - equal: 
           path: spec.template.spec.hostPID
           value: false
         template: node-exporter/node-exporter.DaemonSet.yaml
-      - equal: 
-          path: spec.hostNetwork
-          value: false
-        template: node-exporter/node-exporter.PodSecurityPolicy.yaml
       - equal: 
           path: spec.hostPID
           value: false
@@ -215,28 +198,20 @@ tests:
           pattern: You have set 'nodeExporter.enabled' to 'false'
         template: NOTES.txt
 
-  - it: should not generate warnings if hostPID or hostNetwork are true
+  - it: should not generate warnings if hostPID is true
     set:
       nodeExporter:
-        hostNetwork: true 
         hostPID: true
     asserts:  
       - notMatchRegexRaw:
           pattern: You have set 'nodeExporter.hostPID' to 'false'
         template: NOTES.txt
-      - notMatchRegexRaw:
-          pattern: You have set 'nodeExporter.hostNetwork' to 'false'
-        template: NOTES.txt
 
-  - it: should generate warnings if hostPID or hostNetwork are false 
+  - it: should generate warnings if hostPID is false 
     set:
       nodeExporter:
-        hostNetwork: false 
         hostPID: false
     asserts:  
       - matchRegexRaw:
           pattern: You have set 'nodeExporter.hostPID' to 'false'
-        template: NOTES.txt
-      - matchRegexRaw:
-          pattern: You have set 'nodeExporter.hostNetwork' to 'false'
         template: NOTES.txt

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -691,8 +691,6 @@ nodeExporter:
     name: node-exporter
   # Share the host process ID namespace. 
   hostPID: true
-  # Expose the service to the host network
-  hostNetwork: true
   ## Additional container arguments for the node-exporter container
   extraArgs: []
   #   - --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v)d[a-z]|nvme\\d+n\\d+p)\\d+$


### PR DESCRIPTION
Stacks on https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/203



### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md) - not necessary, this chart hasn't been released yet

### Test plan

The `hostNetwork: true` setting has[ already been removed on sourcegraph.com](https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/17401).
