### PR TITLE
prometheus: drop labels with duplicate nodename entries

### DIFF
--- a/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
@@ -254,7 +254,7 @@ data:
         target_label: ns
       # Sourcegraph specific customization. We want to add a label to every 
       # metric that indicates the node it came from.
-      - source_labels: [__meta_kubernetes_endpoint_node_name]
+      - source_labels: [__meta_kubernetes_pod_node_name]
         action: replace
         target_label: nodename
 

--- a/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
@@ -176,6 +176,11 @@ data:
       - source_labels: [__meta_kubernetes_endpoint_node_name]
         action: replace
         target_label: nodename
+      metric_relabel_configs:
+      # Sourcegraph specific customization. Drop metrics with empty nodename responses from the k8s API
+      - source_labels: [nodename]
+        regex: ^$
+        action: drop
 
     # Example scrape config for probing services via the Blackbox Exporter.
     #
@@ -272,6 +277,10 @@ data:
         action: replace
         target_label: name
         separator: '-'
+      # Sourcegraph specific customization. Drop metrics with empty nodename responses from the k8s API
+      - source_labels: [nodename]
+        regex: ^$
+        action: drop
 
     # Scrape prometheus itself for metrics.
     - job_name: 'builtin-prometheus'


### PR DESCRIPTION
Follows https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/pull/5616, https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/pull/5613

This PR tweaks the Prometheus configuration to drop labels with an empty `nodename` parameter. 

Since https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/194, there seems to be duplicate metrics (one with an empty `nodename`, one with a `populated` one). I'm unsure of the exact cause, but I can speculate that:
- perhaps the k8s api is returning empty responses in some cases
- perhaps the metric relabelling process ends up duplicating a time series 

This PR resolves this situtation by dropping the metrics with  empty `nodename` labels.


### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md) (not needed - change hasn't released yet)

### Test plan

Running on k8s.sgdev.org, see the following commits:

https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/pull/5613
https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/pull/5616