### PR TITLE
sourcegraph: add multiple hostname support

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -6,6 +6,8 @@ Use `**BREAKING**:` to denote a breaking change
 
 <!-- START CHANGELOG -->
 
+- Added support for additional hostnames for Ingress [#271](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/271)
+
 ## Unreleased
 
 ## 5.0.1

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -98,6 +98,8 @@ In addition to the documented values, all services also support the following va
 | frontend.ingress.annotations | object | `{"kubernetes.io/ingress.class":"nginx","nginx.ingress.kubernetes.io/proxy-body-size":"150m"}` | Annotations for the Sourcegraph server ingress. For example, securing ingress with TLS provided by [cert-manager](https://cert-manager.io/docs/usage/ingress/) |
 | frontend.ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` | [Deprecated annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) for specifing the IngressClass in Kubernetes 1.17 and earlier. If you are using Kubernetes 1.18+, use `ingressClassName` instead and set an override value of `null` for this annotation. |
 | frontend.ingress.enabled | bool | `true` | Enable ingress for the Sourcegraph server |
+| frontend.ingress.extraHosts | list | `[]` | Additional hostnames for the Sourcegraph server ingress Note this is additional to the `host` field |
+| frontend.ingress.extraTLSSecrets | list | `[]` | Secret configuration when extra hosts are used Note this is additional to the `tlsSecret` field |
 | frontend.ingress.host | string | `""` | External hostname for the Sourcegraph server ingress (SSL) |
 | frontend.ingress.ingressClassName | string | `nil` | IngressClassName for the Ingress (Available in Kubernetes 1.18+) If you set this field, set the annotation `frontend.ingress.annotations."kubernetes.io/ingress.class"` to `null` |
 | frontend.ingress.tlsSecret | string | `""` | Secret containing SSL cert |

--- a/charts/sourcegraph/examples/extra-hostnames/override.yaml
+++ b/charts/sourcegraph/examples/extra-hostnames/override.yaml
@@ -1,0 +1,11 @@
+frontend:
+  ingress:
+    enabled: true
+    host: chart-example.local
+    extraHosts:
+      - chart-example-02.local
+    tlsSecret: chart-example-local
+    extraTLSSecrets:
+      - secretName: chart-example-02-local
+        hosts:
+          - chart-example-02.local

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Ingress.yaml
@@ -1,3 +1,5 @@
+{{- $serviceName := "sourcegraph-frontend" -}}
+{{- $servicePort := 30080 -}}
 {{- if .Values.frontend.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -10,7 +12,7 @@ metadata:
     app: sourcegraph-frontend
     deploy: sourcegraph
     app.kubernetes.io/component: frontend
-    {{- if .Values.frontend.ingress.labels}}
+    {{- if .Values.frontend.ingress.labels }}
       {{- toYaml .Values.frontend.ingress.labels | nindent 4 }}
     {{- end }}
   name: {{ .Values.frontend.name }}
@@ -20,7 +22,11 @@ spec:
   - hosts:
     - {{ .Values.frontend.ingress.host }}
     secretName: {{ .Values.frontend.ingress.tlsSecret }}
+  {{- if .Values.frontend.ingress.extraTLSSecrets }}
+  {{- toYaml .Values.frontend.ingress.extraTLSSecrets | nindent 2 }}
   {{- end }}
+  {{- end }}
+  {{- if .Values.frontend.ingress.host }}
   rules:
   - http:
       paths:
@@ -28,13 +34,24 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: sourcegraph-frontend
+            name: {{ $serviceName }}
             port:
-              number: 30080
-  {{- if .Values.frontend.ingress.host}}
+              number: {{ $servicePort }}
     host: {{ .Values.frontend.ingress.host }}
+  {{- range $host := .Values.frontend.ingress.extraHosts }}
+  - http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ $serviceName }}
+              port:
+                number: {{ $servicePort }}
+    host: {{ $host }}
   {{- end }}
-  {{- if .Values.frontend.ingress.ingressClassName}}
+  {{- end }}
+  {{- if .Values.frontend.ingress.ingressClassName }}
   ingressClassName: {{ .Values.frontend.ingress.ingressClassName }}
   {{- end }}
 {{- end }}

--- a/charts/sourcegraph/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/sourcegraph/tests/__snapshot__/ingress_test.yaml.snap
@@ -1,0 +1,60 @@
+should render ingress with a one tls secret:
+  1: |
+    - hosts:
+      - chart-example.local
+      secretName: chart-example-tls
+should render ingress with many hosts when extraHosts is set:
+  1: |
+    - host: chart-example.local
+      http:
+        paths:
+        - backend:
+            service:
+              name: sourcegraph-frontend
+              port:
+                number: 30080
+          path: /
+          pathType: Prefix
+    - host: chart-example-1.local
+      http:
+        paths:
+        - backend:
+            service:
+              name: sourcegraph-frontend
+              port:
+                number: 30080
+          path: /
+          pathType: Prefix
+    - host: chart-example-2.local
+      http:
+        paths:
+        - backend:
+            service:
+              name: sourcegraph-frontend
+              port:
+                number: 30080
+          path: /
+          pathType: Prefix
+should render ingress with many tls secrets when extraTLSSecrets is set:
+  1: |
+    - hosts:
+      - chart-example.local
+      secretName: chart-example-tls
+    - hosts:
+      - chart-example-1.local
+      secretName: chart-example-tls-1
+    - hosts:
+      - chart-example-2.local
+      secretName: chart-example-tls-2
+should render ingress with only one host:
+  1: |
+    - host: chart-example.local
+      http:
+        paths:
+        - backend:
+            service:
+              name: sourcegraph-frontend
+              port:
+                number: 30080
+          path: /
+          pathType: Prefix

--- a/charts/sourcegraph/tests/ingress_test.yaml
+++ b/charts/sourcegraph/tests/ingress_test.yaml
@@ -1,0 +1,55 @@
+suite: ingress
+templates:
+  - frontend/sourcegraph-frontend.Ingress.yaml
+release:
+  name: sourcegraph
+  namespace: sourcegraph
+tests:
+  - it: should render ingress with only one host
+    set:
+      frontend:
+        ingress:
+          enabled: true
+          host: "chart-example.local"
+    asserts:
+      - matchSnapshot:
+          path: spec.rules
+  - it: should render ingress with many hosts when extraHosts is set
+    set:
+      frontend:
+        ingress:
+          enabled: true
+          host: "chart-example.local"
+          extraHosts:
+            - chart-example-1.local
+            - chart-example-2.local
+    asserts:
+      - matchSnapshot:
+          path: spec.rules
+  - it: should render ingress with a one tls secret
+    set:
+      frontend:
+        ingress:
+          enabled: true
+          host: "chart-example.local"
+          tlsSecret: "chart-example-tls"
+    asserts:
+      - matchSnapshot:
+          path: spec.tls
+  - it: should render ingress with many tls secrets when extraTLSSecrets is set
+    set:
+      frontend:
+        ingress:
+          enabled: true
+          host: "chart-example.local"
+          tlsSecret: "chart-example-tls"
+          extraTLSSecrets:
+            - secretName: chart-example-tls-1
+              hosts:
+                - chart-example-1.local
+            - secretName: chart-example-tls-2
+              hosts:
+                - chart-example-2.local
+    asserts:
+      - matchSnapshot:
+          path: spec.tls

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -311,11 +311,21 @@ frontend:
       nginx.ingress.kubernetes.io/proxy-body-size: 150m
     # -- External hostname for the Sourcegraph server ingress (SSL)
     host: ""
+    # -- Additional hostnames for the Sourcegraph server ingress
+    # Note this is additional to the `host` field
+    extraHosts: []
+    #  - "chart-example.local"
     # -- IngressClassName for the Ingress (Available in Kubernetes 1.18+)
     # If you set this field, set the annotation `frontend.ingress.annotations."kubernetes.io/ingress.class"` to `null`
     ingressClassName: null
     # -- Secret containing SSL cert
     tlsSecret: ""
+    # -- Secret configuration when extra hosts are used
+    # Note this is additional to the `tlsSecret` field
+    extraTLSSecrets: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   # -- Security context for the `frontend` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
   containerSecurityContext:


### PR DESCRIPTION
On Cloud, we're looking to launch custom domain support https://github.com/sourcegraph/pr-faqs/issues/126, hence we need to allow adding extra hostname to Ingress.

This PR introduces two new values:

#### `extraHosts`

In addition to `host`, `extraHosts` will be added to `.spec.rule`

#### `extraTLSSecrets`

In addition to `tlsSecret`, this value will be added to `.spec.tls` as well.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

tested rendering the chart with the added sample override

added unit test