### PR TITLE
Enable  .Values.postgresExporter.containerSecurityContext in codeintel-db and codeinsights-db

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -6,6 +6,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 <!-- START CHANGELOG -->
 - Fix erroneous indentation of `deploy`, `app.kubernetes.io/component` labels and `volumes` in Embeddings deployment
+- Add `.Values.postgresExporter.containerSecurityContext` to `codeintel-db` and `codensights-db`
 
 ## Unreleased
 

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -112,6 +112,8 @@ spec:
         resources:
           {{- toYaml .Values.postgresExporter.resources | nindent 10 }}
         {{- end }}
+        securityContext:
+          {{- toYaml .Values.postgresExporter.containerSecurityContext | nindent 10 }}
       {{- if .Values.codeInsightsDB.extraContainers }}
         {{- toYaml .Values.codeInsightsDB.extraContainers | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -126,6 +126,8 @@ spec:
         resources:
           {{- toYaml .Values.postgresExporter.resources | nindent 10 }}
         {{- end }}
+        securityContext:
+          {{- toYaml .Values.postgresExporter.containerSecurityContext | nindent 10 }}
       terminationGracePeriodSeconds: 120
       securityContext:
         {{- toYaml .Values.codeIntelDB.podSecurityContext | nindent 8 }}


### PR DESCRIPTION
### Checklist

- [ x ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ x ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

This resolves an open issue -> https://github.com/sourcegraph/deploy-sourcegraph-helm/issues/302

### Test plan
- helm lint returns 0 errors
- helm template returns correct resources
- unit test pass for changes (various fails _not_ related to my code)

and, finally, this is actively running my organization's GKE cluster.
