### PR TITLE
otel: support custom `hostPort` values for agents

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -7,7 +7,7 @@ Use `**BREAKING**:` to denote a breaking change
 <!-- START CHANGELOG -->
 
 ## Unreleased
-
+* The default `hostPort`s for OpenTelemetry agent pods deployed by the DaemonSet can now be overridden by setting `openTelemetry.agent.hostPorts` for one or more of `otlpGrpc`, `otlpHttp`, and `zpages`. This allows multiple instances of Sourcegraph to be deployed on a single cluster [#245](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/245).
 
 ## 4.5.0
 

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -189,8 +189,12 @@ In addition to the documented values, all services also support the following va
 | nodeExporter.resources | object | `{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":".2","memory":"100Mi"}}` | Resource requests & limits for the `node-exporter` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | nodeExporter.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `node-exporter` |
 | nodeExporter.serviceAccount.name | string | `"node-exporter"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| openTelemetry.agent.hostPorts | object | `{"otlpGrpc":4317,"otlpHttp":4318,"zpages":55679}` | Resource requests & limits for the `otel-agent` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | openTelemetry.agent.name | string | `"otel-agent"` | Name used by resources. Does not affect service names or PVCs. |
-| openTelemetry.agent.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resource requests & limits for the `otel-agent` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| openTelemetry.agent.resources.limits.cpu | string | `"500m"` |  |
+| openTelemetry.agent.resources.limits.memory | string | `"500Mi"` |  |
+| openTelemetry.agent.resources.requests.cpu | string | `"100m"` |  |
+| openTelemetry.agent.resources.requests.memory | string | `"100Mi"` |  |
 | openTelemetry.enabled | bool | `true` |  |
 | openTelemetry.gateway.config.traces.exporters | object | `{}` | Define where traces should be exported to.  Read how to configure different backends in the [OpenTelemetry documentation](https://opentelemetry.io/docs/collector/configuration/#exporters) |
 | openTelemetry.gateway.config.traces.exportersTlsSecretName | string | `""` | Define the name of a preexisting secret containing TLS certificates for exporters, which will be mounted under "/tls". Read more about TLS configuration of exporters in the [OpenTelemetry Collector documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md) |

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -146,7 +146,7 @@ app.kubernetes.io/name: jaeger
     fieldRef:
       fieldPath: status.hostIP
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
-  value: http://$(OTEL_AGENT_HOST):4317
+  value: http://$(OTEL_AGENT_HOST):{{ toYaml .Values.openTelemetry.agent.hostPorts.otlpGrpc }}
 {{- end }}
 {{- end }}
 

--- a/charts/sourcegraph/templates/otel-collector/otel-agent.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-agent.DaemonSet.yaml
@@ -68,13 +68,13 @@ spec:
             port: 13133
         ports:
           - containerPort: 55679
-            hostPort: 55679
+            hostPort: {{ toYaml .Values.openTelemetry.agent.hostPorts.zpages }}
             name: zpages
           - containerPort: 4317
-            hostPort: 4317
+            hostPort: {{ toYaml .Values.openTelemetry.agent.hostPorts.otlpGrpc }}
             name: otlp-grpc
           - containerPort: 4318
-            hostPort: 4318
+            hostPort: {{ toYaml .Values.openTelemetry.agent.hostPorts.otlpHttp }}
             name: otlp-http
         volumeMounts:
           - name: config

--- a/charts/sourcegraph/tests/otelAgentHostPort_test.yaml
+++ b/charts/sourcegraph/tests/otelAgentHostPort_test.yaml
@@ -1,0 +1,75 @@
+---
+suite: otelAgentHostPort
+tests:
+  - it: should use the default host ports when not defined in values
+    template: otel-collector/otel-agent.DaemonSet.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 55679
+            hostPort: 55679
+            name: zpages
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 4317
+            hostPort: 4317
+            name: otlp-grpc
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 4318
+            hostPort: 4318
+            name: otlp-http
+  - it: should render the agent endpoint with the default gRPC host port
+    template: searcher/searcher.StatefulSet.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "http://$(OTEL_AGENT_HOST):4317"
+  - it: should set the host ports when defined in values
+    template: otel-collector/otel-agent.DaemonSet.yaml
+    set:
+      openTelemetry:
+        agent:
+          hostPorts:
+            otlpGrpc: 4319
+            otlpHttp: 4320
+            zpages: 55680
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 55679
+            hostPort: 55680
+            name: zpages
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 4317
+            hostPort: 4319
+            name: otlp-grpc
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 4318
+            hostPort: 4320
+            name: otlp-http
+  - it: should render the agent endpoint with the custom gRPC host port
+    template: searcher/searcher.StatefulSet.yaml
+    set:
+      openTelemetry:
+        agent:
+          hostPorts:
+            otlpGrpc: 4319
+            otlpHttp: 4320
+            zpages: 55680
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "http://$(OTEL_AGENT_HOST):4319"

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -642,6 +642,10 @@ openTelemetry:
     name: "otel-agent"
     # -- Resource requests & limits for the `otel-agent` container,
     # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+    hostPorts:
+      otlpGrpc: 4317
+      otlpHttp: 4318
+      zpages: 55679
     resources:
       limits:
         cpu: "500m"


### PR DESCRIPTION
Deploying the Helm chart multiple times on a single cluster will currently fail with OpenTelemetry enabled:
- The agent DaemonSet opens a `hostPort`, because services producing spans have to target the DaemonSet pod running on the same node as that service. This is achieved by setting `OTEL_EXPORTER_OTLP_ENDPOINT` to `hostIP` and then targeting the gRPC port (4317).
- A `hostPort` needs to be unique on each node.
- When deploying an additional instance of Sourcegraph with the Helm chart, it will try to deploy the DaemonSet, but the preexisting deployment already uses the `hostPort`, so the additional deployment fails.
- The existing implementation can only disable OpenTelemetry entirely, which drops tracing support.

This PR allows overriding the `hostPort`s of the agent DaemonSet, which will enable users to pick free ports on the node.

### Alternative approach
Theoretically, a single deployment of OpenTelemetry should suffice for each instance of Sourcegraph, but that would also mean a single configuration for both instances, which might not be desired (e.g. exporting to separate backends).  
This also requires a reasonable amount of refactoring, likely moving OpenTelemetry resources out of the `sourcegraph` Helm chart, as uninstalling one instance should not remove OpenTelemetry for any remaining instances.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan
- [x] unit tests pass
- [x] deploy on dogfood cluster with dogfood and scaletesting running in parallel

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
