### PR TITLE
test-connection: allow test-connection pod configuration

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -332,10 +332,6 @@ In addition to the documented values, all services also support the following va
 | syntectServer.resources | object | `{"limits":{"cpu":"4","memory":"6G"},"requests":{"cpu":"250m","memory":"2G"}}` | Resource requests & limits for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | syntectServer.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `syntect-server` |
 | syntectServer.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
-| testConnection.enabled | bool | `true` | Enable `test-connection` test |
-| testConnection.image.defaultTag | string | `"latest"` | Docker image tag for the `test-connection` image |
-| testConnection.image.name | string | `"busybox"` | Docker image name for the `test-connection` image |
-| testConnection.name | string| `"sg-test-connection"` | Name used by resources. Does not effect service names of PVCs. |
 | worker.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | worker.image.defaultTag | string | `"4.1.2@sha256:79c85866469e96379a6f0b36c2deee08ba3d81520f6fffc8de16a6e7667a67ab"` | Docker image tag for the `worker` image |
 | worker.image.name | string | `"worker"` | Docker image name for the `worker` image |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -332,6 +332,10 @@ In addition to the documented values, all services also support the following va
 | syntectServer.resources | object | `{"limits":{"cpu":"4","memory":"6G"},"requests":{"cpu":"250m","memory":"2G"}}` | Resource requests & limits for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | syntectServer.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `syntect-server` |
 | syntectServer.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| testConnection.enabled | bool | `true` | Enable `test-connection` test |
+| testConnection.image.defaultTag | string | `"latest"` | Docker image tag for the `test-connection` image |
+| testConnection.image.name | string | `"busybox"` | Docker image name for the `test-connection` image |
+| testConnection.name | string| `"sg-test-connection"` | Name used by resources. Does not effect service names of PVCs. |
 | worker.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | worker.image.defaultTag | string | `"4.1.2@sha256:79c85866469e96379a6f0b36c2deee08ba3d81520f6fffc8de16a6e7667a67ab"` | Docker image tag for the `worker` image |
 | worker.image.name | string | `"worker"` | Docker image name for the `worker` image |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -332,6 +332,10 @@ In addition to the documented values, all services also support the following va
 | syntectServer.resources | object | `{"limits":{"cpu":"4","memory":"6G"},"requests":{"cpu":"250m","memory":"2G"}}` | Resource requests & limits for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | syntectServer.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `syntect-server` |
 | syntectServer.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| testConnection.enabled | bool | `true` | Enable `test-connection` |
+| testConnection.image.defaultTag | string | `"latest"` | Docker image tag for the `test-connection` image |
+| testConnection.image.name | string | `"busybox"` | Docker image name for the `test-connection` image |
+| testConnection.name | string | `"sg-test-connection"` | Name used by resources. Does not affect service names or PVCs. |
 | worker.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | worker.image.defaultTag | string | `"4.1.2@sha256:79c85866469e96379a6f0b36c2deee08ba3d81520f6fffc8de16a6e7667a67ab"` | Docker image tag for the `worker` image |
 | worker.image.name | string | `"worker"` | Docker image name for the `worker` image |

--- a/charts/sourcegraph/templates/tests/test-connection.yaml
+++ b/charts/sourcegraph/templates/tests/test-connection.yaml
@@ -1,15 +1,20 @@
+{{- if .Values.testConnection.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "sg-test-connection"
+  name: {{ .Values.testConnection.name }}
   labels:
     {{- include "sourcegraph.labels" . | nindent 4 }}
+    {{- if .Values.testConnection.labels }}
+      {{- toYaml .Values.testConnection.labels | nindent 4 }}
+    {{- end }}
   annotations:
     "helm.sh/hook": test
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: {{ .Values.testConnection.image.name }}:{{ .Values.testConnection.image.defaultTag }}
       command: ['wget']
       args: ['sourcegraph-frontend:30080/']
   restartPolicy: Never
+{{- end }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1255,6 +1255,17 @@ worker:
     create: false
     # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: ""
+      
+testConnection:
+  # -- Enable `test-connection`
+  enabled: true
+  image:
+    # -- Docker image tag for the `test-connection` image
+    defaultTag: "latest"
+    # -- Docker image name for the `test-connection` image
+    name: "busybox"
+  # -- Name used by resources. Does not affect service names or PVCs.
+  name: "sg-test-connection"
 
 # -- Additional resources to include in the rendered manifest. Templates are supported.
 extraResources: []


### PR DESCRIPTION
Add support for disabling or changing the `test-connections` pod. See issue #189.

This PR makes the following changes:
* `testConnection` is enabled by default and uses the `busybox:latest` image from DockerHub.
* `testConnection` can be disabled or set to use a different image using the `override.yaml` file.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan
This is a change to a test. The manual testing process was followed as described above. 
