### PR TITLE
removed minReadySeconds settings from Searcher and Symbols

### DIFF
--- a/charts/sourcegraph/templates/searcher/searcher.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.StatefulSet.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/component: searcher
   name: {{ .Values.searcher.name }}
 spec:
-  minReadySeconds: 10
   replicas: {{ .Values.searcher.replicaCount }}
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
   selector:

--- a/charts/sourcegraph/templates/symbols/symbols.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.StatefulSet.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/component: symbols
   name: {{ .Values.symbols.name }}
 spec:
-  minReadySeconds: 10
   replicas: {{ .Values.symbols.replicaCount }}
   revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
   selector:


### PR DESCRIPTION
This change is proposed because:
1. Symbols and Searcher were switched from Deployment Controllers to StatefulSets in [PR 242](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/242)
2. Kubernetes [introduced](https://kubernetes.io/blog/2021/08/27/minreadyseconds-statefulsets/) StatefulSet support for the `minReadySeconds` configuration in release v1.22
3. Sourcegraph docs advertise [support for Kubernetes 1.19+](https://docs.sourcegraph.com/admin/deploy/kubernetes#prerequisites), so we shouldn't ship default k8s configurations that are unsupported in 1.19

Alternative solutions could involve making `minReadySeconds` a configurable, optional helm value for these STSs, or possibly reverting these two services back to Deployments if we absolutely want to enforce this setting. The impact of removing this setting should be minimal, and we already ship other StatefulSets that do not define `minReadySeconds` setting.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

1. `helm lint charts/sourcegraph/.`
2. `helm template charts/sourcegraph/ | grep -i "minReadySeconds" -B 2`
3. Deployed in GKE reference sandbox to confirm