### PR TITLE
Update executors charts.yaml versions

### DIFF
--- a/charts/sourcegraph-executor/dind/Chart.yaml
+++ b/charts/sourcegraph-executor/dind/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://sourcegraph.com/favicon.ico
 type: application
 
 # Chart version, separate from Sourcegraph
-version: "5.1.5"
+version: "5.1.6"
 
 # Version of Sourcegraph release
-appVersion: "5.1.5"
+appVersion: "5.1.6"

--- a/charts/sourcegraph-executor/k8s/Chart.yaml
+++ b/charts/sourcegraph-executor/k8s/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://sourcegraph.com/favicon.ico
 type: application
 
 # Chart version, separate from Sourcegraph
-version: "5.1.5"
+version: "5.1.6"
 
 # Version of Sourcegraph release
-appVersion: "5.1.5"
+appVersion: "5.1.6"


### PR DESCRIPTION
Update executors versions in `Chart.yaml` files. These values seem to be missed by the release tooling.