### PR TITLE
Jac/embeddings

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,8 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Add Embeddings service (disabled by default) for Cody embeddings
+
 ## 5.0.1
 
 - Sourcegraph 5.0.1 is now available!

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -90,6 +90,20 @@ In addition to the documented values, all services also support the following va
 | codeIntelDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeintel-db` |
 | codeIntelDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeIntelDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeintel-db` data volume |
+| embeddings.backend | object | `{"EMBEDDINGS_UPLOAD_AWS_ENDPOINT":"http://blobstore:9000","EMBEDDINGS_UPLOAD_BACKEND":"blobstore"}` | Configure the storage backend for embeddings |
+| embeddings.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| embeddings.enabled | bool | `false` | Enable `embeddings` |
+| embeddings.env | object | `{}` | Environment variables for the `embeddings` container |
+| embeddings.extraVolumeMounts | object | `{}` |  |
+| embeddings.extraVolumes | object | `{}` |  |
+| embeddings.image.defaultTag | string | `"5.0.2@sha256:fac554b8dc22ee2842228ed56eac059a3671a8ad8d246c8120106508b74bc621"` | Docker image tag for the `embeddings` image |
+| embeddings.image.name | string | `"embeddings"` | Docker image name for the `embeddings` image |
+| embeddings.name | string | `"embeddings"` | Name of the `embeddings` service |
+| embeddings.podSecurityContext | object | `{}` | Security context for the `embeddings` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| embeddings.resources | object | `{"limits":{"cpu":"8","memory":"64G"},"requests":{"cpu":"4","memory":"32G"}}` | Resource requests & limits for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| embeddings.serviceAccount.annotations | object | `{}` |  |
+| embeddings.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `embeddings` |
+| embeddings.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | extraResources | list | `[]` | Additional resources to include in the rendered manifest. Templates are supported. |
 | frontend.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `frontend` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | frontend.env | object | the chart will add some default environment values | Environment variables for the `frontend` container |
@@ -152,7 +166,7 @@ In addition to the documented values, all services also support the following va
 | indexedSearchIndexer.image.defaultTag | string | `"5.0.2@sha256:7a770bfebd2c4d0eeaccb2ae3c7b93208514910d39a13e6289cc0db66b6b444e"` | Docker image tag for the `zoekt-indexserver` image |
 | indexedSearchIndexer.image.name | string | `"search-indexer"` | Docker image name for the `zoekt-indexserver` image |
 | indexedSearchIndexer.resources | object | `{"limits":{"cpu":"8","memory":"8G"},"requests":{"cpu":"4","memory":"4G"}}` | Resource requests & limits for the `zoekt-indexserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) zoekt-indexserver is CPU bound. The more CPU you allocate to it, the lower lag between a new commit and it being indexed for search. |
-| jaeger.collector.name | string | `""` | Name of jaeger `collector` service  |
+| jaeger.collector.name | string | `""` | Name of jaeger `collector` service |
 | jaeger.collector.serviceAnnotations | object | `{}` | Add extra annotations to jaeger `collector` service |
 | jaeger.collector.serviceLabels | object | `{}` | Add extra labels to jaeger `collector` service |
 | jaeger.collector.serviceType | string | "ClusterIP" | Kubernetes service type of jaeger `collector` service, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
@@ -162,7 +176,7 @@ In addition to the documented values, all services also support the following va
 | jaeger.image.name | string | `"jaeger-all-in-one"` | Docker image name for the `jaeger` image |
 | jaeger.name | string | `"jaeger"` | Name used by resources. Does not affect service names or PVCs. |
 | jaeger.podSecurityContext | object | `{}` | Security context for the `jaeger` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| jaeger.query.name | string | `""` | Name of jaeger `query` service  |
+| jaeger.query.name | string | `""` | Name of jaeger `query` service |
 | jaeger.query.serviceAnnotations | object | `{}` | Add extra annotations to jaeger `query` service |
 | jaeger.query.serviceLabels | object | `{}` | Add extra labels to jaeger `query` service |
 | jaeger.query.serviceType | string | "ClusterIP" | Kubernetes service type of jaeger `query` service, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
@@ -197,7 +211,7 @@ In addition to the documented values, all services also support the following va
 | openTelemetry.agent.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `otel-agent` |
 | openTelemetry.agent.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | openTelemetry.enabled | bool | `true` |  |
-| openTelemetry.gateway.config.traces.exporters | object | `{}` | Define where traces should be exported to.  Read how to configure different backends in the [OpenTelemetry documentation](https://opentelemetry.io/docs/collector/configuration/#exporters) |
+| openTelemetry.gateway.config.traces.exporters | object | `{}` | Define where traces should be exported to. Read how to configure different backends in the [OpenTelemetry documentation](https://opentelemetry.io/docs/collector/configuration/#exporters) |
 | openTelemetry.gateway.config.traces.exportersTlsSecretName | string | `""` | Define the name of a preexisting secret containing TLS certificates for exporters, which will be mounted under "/tls". Read more about TLS configuration of exporters in the [OpenTelemetry Collector documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md) |
 | openTelemetry.gateway.config.traces.processors | object | `{}` | Define trace processors. Read how to configure sampling in the [OpenTelemetry documentation](https://docs.sourcegraph.com/admin/observability/opentelemetry#sampling-traces) |
 | openTelemetry.gateway.name | string | `"otel-collector"` | Name used by resources. Does not affect service names or PVCs. |

--- a/charts/sourcegraph/templates/embeddings/embeddings.Deployment.yaml
+++ b/charts/sourcegraph/templates/embeddings/embeddings.Deployment.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.embeddings.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.embeddings.name }}
+  annotations:
+    description: Handles embeddings which enhance Cody's context fetching
+  labels:
+    {{- include "sourcegraph.labels" . | nindent 4 }}
+    {{- if .Values.embeddings.labels }}
+      {{- toYaml .Values.embeddings.labels | nindent 4 }}
+    {{- end }}
+  deploy: sourcegraph
+  app.kubernetes.io/component: embeddings
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: {{ .Values.embeddings.name }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      {{- if .Values.sourcegraph.podAnnotations }}
+      {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.embeddings.podAnnotations }}
+      {{- toYaml .Values.embeddings.podAnnotations | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ .Values.embeddings.name }}
+        app.kubernetes.io/component: embeddings
+        deploy: sourcegraph
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
+      {{- if .Values.sourcegraph.podLabels }}
+      {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
+      {{- end }}
+      {{- if .Values.embeddings.podLabels }}
+      {{- toYaml .Values.embeddings.podLabels | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+      - name: {{ .Values.embeddings.name }}
+        image: {{ include "sourcegraph.image" (list . "embeddings") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        env:
+        {{- range $name, $item := .Values.embeddings.env }}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
+        {{- range $name, $item := .Values.embeddings.backend }}
+        - name: {{ $name }}
+          value: {{ $item | quote }}
+        {{- end }}
+        ports:
+        - containerPort: 9991
+          name: http
+          protocol: TCP
+        volumeMounts:
+          {{- if .Values.embeddings.extraVolumeMounts }}
+          {{- toYaml .Values.embeddings.extraVolumeMounts | nindent 8 }}
+          {{- end }}
+        {{- if not .Values.sourcegraph.localDevMode}}
+        resources:
+          {{- toYaml .Values.embeddings.resources | nindent 10 }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.embeddings.containerSecurityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.embeddings.podSecurityContext | nindent 8 }}
+      {{- include "sourcegraph.nodeSelector" (list . "embeddings" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "embeddings" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "embeddings" ) | trim | nindent 6 }}
+      {{- if .Values.embeddings.serviceAccount.create }}
+      serviceAccountName: {{ .Values.embeddings.serviceAccount.name }}
+      {{- end}}
+    volumes:
+      {{- if .Values.embeddings.extraVolumes }}
+      {{- toYaml .Values.embeddings.extraVolumes | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/charts/sourcegraph/templates/embeddings/embeddings.Service.yaml
+++ b/charts/sourcegraph/templates/embeddings/embeddings.Service.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.embeddings.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "6060"
+    sourcegraph.prometheus/scrape: "true"
+    {{- if .Values.frontend.serviceAnnotations }}
+    {{- toYaml .Values.frontend.serviceAnnotations | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ .Values.embeddings.name }}
+    deploy: sourcegraph
+    app.kubernetes.io/component: embeddings
+    {{- if .Values.sourcegraph.serviceLabels }}
+      {{- toYaml .Values.sourcegraph.serviceLabels | nindent 4 }}
+    {{- end }}
+  name: {{ .Values.embeddings.name }}
+spec:
+  ports:
+  - name: http
+    port: 9991
+    protocol: TCP
+    targetPort: http
+  selector:
+    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
+    app: {{ .Values.embeddings.name }}
+  type: {{ .Values.embeddings.serviceType | default "ClusterIP" }}
+{{- end }}

--- a/charts/sourcegraph/templates/embeddings/embeddings.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/embeddings/embeddings.ServiceAccount.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.embeddings.enabled .Values.embeddings.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: {{ .Values.embeddings.name }}
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "embeddings") | trim | nindent 2 }}
+  name: {{ include "sourcegraph.serviceAccountName" (list . "embeddings") }}
+{{- end }}

--- a/charts/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -60,6 +60,12 @@ spec:
         - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT
           value: http://blobstore:9000
         {{- end }}
+        {{- if .Values.embeddings.enabled }}
+        {{- range $name, $item := .Values.embeddings.backend }}
+        - name: {{ $name }}
+          value: {{ $item | quote }}
+        {{- end }}
+        {{- end }}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -5,7 +5,7 @@
 sourcegraph:
   image:
     # -- Global docker image tag
-    defaultTag: '{{ .Chart.AppVersion }}'
+    defaultTag: "{{ .Chart.AppVersion }}"
     # -- Global docker image pull policy
     pullPolicy: IfNotPresent
     # -- Global docker image registry or prefix
@@ -38,7 +38,6 @@ sourcegraph:
   revisionHistoryLimit: 10
   # -- Add extra labels to all services
   serviceLabels: {}
-
 
 # Generic application configuration options, used by most applications below
 # app: # Generally matches directory name
@@ -282,6 +281,50 @@ codeIntelDB:
     name: ""
   # -- PVC Storage Request for `codeintel-db` data volume
   storageSize: 200Gi
+
+embeddings:
+  # -- Enable `embeddings`
+  enabled: false
+  # -- Name of the `embeddings` service
+  name: embeddings
+  image:
+    # -- Docker image name for the `embeddings` image
+    name: "embeddings"
+    # -- Docker image tag for the `embeddings` image
+    defaultTag: "5.0.2@sha256:fac554b8dc22ee2842228ed56eac059a3671a8ad8d246c8120106508b74bc621"
+  # -- Resource requests & limits for the `worker` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  resources:
+    limits:
+      cpu: "8"
+      memory: 64G
+    requests:
+      cpu: "4"
+      memory: 32G
+  # -- Configure the storage backend for embeddings
+  backend:
+    EMBEDDINGS_UPLOAD_BACKEND: "blobstore"
+    EMBEDDINGS_UPLOAD_AWS_ENDPOINT: "http://blobstore:9000"
+  # -- Environment variables for the `embeddings` container
+  env: {}
+  # -- Security context for the `worker` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 100
+    runAsGroup: 101
+    readOnlyRootFilesystem: true
+  # -- Security context for the `embeddings` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  podSecurityContext: {}
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `embeddings`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
+    annotations: {}
+  extraVolumeMounts: {}
+  extraVolumes: {}
 
 frontend:
   # -- Environment variables for the `frontend` container
@@ -628,7 +671,7 @@ openTelemetry:
         # -- Define trace processors.
         # Read how to configure sampling in the [OpenTelemetry documentation](https://docs.sourcegraph.com/admin/observability/opentelemetry#sampling-traces)
         processors: {}
-        # -- Define where traces should be exported to. 
+        # -- Define where traces should be exported to.
         # Read how to configure different backends in the [OpenTelemetry documentation](https://opentelemetry.io/docs/collector/configuration/#exporters)
         exporters: {}
         # -- Define the name of a preexisting secret containing TLS certificates for exporters, which will be mounted under "/tls".
@@ -639,7 +682,7 @@ openTelemetry:
       create: false
       # -- Name of the ServiceAccount to be created or an existing ServiceAccount
       name: ""
-      
+
   agent:
     # -- Name used by resources. Does not affect service names or PVCs.
     name: "otel-agent"
@@ -679,17 +722,17 @@ nodeExporter:
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
     limits:
-      cpu: '1'
+      cpu: "1"
       memory: 1Gi
     requests:
-      cpu: '.2'
+      cpu: ".2"
       memory: 100Mi
   serviceAccount:
     # -- Enable creation of ServiceAccount for `node-exporter`
     create: false
     # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: node-exporter
-  # Share the host process ID namespace. 
+  # Share the host process ID namespace.
   hostPID: true
   ## Additional container arguments for the node-exporter container
   extraArgs: []
@@ -709,7 +752,7 @@ nodeExporter:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 65534
-    
+
 pgsql:
   # -- Enable `pgsql` PostgreSQL server
   enabled: true
@@ -1168,7 +1211,7 @@ syntectServer:
 
 jaeger:
   collector:
-    # -- Name of jaeger `collector` service 
+    # -- Name of jaeger `collector` service
     name: ""
     # -- Add extra annotations to jaeger `collector` service
     serviceAnnotations: {}
@@ -1198,7 +1241,7 @@ jaeger:
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
   query:
-    # -- Name of jaeger `query` service 
+    # -- Name of jaeger `query` service
     name: ""
     # -- Add extra annotations to jaeger `query` service
     serviceAnnotations: {}


### PR DESCRIPTION
Adds Embeddings service for Cody embeddings (disabled by default)
- SG blobstore + external storage supported by setting `.Values.embeddings.backend` to appropriate [values](https://docs.sourcegraph.com/cody/explanations/code_graph_context#storing-embedding-indexes)
  - Updates env vars on both the `embeddings` container and `worker` container.
  - Doesn't set on `frontend` despite being mentioned in docs as consensus is it's not actually needed on frontend (happy to be proven wrong)

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan
Tested locally using blobstore + gcs (using `EMBEDDINGS_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT`)
  - Successfully created embeddings for repositories
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
