### PR TITLE
change CACHE_DIR env var to SYMBOLS_CACHE_DIR in symbols template

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Change CACHE_DIR env var to SYMBOLS_CACHE_DIR in symbols template [#258](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/258)
 
 ## 4.5.0
 

--- a/charts/sourcegraph/templates/symbols/symbols.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.StatefulSet.yaml
@@ -65,7 +65,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: CACHE_DIR
+        - name: SYMBOLS_CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
         - name: TMPDIR
           value: /mnt/tmp


### PR DESCRIPTION
## Description
This PR fixes a bug introduced into the helm charts as a result of changes in `sourcegraph/sourcegraph`, TL;DR `CACHE_DIR` was renamed to `SYMBOLS_CACHE_DIR`. This causes some symbols searches to fail to resolve --

<img width="615" alt="Screenshot 2023-03-02 at 11 38 50 PM" src="https://user-images.githubusercontent.com/13024338/222683840-3c9e172b-32ba-4428-8c40-5e8cea796012.png">

### Temporary Fix till this is merged

You can add the following to your `override.yaml`:
```yaml
  env:
    - name: CACHE_DIR
      value: null
    - name: SYMBOLS_CACHE_DIR
      value: /mnt/cache/$(POD_NAME)
```
and apply the changes to your cluster with --
```
helm -n sourcegraph upgrade --install -f override.yaml --version 4.5.1 sourcegraph sourcegraph/sourcegraph
```

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
