### PR TITLE
sourcegraph: add `json_gcp` log format in gcp example overrides

### DIFF
--- a/charts/sourcegraph/examples/gcp/README.md
+++ b/charts/sourcegraph/examples/gcp/README.md
@@ -2,6 +2,8 @@
 
 Deploy Sourcegraph on GKE and use [Container-native load balancing through Ingress] to make Sourcegraph publicly accessible.
 
+Additionally, it will configure output logs format that works better with GCP Logging by setting `SRC_LOG_FORMAT=json_gcp` in all services.
+
 ## Get started
 
 Deploy or upgrade Sourcegraph Helm chart with the provided [override.yaml](./override.yaml). This will create a public-facing load balancer that supports HTTP traffic. You can then access your deployment via the IP of the load balancer.

--- a/charts/sourcegraph/examples/gcp/override.yaml
+++ b/charts/sourcegraph/examples/gcp/override.yaml
@@ -11,6 +11,9 @@ frontend:
     cloud.google.com/neg: '{"ingress": true}'
     # Reference the `BackendConfig` CR created below
     beta.cloud.google.com/backend-config: '{"default": "sourcegraph-frontend"}'
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
 
 storageClass:
   create: true
@@ -30,3 +33,68 @@ extraResources:
         timeoutSec: 5
         requestPath: /ready
         port: 6060 # we use a custom port to perform healthcheck
+
+migrator:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+githubProxy:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+gitserver:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+grafana:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+indexedSearch:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+indexedSearchIndexer:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+blobstore:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+preciseCodeIntel:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+repoUpdater:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+searcher:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+symbols:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+syntectServer:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
+worker:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp


### PR DESCRIPTION
https://sourcegraph.slack.com/archives/C89KCDK5J/p1689091378857949

https://github.com/sourcegraph/log/pull/61, https://github.com/sourcegraph/sourcegraph/pull/54793

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->


tested on cloud