### PR TITLE
sourcegraph: add service account support for otel

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -195,12 +195,16 @@ In addition to the documented values, all services also support the following va
 | openTelemetry.agent.resources.limits.memory | string | `"500Mi"` |  |
 | openTelemetry.agent.resources.requests.cpu | string | `"100m"` |  |
 | openTelemetry.agent.resources.requests.memory | string | `"100Mi"` |  |
+| openTelemetry.agent.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `otel-agent` |
+| openTelemetry.agent.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | openTelemetry.enabled | bool | `true` |  |
 | openTelemetry.gateway.config.traces.exporters | object | `{}` | Define where traces should be exported to.  Read how to configure different backends in the [OpenTelemetry documentation](https://opentelemetry.io/docs/collector/configuration/#exporters) |
 | openTelemetry.gateway.config.traces.exportersTlsSecretName | string | `""` | Define the name of a preexisting secret containing TLS certificates for exporters, which will be mounted under "/tls". Read more about TLS configuration of exporters in the [OpenTelemetry Collector documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md) |
 | openTelemetry.gateway.config.traces.processors | object | `{}` | Define trace processors. Read how to configure sampling in the [OpenTelemetry documentation](https://docs.sourcegraph.com/admin/observability/opentelemetry#sampling-traces) |
 | openTelemetry.gateway.name | string | `"otel-collector"` | Name used by resources. Does not affect service names or PVCs. |
 | openTelemetry.gateway.resources | object | `{"limits":{"cpu":"3","memory":"3Gi"},"requests":{"cpu":"1","memory":"1Gi"}}` | Resource requests & limits for the `otel-collector` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| openTelemetry.gateway.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `otel-collector` |
+| openTelemetry.gateway.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | openTelemetry.image.defaultTag | string | `"4.4.2@sha256:f0723c96c973258ad3123ddc479261bb8f5827bbac1d091b6a683fde55334413"` | Docker image tag for the `otel-collector` image |
 | openTelemetry.image.name | string | `"opentelemetry-collector"` | Docker image name for the `otel-collector` image |
 | pgsql.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from our [recommended PostgreSQL configuration](https://docs.sourcegraph.com/admin/config/postgres-conf) and [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -37,28 +37,56 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/*
 Create the name of the service account to use
+
+When calling these partial functions,
+
+For top-level services, pass in the top-level values:
+
+{{ include "sourcegraph.serviceAccountName" (list . "frontend") }}
+
+frontend:
+  serivceAccount:
+    create: false
+
+For nested services, pass in the nested values:
+
+{{ include "sourcegraph.serviceAccountName" (list .Values.openTelemetry "gateway") }}
+
+openTelemetry:
+  gateway:
+    serviceAccount:
+      create: false
 */}}
 {{- define "sourcegraph.serviceAccountName" -}}
 {{- $top := index . 0 }}
+{{- if hasKey $top "Values" -}}
+{{- $top = index $top "Values" -}}
+{{- end -}}
 {{- $service := index . 1 }}
-{{- $defaultServiceAccountName := (index $top.Values $service "name") }}
-{{- default $defaultServiceAccountName (index $top.Values $service "serviceAccount" "name") }}
-{{- end }}
+{{- $defaultServiceAccountName := (index $top $service "name") }}
+{{- default $defaultServiceAccountName (index $top $service "serviceAccount" "name") }}
+{{- end -}}
 
 {{- define "sourcegraph.renderServiceAccountName" -}}
 {{- $top := index . 0 }}
+{{- if hasKey $top "Values" -}}
+{{- $top = index $top "Values" -}}
+{{- end -}}
 {{- $service := index . 1 }}
-{{- if or (index $top.Values $service "serviceAccount" "create") (index $top.Values $service "serviceAccount" "name") }}
+{{- if or (index $top $service "serviceAccount" "create") (index $top $service "serviceAccount" "name") }}
 serviceAccountName: {{ include "sourcegraph.serviceAccountName" (list $top $service) }}
-{{- end }}
-{{- end }}
+{{- end -}}
+{{- end -}}
 
 {{- define "sourcegraph.serviceAccountAnnotations" -}}
 {{- $top := index . 0 }}
+{{- if hasKey $top "Values" -}}
+{{- $top = index $top "Values" -}}
+{{- end -}}
 {{- $service := index . 1 }}
-{{- with (index $top.Values $service "serviceAccount" "annotations") }}
+{{- with (index $top $service "serviceAccount" "annotations") }}
 annotations:
-{{- . | toYaml | trim | nindent 4 }}
+{{- . | toYaml | trim | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/charts/sourcegraph/templates/otel-collector/otel-agent.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-agent.DaemonSet.yaml
@@ -87,6 +87,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list .Values.openTelemetry "agent") | trim | nindent 6 }}
       volumes:
         - name: config
           configMap:

--- a/charts/sourcegraph/templates/otel-collector/otel-agent.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-agent.ServiceAccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.openTelemetry.agent.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: otel-collector
+  {{- include "sourcegraph.serviceAccountAnnotations" (list .Values.openTelemetry "agent") | trim | nindent 2 -}}
+  name: {{ include "sourcegraph.serviceAccountName" (list .Values.openTelemetry "agent") }}
+{{- end }}

--- a/charts/sourcegraph/templates/otel-collector/otel-collector.Deployment.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-collector.Deployment.yaml
@@ -104,6 +104,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list .Values.openTelemetry "gateway") | trim | nindent 6 }}
       volumes:
         {{- if .Values.openTelemetry.gateway.config.traces.exporters }}
         - name: config

--- a/charts/sourcegraph/templates/otel-collector/otel-collector.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-collector.ServiceAccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.openTelemetry.gateway.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: otel-collector
+  {{- include "sourcegraph.serviceAccountAnnotations" (list .Values.openTelemetry "gateway") | trim | nindent 2 -}}
+  name: {{ include "sourcegraph.serviceAccountName" (list .Values.openTelemetry "gateway") }}
+{{- end }}

--- a/charts/sourcegraph/tests/__snapshot__/serviceAccountAnnotations_test.yaml.snap
+++ b/charts/sourcegraph/tests/__snapshot__/serviceAccountAnnotations_test.yaml.snap
@@ -1,0 +1,37 @@
+should render service account annotations when cadvisor.serviceAccount.annotations is defined:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+      labels:
+        app: cadvisor
+        app.kubernetes.io/component: cadvisor
+        category: rbac
+        deploy: sourcegraph
+      name: cadvisor
+should render service account annotations when frontend.serviceAccount.annotations is defined:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+      labels:
+        app.kubernetes.io/component: frontend
+        category: rbac
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+should render service account annotations when prometheus.serviceAccount.annotations is defined:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+      labels:
+        app.kubernetes.io/component: prometheus
+        category: rbac
+        deploy: sourcegraph
+      name: prometheus

--- a/charts/sourcegraph/tests/__snapshot__/serviceAccounts_test.yaml.snap
+++ b/charts/sourcegraph/tests/__snapshot__/serviceAccounts_test.yaml.snap
@@ -1,0 +1,187 @@
+should render service account when frontend.serviceAccount.create=true:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: frontend
+        category: rbac
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+should render service account when openTelemetry.agent.serviceAccount.create is true:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: otel-collector
+        category: rbac
+        deploy: sourcegraph
+      name: otel-agent
+should render service account when openTelemetry.gateway.serviceAccount.create is true:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: otel-collector
+        category: rbac
+        deploy: sourcegraph
+      name: otel-collector
+should should reference service account when openTelemetry.agent.serviceAccount.create is true:
+  1: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      annotations:
+        description: Forwards telemetry data to the OpenTelemetry Collector Deployment.
+      labels:
+        app.kubernetes.io/component: otel-collector
+        app.kubernetes.io/instance: sourcegraph
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: sourcegraph
+        app.kubernetes.io/version: 4.4.2
+        deploy: sourcegraph
+        helm.sh/chart: sourcegraph-4.4.2
+      name: otel-agent
+    spec:
+      minReadySeconds: 5
+      selector:
+        matchLabels:
+          app: otel-agent
+          app.kubernetes.io/instance: sourcegraph
+          app.kubernetes.io/name: sourcegraph
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/default-container: otel-agent
+          labels:
+            app: otel-agent
+            app.kubernetes.io/instance: sourcegraph
+            app.kubernetes.io/name: sourcegraph
+            deploy: sourcegraph
+        spec:
+          affinity: null
+          containers:
+          - command:
+            - /bin/otelcol-sourcegraph
+            - --config=/etc/otel-agent/config.yaml
+            env: null
+            image: index.docker.io/sourcegraph/opentelemetry-collector:4.4.2@sha256:f0723c96c973258ad3123ddc479261bb8f5827bbac1d091b6a683fde55334413
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 13133
+            name: otel-agent
+            ports:
+            - containerPort: 55679
+              hostPort: 55679
+              name: zpages
+            - containerPort: 4317
+              hostPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              hostPort: 4318
+              name: otlp-http
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 13133
+            resources:
+              limits:
+                cpu: 500m
+                memory: 500Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /etc/otel-agent
+              name: config
+          nodeSelector: null
+          serviceAccountName: otel-agent
+          terminationGracePeriodSeconds: 120
+          tolerations: null
+          volumes:
+          - configMap:
+              items:
+              - key: config.yaml
+                path: config.yaml
+              name: otel-agent
+            name: config
+should should reference service account when openTelemetry.gateway.serviceAccount.create is true:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        description: Receives, processes, and exports telemetry data.
+      labels:
+        app.kubernetes.io/component: otel-collector
+        app.kubernetes.io/instance: sourcegraph
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: sourcegraph
+        app.kubernetes.io/version: 4.4.2
+        deploy: sourcegraph
+        helm.sh/chart: sourcegraph-4.4.2
+      name: otel-collector
+    spec:
+      minReadySeconds: 5
+      progressDeadlineSeconds: 120
+      replicas: 1
+      selector:
+        matchLabels:
+          app: otel-collector
+          app.kubernetes.io/instance: sourcegraph
+          app.kubernetes.io/name: sourcegraph
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/default-container: otel-collector
+          labels:
+            app: otel-collector
+            app.kubernetes.io/instance: sourcegraph
+            app.kubernetes.io/name: sourcegraph
+            deploy: sourcegraph
+        spec:
+          affinity: null
+          containers:
+          - command:
+            - /bin/otelcol-sourcegraph
+            - --config=/etc/otel-collector/configs/logging.yaml
+            env: null
+            image: index.docker.io/sourcegraph/opentelemetry-collector:4.4.2@sha256:f0723c96c973258ad3123ddc479261bb8f5827bbac1d091b6a683fde55334413
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 13133
+            name: otel-collector
+            ports:
+            - containerPort: 55679
+              name: zpages
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
+            - containerPort: 8888
+              name: metrics
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 13133
+            resources:
+              limits:
+                cpu: "3"
+                memory: 3Gi
+              requests:
+                cpu: "1"
+                memory: 1Gi
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts: null
+          nodeSelector: null
+          serviceAccountName: otel-collector
+          terminationGracePeriodSeconds: 120
+          tolerations: null
+          volumes: null

--- a/charts/sourcegraph/tests/serviceAccountAnnotations_test.yaml
+++ b/charts/sourcegraph/tests/serviceAccountAnnotations_test.yaml
@@ -15,6 +15,7 @@ tests:
       path: metadata.annotations
       value:
         iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+  - matchSnapshot: {}
 
 - it: should render service account annotations when cadvisor.serviceAccount.annotations is defined
   set:
@@ -28,6 +29,7 @@ tests:
       path: metadata.annotations
       value:
         iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+  - matchSnapshot: {}
 
 - it: should render service account annotations when prometheus.serviceAccount.annotations is defined
   set:
@@ -41,3 +43,4 @@ tests:
       path: metadata.annotations
       value:
         iam.gke.io/gcp-service-account: sourcegraph@sourcegraph.iam.gserviceaccount.com
+  - matchSnapshot: {}

--- a/charts/sourcegraph/tests/serviceAccounts_test.yaml
+++ b/charts/sourcegraph/tests/serviceAccounts_test.yaml
@@ -1,0 +1,74 @@
+suite: serviceAccount
+release:
+  name: sourcegraph
+  namespace: sourcegraph
+tests:
+- it: should render service account when openTelemetry.gateway.serviceAccount.create is true
+  set:
+    openTelemetry:
+      gateway:
+        serviceAccount:
+          create: true
+  template: otel-collector/otel-collector.ServiceAccount.yaml
+  asserts:
+  - isKind:
+      of: ServiceAccount
+  - equal:
+      path: metadata.name
+      value: otel-collector
+  - matchSnapshot: {}
+
+- it: should should reference service account when openTelemetry.gateway.serviceAccount.create is true
+  set:
+    openTelemetry:
+      gateway:
+        serviceAccount:
+          create: true
+  template: otel-collector/otel-collector.Deployment.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: otel-collector
+  - matchSnapshot: {}
+
+- it: should render service account when openTelemetry.agent.serviceAccount.create is true
+  set:
+    openTelemetry:
+      agent:
+        serviceAccount:
+          create: true
+  template: otel-collector/otel-agent.ServiceAccount.yaml
+  asserts:
+  - isKind:
+      of: ServiceAccount
+  - equal:
+      path: metadata.name
+      value: otel-agent
+  - matchSnapshot: {}
+
+- it: should should reference service account when openTelemetry.agent.serviceAccount.create is true
+  set:
+    openTelemetry:
+      agent:
+        serviceAccount:
+          create: true
+  template: otel-collector/otel-agent.DaemonSet.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: otel-agent
+  - matchSnapshot: {}
+
+- it: should render service account when frontend.serviceAccount.create=true
+  set:
+    frontend:
+      serviceAccount:
+        create: true
+  template: frontend/sourcegraph-frontend.ServiceAccount.yaml
+  asserts:
+  - isKind:
+      of: ServiceAccount
+  - equal:
+      path: metadata.name
+      value: sourcegraph-frontend
+  - matchSnapshot: {}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -636,6 +636,11 @@ openTelemetry:
         # -- Define the name of a preexisting secret containing TLS certificates for exporters, which will be mounted under "/tls".
         # Read more about TLS configuration of exporters in the [OpenTelemetry Collector documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
         exportersTlsSecretName: ""
+    serviceAccount:
+      # -- Enable creation of ServiceAccount for `otel-collector`
+      create: false
+      # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+      name: ""
       
   agent:
     # -- Name used by resources. Does not affect service names or PVCs.
@@ -653,6 +658,11 @@ openTelemetry:
       requests:
         cpu: "100m"
         memory: 100Mi
+    serviceAccount:
+      # -- Enable creation of ServiceAccount for `otel-agent`
+      create: false
+      # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+      name: ""
 
 nodeExporter:
   # -- Enable `node-exporter`


### PR DESCRIPTION
context: https://github.com/sourcegraph/cloud/pull/233/files#diff-de28fac124e846e1aa56e057edeec7edc7cab80be1a00512a5660d02e5cacfb8R65-R72

we need workload identity for otel-collector so we can export traces to GCP Trace

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] ~Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)~

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

added test and CI