### PR TITLE
fix: Sourcegraph chart hotfix version

### DIFF
--- a/charts/sourcegraph/Chart.yaml
+++ b/charts/sourcegraph/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://sourcegraph.com/favicon.ico
 type: application
 
 # Chart version, separate from Sourcegraph
-version: "5.0.4"
+version: "5.0.4-rev.1"
 
 # Version of Sourcegraph release
 appVersion: "5.0.4"


### PR DESCRIPTION
### Checklist
Previous PR https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/289 incorrectly bumped version for sourcegraph-migrator chart instead of sourcegraph chart
- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan
only version change
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
