### PR TITLE
changelog: move node exporter nodes to unreleased

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,15 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Added a node-exporter daemonset, which collects crucial machine-level metrics that help Sourcegraph scale your deployment. See [#194](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/194) for more information
+
+  - 🚨 **WARNING**: Similarly to cadvisor,  `node-exporter`:
+    - runs as a daemonset 
+    - needs to mount various read-only directories from the host machine (`/`, `/proc`, and `/sys`)
+    - ideally shares the machine's PID namespaces
+
+  - If necessary, node-exporter can be disabled by setting `nodeExporter.enabled: false` in your `override.yaml` configuration file.
+
 ## 4.1.2
 
 Sourcegraph 4.1.2 is now available!
@@ -23,14 +32,6 @@ Sourcegraph 4.1.1 is now available!
 Sourcegraph 4.1.0 is now available!
 - [Changelog](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md#4-1-0)
 - Added `allowedTopologies` support to storageclass [#188](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/188). This is useful to restrict provisioning of PV in specific zones or regions. In some cloud providers (e.g. GCP), this can be used to provision regional disks with only one worker node present.
-- Added a node-exporter daemonset, which collects crucial machine-level metrics that help Sourcegraph scale your deployment. See [#194](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/194) for more information
-
-🚨 **WARNING**: Similarly to cadvisor,  `node-exporter`:
-  - runs as a daemonset 
-  - needs to mount various read-only directories from the host machine (`/`, `/proc`, and `/sys`)
-  - ideally shares the machine's PID namespaces
-
-If necessary, node-exporter can be disabled by setting `nodeExporter.enabled: false` in your `override.yaml` configuration file.
 
 ## 4.0.1
 


### PR DESCRIPTION
This was accidentally moved to the 4.1.x release section

### Checklist

- [x ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

N/A - this is just a changelog change
