### PR TITLE
Fix port naming in codeintel-db service spec

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Port names for all the DBs are renamed to `postgres` to create consistency across the deployments [#275](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/275)
 
 ## 5.0.0
 

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Service.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Service.yaml
@@ -18,9 +18,9 @@ metadata:
   name: codeinsights-db
 spec:
   ports:
-  - name: codeinsights-db
+  - name: postgres
     port: 5432
-    targetPort: codeinsights-db
+    targetPort: postgres
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: codeinsights-db

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -80,7 +80,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 5432
-          name: codeinsights-db
+          name: postgres
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.codeInsightsDB.resources | nindent 10 }}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.Service.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.Service.yaml
@@ -18,9 +18,9 @@ metadata:
   name: codeintel-db
 spec:
   ports:
-  - name: codeintel-db
+  - name: postgres
     port: 5432
-    targetPort: codeintel-db
+    targetPort: postgres
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: codeintel-db

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.Service.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.Service.yaml
@@ -18,9 +18,9 @@ metadata:
   name: codeintel-db
 spec:
   ports:
-  - name: pgsql
+  - name: codeintel-db
     port: 5432
-    targetPort: pgsql
+    targetPort: codeintel-db
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: codeintel-db

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -91,7 +91,7 @@ spec:
           periodSeconds: 10
         ports:
         - containerPort: 5432
-          name: pgsql
+          name: postgres
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.codeIntelDB.resources | nindent 10 }}

--- a/charts/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -18,9 +18,9 @@ metadata:
   name: pgsql
 spec:
   ports:
-  - name: pgsql
+  - name: postgres
     port: 5432
-    targetPort: pgsql
+    targetPort: postgres
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: pgsql

--- a/charts/sourcegraph/templates/pgsql/pgsql.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.StatefulSet.yaml
@@ -91,7 +91,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: 5432
-          name: pgsql
+          name: postgres
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.pgsql.resources | nindent 10 }}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/51175.

Ultimately this change is minor, but may prevent confusion.

The port name and targetPort name are not actually used for anything besides human readability to my knowledge and there are no known issues with the current manifest. This does bring things in line with the convention in use in codeinsights-db service file though, and will eliminate possible confusion by readers

[Codeinsights manifest](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph-helm@release/5.0/-/blob/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Service.yaml?L23:5)

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
