### PR TITLE
fix: Embeddings indentation (#288)

### DIFF
--- a/charts/sourcegraph-executor/Chart.yaml
+++ b/charts/sourcegraph-executor/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://sourcegraph.com/favicon.ico
 type: application
 
 # Chart version, separate from Sourcegraph
-version: "5.0.4"
+version: "5.0.4-rev.1"
 
 # Version of Sourcegraph release
 appVersion: "5.0.4"

--- a/charts/sourcegraph/templates/embeddings/embeddings.Deployment.yaml
+++ b/charts/sourcegraph/templates/embeddings/embeddings.Deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     {{- if .Values.embeddings.labels }}
       {{- toYaml .Values.embeddings.labels | nindent 4 }}
     {{- end }}
-  deploy: sourcegraph
-  app.kubernetes.io/component: embeddings
+    deploy: sourcegraph
+    app.kubernetes.io/component: embeddings
 spec:
   minReadySeconds: 10
   replicas: 1
@@ -85,8 +85,8 @@ spec:
       {{- if .Values.embeddings.serviceAccount.create }}
       serviceAccountName: {{ .Values.embeddings.serviceAccount.name }}
       {{- end}}
-    volumes:
-      {{- if .Values.embeddings.extraVolumes }}
-      {{- toYaml .Values.embeddings.extraVolumes | nindent 6 }}
-      {{- end }}
+      volumes:
+        {{- if .Values.embeddings.extraVolumes }}
+        {{- toYaml .Values.embeddings.extraVolumes | nindent 6 }}
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
Incorrect indentation of metadata causes warnings on 5.0.4 when embeddings are enabled.
Unfortunately for customers using Argo validation this causes the deployment to fail.

Closes #287 

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan
Tested locally; embeddings service works, helm warnings gone
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
