### PR TITLE
Pin helm-unittest version

### DIFF
--- a/scripts/ci/helm-unittest.sh
+++ b/scripts/ci/helm-unittest.sh
@@ -3,7 +3,7 @@
 set -euf -o pipefail
 
 ### Install the helm-unittest plugin
-helm plugin install https://github.com/quintush/helm-unittest
+helm plugin install https://github.com/quintush/helm-unittest --version v0.2.11
 
 ### Run the helm tests
 helm unittest -3q charts/sourcegraph


### PR DESCRIPTION
The helm-unittest library was recently updated. 
This change pins an older, working version until the newer version can be checked and tests updated accordingly 

### Test plan
Tests pass locally
