### PR TITLE
fix for rendering jaeger Deployment when specifying an image pull secret

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -52,7 +52,7 @@ sourcegraph:
 # More values to be added in order to test your change
 ```
 
-Make sure you test both enabled and disabled toggles. For example, if you added a new values to conditional render some templates, turn it on and off in the `overrid.yaml` to make sure they both work. You can also include your `override.yaml` in the `Test plan` during PR review to help others understand your testing strategy.
+Make sure you test both enabled and disabled toggles. For example, if you added a new values to conditional render some templates, turn it on and off in the `override.yaml` to make sure they both work. You can also include your `override.yaml` in the `Test plan` during PR review to help others understand your testing strategy.
 
 ### Inspect the entire rendered template
 

--- a/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
+++ b/charts/sourcegraph/templates/jaeger/jaeger.Deployment.yaml
@@ -98,8 +98,8 @@ spec:
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- include "sourcegraph.renderServiceAccountName" (list . "jaeger") | trim | nindent 6 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "jaeger") | trim | nindent 6 }}
       volumes:
       {{- if .Values.jaeger.extraVolumes }}
       {{- toYaml .Values.jaeger.extraVolumes | nindent 6 }}


### PR DESCRIPTION
### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

Customer reported issue rendering Jaeger Deployment template when specifying an image pull secret:

<img width="993" alt="Screenshot 2023-02-02 at 21 33 09" src="https://user-images.githubusercontent.com/31862633/216539350-b8fa391d-2851-47d0-875f-b82942ff3e5e.png">

### Test plan

1. `helm lint charts/sourcegraph/.` ✅ 
2. `helm unittest --helm3 ./charts/sourcegraph/.` ✅ 
3. `helm template . --values override.yaml` ✅ 

override.yaml:
```
sourcegraph:
  imagePullSecrets:
  - name: docker-pullsecret
jaeger:
  enabled: true
  serviceAccount:
    name: jaeger
```