### PR TITLE
Qdrant: add helm charts

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -67,7 +67,7 @@ helm template -f ./override.yaml sourcegraph charts/sourcegraph/.
 Perform a diff of the rendered helm manifests before and after your change. There're many ways to produce the diff:
 
 - Run `helm template` before and after the change, then run `diff bundle.old.yaml bundle.new.yaml`.
-- Run `helm install` before the change, then run `helm diff` to inspecth the diff.
+- Run `helm install` before the change, then run `helm diff` to inspect the diff.
 
 ### Deploy the chart
 

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,8 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Added a service for the Qdrant vector database
+
 ## 5.1.6
 
 - Sourcegraph 5.1.6 is now available!

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -99,7 +99,7 @@ In addition to the documented values, all services also support the following va
 | embeddings.image.name | string | `"embeddings"` | Docker image name for the `embeddings` image |
 | embeddings.name | string | `"embeddings"` | Name of the `embeddings` service |
 | embeddings.podSecurityContext | object | `{}` | Security context for the `embeddings` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
-| embeddings.resources | object | `{"limits":{"cpu":"8","memory":"64G"},"requests":{"cpu":"4","memory":"32G"}}` | Resource requests & limits for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| embeddings.resources | object | `{"limits":{"cpu":"8","memory":"64G"},"requests":{"cpu":"4","memory":"32G"}}` | Resource requests & limits for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | embeddings.serviceAccount.annotations | object | `{}` |  |
 | embeddings.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `embeddings` |
 | embeddings.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
@@ -264,6 +264,20 @@ In addition to the documented values, all services also support the following va
 | prometheus.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount |
 | prometheus.serviceAccount.name | string | `"prometheus"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | prometheus.storageSize | string | `"200Gi"` | PVC Storage Request for `prometheus` data volume |
+| qdrant.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"fsGroup":101,"runAsGroup":101,"runAsUser":100}` | Security context for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| qdrant.enabled | bool | `false` | Enable `qdrant` |
+| qdrant.env | object | `{}` | Environment variables for the `qdrant` container |
+| qdrant.extraVolumeMounts | object | `{}` |  |
+| qdrant.extraVolumes | object | `{}` |  |
+| qdrant.image.defaultTag | string | `"239247_2023-08-18_5.1-433e1b1c997f@sha256:eafcd7af2aca699fa9c9ce8e6aa674cc0470441f794baf031296d5d1cdadd0bc"` | Docker image tag for the `embeddings` image |
+| qdrant.image.name | string | `"qdrant"` | Docker image name for the `embeddings` image |
+| qdrant.name | string | `"qdrant"` | Name of the `qdrant` service |
+| qdrant.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"Always","runAsGroup":101,"runAsUser":100}` | Security context for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| qdrant.resources | object | `{"limits":{"cpu":"4","memory":"16G"},"requests":{"cpu":"4","memory":"16G"}}` | Resource requests & limits for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| qdrant.serviceAccount.annotations | object | `{}` |  |
+| qdrant.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `embeddings` |
+| qdrant.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| qdrant.storageSize | string | `"100Gi"` | PVC Storage Request for `qdrant` data volume |
 | redisCache.connection.endpoint | string | `"redis-cache:6379"` | Endpoint to use for redis-cache. Supports either host:port or IANA specification |
 | redisCache.connection.existingSecret | string | `""` | Name of existing secret to use for Redis endpoint The secret must contain the key `endpoint` and should follow IANA specification learn more from the [Helm docs](https://docs.sourcegraph.com/admin/install/kubernetes/helm#using-external-redis-instances) |
 | redisCache.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsUser":999}` | Security context for the `redis-cache` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -273,7 +273,7 @@ In addition to the documented values, all services also support the following va
 | qdrant.image.name | string | `"qdrant"` | Docker image name for the `embeddings` image |
 | qdrant.name | string | `"qdrant"` | Name of the `qdrant` service |
 | qdrant.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":101,"runAsUser":100}` | Security context for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
-| qdrant.resources | object | `{"limits":{"cpu":"4","memory":"16G"},"requests":{"cpu":"4","memory":"16G"}}` | Resource requests & limits for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| qdrant.resources | object | `{"limits":{"cpu":"2","memory":"8G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | qdrant.serviceAccount.annotations | object | `{}` |  |
 | qdrant.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `embeddings` |
 | qdrant.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -90,7 +90,7 @@ In addition to the documented values, all services also support the following va
 | codeIntelDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeintel-db` |
 | codeIntelDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeIntelDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeintel-db` data volume |
-| embeddings.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| embeddings.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `embeddings` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | embeddings.enabled | bool | `false` | Enable `embeddings` |
 | embeddings.env | object | `{}` | Environment variables for the `embeddings` container |
 | embeddings.extraVolumeMounts | object | `{}` |  |
@@ -99,7 +99,7 @@ In addition to the documented values, all services also support the following va
 | embeddings.image.name | string | `"embeddings"` | Docker image name for the `embeddings` image |
 | embeddings.name | string | `"embeddings"` | Name of the `embeddings` service |
 | embeddings.podSecurityContext | object | `{}` | Security context for the `embeddings` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
-| embeddings.resources | object | `{"limits":{"cpu":"8","memory":"64G"},"requests":{"cpu":"4","memory":"32G"}}` | Resource requests & limits for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| embeddings.resources | object | `{"limits":{"cpu":"8","memory":"64G"},"requests":{"cpu":"4","memory":"32G"}}` | Resource requests & limits for the `embeddings` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | embeddings.serviceAccount.annotations | object | `{}` |  |
 | embeddings.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `embeddings` |
 | embeddings.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
@@ -272,7 +272,7 @@ In addition to the documented values, all services also support the following va
 | qdrant.image.defaultTag | string | `"239247_2023-08-18_5.1-433e1b1c997f@sha256:eafcd7af2aca699fa9c9ce8e6aa674cc0470441f794baf031296d5d1cdadd0bc"` | Docker image tag for the `embeddings` image |
 | qdrant.image.name | string | `"qdrant"` | Docker image name for the `embeddings` image |
 | qdrant.name | string | `"qdrant"` | Name of the `qdrant` service |
-| qdrant.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"Always","runAsGroup":101,"runAsUser":100}` | Security context for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| qdrant.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":101,"runAsUser":100}` | Security context for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | qdrant.resources | object | `{"limits":{"cpu":"4","memory":"16G"},"requests":{"cpu":"4","memory":"16G"}}` | Resource requests & limits for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | qdrant.serviceAccount.annotations | object | `{}` |  |
 | qdrant.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `embeddings` |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -264,6 +264,7 @@ In addition to the documented values, all services also support the following va
 | prometheus.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount |
 | prometheus.serviceAccount.name | string | `"prometheus"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | prometheus.storageSize | string | `"200Gi"` | PVC Storage Request for `prometheus` data volume |
+| qdrant.config | object | `{"debug":true,"log_level":"INFO"}` | Resource requests & limits for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | qdrant.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"fsGroup":101,"runAsGroup":101,"runAsUser":100}` | Security context for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | qdrant.enabled | bool | `false` | Enable `qdrant` |
 | qdrant.env | object | `{}` | Environment variables for the `qdrant` container |
@@ -273,7 +274,10 @@ In addition to the documented values, all services also support the following va
 | qdrant.image.name | string | `"qdrant"` | Docker image name for the `embeddings` image |
 | qdrant.name | string | `"qdrant"` | Name of the `qdrant` service |
 | qdrant.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":101,"runAsUser":100}` | Security context for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
-| qdrant.resources | object | `{"limits":{"cpu":"2","memory":"8G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| qdrant.resources.limits.cpu | string | `"2"` |  |
+| qdrant.resources.limits.memory | string | `"8G"` |  |
+| qdrant.resources.requests.cpu | string | `"500m"` |  |
+| qdrant.resources.requests.memory | string | `"2G"` |  |
 | qdrant.serviceAccount.annotations | object | `{}` |  |
 | qdrant.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `embeddings` |
 | qdrant.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |

--- a/charts/sourcegraph/templates/qdrant/qdrant.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.ConfigMap.yaml
@@ -8,18 +8,24 @@ metadata:
     app.kubernetes.io/component: qdrant
 data:
   config.yaml: |
-    debug: true
-    log_level: INFO
+    debug: {{ .Values.qdrant.config.debug }}
+    log_level: {{ .Values.qdrant.config.log_level }}
     storage:
       storage_path: /data
       snapshots_path: /data/storage
       on_disk_payload: true
+    service:
+      http_port: 6333
+      grpc_port: 6334
+    telemetry_disabled: true
+    # The following parameters can be configured
+    # on a per-collection basis, so these are just defaults.
     performance:
       max_optimization_threads: 4
     optimizers:
       max_optimization_threads: 4
       mmap_threshold_kb: 1
-      indexing_threshold_kb: 0
+      indexing_threshold_kb: 0 # disable indexing
     hnsw_index:
       m: 8
       ef_construct: 100
@@ -27,8 +33,4 @@ data:
       max_indexing_threads: 4
       on_disk: true
       payload_m: 8
-    service:
-      http_port: 6333
-      grpc_port: 6334
-    telemetry_disabled: true
 {{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.ConfigMap.yaml
@@ -12,6 +12,7 @@ data:
     log_level: INFO
     storage:
       storage_path: /data
+      snapshots_path: /data/storage
       on_disk_payload: true
     performance:
       max_optimization_threads: 4

--- a/charts/sourcegraph/templates/qdrant/qdrant.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.ConfigMap.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.qdrant.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.qdrant.name }}
+  labels:
+    deploy: sourcegraph
+    app.kubernetes.io/component: qdrant
+data:
+  config.yaml: |
+    debug: true
+    log_level: INFO
+    storage:
+      storage_path: /data
+      on_disk_payload: true
+    performance:
+      max_optimization_threads: 4
+    optimizers:
+      max_optimization_threads: 4
+      mmap_threshold_kb: 1
+      indexing_threshold_kb: 0
+    hnsw_index:
+      m: 8
+      ef_construct: 100
+      full_scan_threshold: 10
+      max_indexing_threads: 4
+      on_disk: true
+      payload_m: 8
+    service:
+      http_port: 6333
+      grpc_port: 6334
+    telemetry_disabled: true
+{{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.Deployment.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.Deployment.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.embeddings.enabled -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.embeddings.name }}
+  annotations:
+    description: Backend for vector search operations.
+  labels:
+    {{- include "sourcegraph.labels" . | nindent 4 }}
+    {{- if .Values.qdrant.labels }}
+      {{- toYaml .Values.qdrant.labels | nindent 4 }}
+    {{- end }}
+    deploy: sourcegraph
+    app.kubernetes.io/component: qdrant
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: {{ .Values.qdrant.name }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      {{- if .Values.sourcegraph.podAnnotations }}
+      {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.qdrant.podAnnotations }}
+      {{- toYaml .Values.qdrant.podAnnotations | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ .Values.embeddings.name }}
+        app.kubernetes.io/component: qdrant
+        deploy: sourcegraph
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
+      {{- if .Values.sourcegraph.podLabels }}
+      {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
+      {{- end }}
+      {{- if .Values.qdrant.podLabels }}
+      {{- toYaml .Values.qdrant.podLabels | nindent 8 }}
+      {{- end }}
+      # TODO: should these live in pod labels?
+        sourcegraph.prometheus/scrape: "true"
+        prometheus.io/port: "6333"
+    spec:
+      containers:
+      - name: {{ .Values.embeddings.name }}
+        image: {{ include "sourcegraph.image" (list . "qdrant") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        env:
+        {{- range $name, $item := .Values.qdrant.env }}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
+        ports:
+          - containerPort: 6333
+            name: http
+            protocol: TCP
+          - containerPort: 6334
+            name: grpc
+            protocol: TCP
+        volumeMounts:
+          {{- if .Values.qdrant.extraVolumeMounts }}
+          {{- toYaml .Values.qdrant.extraVolumeMounts | nindent 8 }}
+          {{- end }}
+          # TODO: move these to extraVolumeMounts?
+          - mountPath: /data
+            name: data
+          - name: config
+            mountPath: /etc/qdrant/config.yaml
+        # TODO: what is this?
+        {{- if not .Values.sourcegraph.localDevMode}}
+        resources:
+          {{- toYaml .Values.qdrant.resources | nindent 10 }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.qdrant.containerSecurityContext | nindent 10 }}
+        resources:
+          limits:
+            cpu: "8"
+            memory: 32Gi
+          requests:
+            cpu: "8"
+            memory: 32Gi
+      securityContext:
+        {{- toYaml .Values.embeddings.podSecurityContext | nindent 8 }}
+      {{- include "sourcegraph.nodeSelector" (list . "qdrant" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "qdrant" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "qdrant" ) | trim | nindent 6 }}
+      {{- if .Values.qdrant.serviceAccount.create }}
+      serviceAccountName: {{ .Values.qdrant.serviceAccount.name }}
+      {{- end}}
+      volumes:
+        {{- if .Values.embeddings.extraVolumes }}
+        {{- toYaml .Values.embeddings.extraVolumes | nindent 6 }}
+        {{- end }}
+        # TODO: move this to extraVolumes?
+        - name: data
+        - name: config
+          configMap:
+            name: qdrant
+            items:
+              - key: config.yaml
+                path: config.yaml
+  # TODO: do I need this?
+  volumeClaimTemplates:
+    - metadata:
+        labels:
+          deploy: sourcegraph
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            # The size of disk to be used for search indexes.
+            storage: 2Ti
+        storageClassName: sourcegraph
+{{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.PersistentVolumeClaim.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.PersistentVolumeClaim.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.qdrant.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    deploy: sourcegraph
+    app.kubernetes.io/component: qdrant
+  name: qdrant
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.qdrant.storageSize }}
+  storageClassName: {{ .Values.storageClass.name }}
+  {{- if .Values.qdrant.volumeName }}
+  volumeName: {{ .Values.qdrant.volumeName }}
+  {{- end }}
+{{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.Service.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.Service.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.embeddings.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "6060"
+    sourcegraph.prometheus/scrape: "true"
+    {{- if .Values.frontend.serviceAnnotations }}
+    {{- toYaml .Values.frontend.serviceAnnotations | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ .Values.embeddings.name }}
+    deploy: sourcegraph
+    app.kubernetes.io/component: embeddings
+    {{- if .Values.sourcegraph.serviceLabels }}
+      {{- toYaml .Values.sourcegraph.serviceLabels | nindent 4 }}
+    {{- end }}
+  name: {{ .Values.embeddings.name }}
+spec:
+  ports:
+  - name: http
+    port: 9991
+    protocol: TCP
+    targetPort: http
+  selector:
+    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
+    app: {{ .Values.embeddings.name }}
+  type: {{ .Values.embeddings.serviceType | default "ClusterIP" }}
+{{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.Service.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.Service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    sourcegraph.prometheus/scrape: "true"
+    prometheus.io/port: "6333"
     {{- if .Values.qdrant.serviceAnnotations }}
     {{- toYaml .Values.qdrant.serviceAnnotations | nindent 4 }}
     {{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.Service.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.Service.yaml
@@ -1,29 +1,29 @@
-{{- if .Values.embeddings.enabled -}}
+{{- if .Values.qdrant.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    prometheus.io/port: "6060"
-    sourcegraph.prometheus/scrape: "true"
-    {{- if .Values.frontend.serviceAnnotations }}
-    {{- toYaml .Values.frontend.serviceAnnotations | nindent 4 }}
+    {{- if .Values.qdrant.serviceAnnotations }}
+    {{- toYaml .Values.qdrant.serviceAnnotations | nindent 4 }}
     {{- end }}
   labels:
-    app: {{ .Values.embeddings.name }}
+    app: qdrant
     deploy: sourcegraph
-    app.kubernetes.io/component: embeddings
-    {{- if .Values.sourcegraph.serviceLabels }}
-      {{- toYaml .Values.sourcegraph.serviceLabels | nindent 4 }}
+    app.kubernetes.io/component: qdrant
+    {{- if .Values.qdrant.serviceLabels }}
+      {{- toYaml .Values.qdrant.serviceLabels | nindent 4 }}
     {{- end }}
-  name: {{ .Values.embeddings.name }}
+  name: qdrant
 spec:
   ports:
+  - name: grpc
+    port: 6333
+    targetPort: grpc
   - name: http
-    port: 9991
-    protocol: TCP
+    port: 6334 
     targetPort: http
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
-    app: {{ .Values.embeddings.name }}
-  type: {{ .Values.embeddings.serviceType | default "ClusterIP" }}
+    app: qdrant
+  type: {{ .Values.qdrant.serviceType | default "ClusterIP" }}
 {{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.Service.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.Service.yaml
@@ -16,12 +16,12 @@ metadata:
   name: qdrant
 spec:
   ports:
-  - name: grpc
-    port: 6333
-    targetPort: grpc
   - name: http
-    port: 6334 
+    port: 6333
     targetPort: http
+  - name: grpc
+    port: 6334
+    targetPort: grpc
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: qdrant

--- a/charts/sourcegraph/templates/qdrant/qdrant.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.ServiceAccount.yaml
@@ -1,11 +1,11 @@
-{{- if and .Values.embeddings.enabled .Values.embeddings.serviceAccount.create -}}
+{{- if and .Values.qdrant.enabled .Values.qdrant.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    app.kubernetes.io/component: {{ .Values.embeddings.name }}
-  {{- include "sourcegraph.serviceAccountAnnotations" (list . "embeddings") | trim | nindent 2 }}
-  name: {{ include "sourcegraph.serviceAccountName" (list . "embeddings") }}
+    app.kubernetes.io/component: {{ .Values.qdrant.name }}
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "qdrant") | trim | nindent 2 }}
+  name: {{ include "sourcegraph.serviceAccountName" (list . "qdrant") }}
 {{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.ServiceAccount.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.embeddings.enabled .Values.embeddings.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: {{ .Values.embeddings.name }}
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "embeddings") | trim | nindent 2 }}
+  name: {{ include "sourcegraph.serviceAccountName" (list . "embeddings") }}
+{{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
@@ -64,16 +64,6 @@ spec:
           - containerPort: 6334
             name: grpc
             protocol: TCP
-        readinessProbe:
-          grpc:
-            port: 6334
-          periodSeconds: 5
-          timeoutSeconds: 5
-        liveness:
-          grpc:
-            port: 6334
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
         volumeMounts:
           - name: qdrant-data
             mountPath: /data

--- a/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.embeddings.enabled -}}
+{{- if .Values.qdrant.enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.embeddings.name }}
+  name: {{ .Values.qdrant.name }}
   annotations:
     description: Backend for vector search operations.
   labels:
@@ -21,13 +21,11 @@ spec:
       {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
       app: {{ .Values.qdrant.name }}
   strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       annotations:
+        kubectl.kubernetes.io/default-container: qdrant
       {{- if .Values.sourcegraph.podAnnotations }}
       {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
       {{- end }}
@@ -35,9 +33,6 @@ spec:
       {{- toYaml .Values.qdrant.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
-        app: {{ .Values.embeddings.name }}
-        app.kubernetes.io/component: qdrant
-        deploy: sourcegraph
       {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
       {{- if .Values.sourcegraph.podLabels }}
       {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
@@ -45,14 +40,18 @@ spec:
       {{- if .Values.qdrant.podLabels }}
       {{- toYaml .Values.qdrant.podLabels | nindent 8 }}
       {{- end }}
+        app: {{ .Values.qdrant.name }}
+        app.kubernetes.io/component: qdrant
+        deploy: sourcegraph
       # TODO: should these live in pod labels?
         sourcegraph.prometheus/scrape: "true"
         prometheus.io/port: "6333"
     spec:
       containers:
-      - name: {{ .Values.embeddings.name }}
+      - name: {{ .Values.qdrant.name }}
         image: {{ include "sourcegraph.image" (list . "qdrant") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        terminationMessagePolicy: FallbackToLogsOnError
         env:
         {{- range $name, $item := .Values.qdrant.env }}
         - name: {{ $name }}
@@ -65,16 +64,24 @@ spec:
           - containerPort: 6334
             name: grpc
             protocol: TCP
+        readinessProbe:
+          grpc:
+            port: grpc
+          periodSeconds: 5
+          timeoutSeconds: 5
+        liveness:
+          grpc:
+            port: grpc
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
         volumeMounts:
-          {{- if .Values.qdrant.extraVolumeMounts }}
-          {{- toYaml .Values.qdrant.extraVolumeMounts | nindent 8 }}
-          {{- end }}
-          # TODO: move these to extraVolumeMounts?
           - mountPath: /data
             name: data
           - name: config
             mountPath: /etc/qdrant/config.yaml
-        # TODO: what is this?
+          {{- if .Values.qdrant.extraVolumeMounts }}
+          {{- toYaml .Values.qdrant.extraVolumeMounts | nindent 8 }}
+          {{- end }}
         {{- if not .Values.sourcegraph.localDevMode}}
         resources:
           {{- toYaml .Values.qdrant.resources | nindent 10 }}
@@ -88,38 +95,32 @@ spec:
           requests:
             cpu: "8"
             memory: 32Gi
+      {{- if .Values.blobstore.extraContainers }}
+        {{- toYaml .Values.blobstore.extraContainers | nindent 6 }}
+      {{- end }}
       securityContext:
-        {{- toYaml .Values.embeddings.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.qdrant.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "qdrant" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "qdrant" ) | trim | nindent 6 }}
       {{- include "sourcegraph.tolerations" (list . "qdrant" ) | trim | nindent 6 }}
       {{- if .Values.qdrant.serviceAccount.create }}
       serviceAccountName: {{ .Values.qdrant.serviceAccount.name }}
       {{- end}}
+      {{- with .Values.sourcegraph.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
-        {{- if .Values.embeddings.extraVolumes }}
-        {{- toYaml .Values.embeddings.extraVolumes | nindent 6 }}
+        {{- if .Values.qdrant.extraVolumes }}
+        {{- toYaml .Values.qdrant.extraVolumes | nindent 6 }}
         {{- end }}
-        # TODO: move this to extraVolumes?
         - name: data
+          persistentVolumeClaim:
+            claimName: data
         - name: config
           configMap:
             name: qdrant
             items:
               - key: config.yaml
                 path: config.yaml
-  # TODO: do I need this?
-  volumeClaimTemplates:
-    - metadata:
-        labels:
-          deploy: sourcegraph
-        name: data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            # The size of disk to be used for search indexes.
-            storage: 2Ti
-        storageClassName: sourcegraph
 {{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
@@ -61,7 +61,25 @@ spec:
           - containerPort: 6334
             name: grpc
             protocol: TCP
-        # TODO: add readiness probe once this PR lands: https://github.com/qdrant/qdrant/pull/2409
+        # TODO: use gRPC liveness/readiness probe once this PR lands: https://github.com/qdrant/qdrant/pull/2409
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            scheme: HTTP
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            scheme: HTTP
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         volumeMounts:
           - name: qdrant-data
             mountPath: /data

--- a/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
@@ -44,8 +44,6 @@ spec:
         app.kubernetes.io/component: qdrant
         deploy: sourcegraph
       # TODO: should these live in pod labels?
-        sourcegraph.prometheus/scrape: "true"
-        prometheus.io/port: "6333"
     spec:
       containers:
       - name: {{ .Values.qdrant.name }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
@@ -43,7 +43,6 @@ spec:
         app: {{ .Values.qdrant.name }}
         app.kubernetes.io/component: qdrant
         deploy: sourcegraph
-      # TODO: should these live in pod labels?
     spec:
       containers:
       - name: {{ .Values.qdrant.name }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
@@ -66,19 +66,19 @@ spec:
             protocol: TCP
         readinessProbe:
           grpc:
-            port: grpc
+            port: 6334
           periodSeconds: 5
           timeoutSeconds: 5
         liveness:
           grpc:
-            port: grpc
+            port: 6334
           initialDelaySeconds: 60
           timeoutSeconds: 5
         volumeMounts:
-          - mountPath: /data
-            name: data
+          - name: qdrant-data
+            mountPath: /data
           - name: config
-            mountPath: /etc/qdrant/config.yaml
+            mountPath: /etc/qdrant
           {{- if .Values.qdrant.extraVolumeMounts }}
           {{- toYaml .Values.qdrant.extraVolumeMounts | nindent 8 }}
           {{- end }}
@@ -90,11 +90,11 @@ spec:
           {{- toYaml .Values.qdrant.containerSecurityContext | nindent 10 }}
         resources:
           limits:
-            cpu: "8"
-            memory: 32Gi
+            cpu: "1"
+            memory: 8Gi
           requests:
-            cpu: "8"
-            memory: 32Gi
+            cpu: "1"
+            memory: 8Gi
       {{- if .Values.blobstore.extraContainers }}
         {{- toYaml .Values.blobstore.extraContainers | nindent 6 }}
       {{- end }}
@@ -114,9 +114,9 @@ spec:
         {{- if .Values.qdrant.extraVolumes }}
         {{- toYaml .Values.qdrant.extraVolumes | nindent 6 }}
         {{- end }}
-        - name: data
+        - name: qdrant-data
           persistentVolumeClaim:
-            claimName: data
+            claimName: qdrant
         - name: config
           configMap:
             name: qdrant

--- a/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
@@ -79,13 +79,6 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.qdrant.containerSecurityContext | nindent 10 }}
-        resources:
-          limits:
-            cpu: "1"
-            memory: 8Gi
-          requests:
-            cpu: "1"
-            memory: 8Gi
       {{- if .Values.blobstore.extraContainers }}
         {{- toYaml .Values.blobstore.extraContainers | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
@@ -64,6 +64,7 @@ spec:
           - containerPort: 6334
             name: grpc
             protocol: TCP
+        # TODO: add readiness probe once this PR lands: https://github.com/qdrant/qdrant/pull/2409
         volumeMounts:
           - name: qdrant-data
             mountPath: /data

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -336,11 +336,11 @@ qdrant:
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
     limits:
-      cpu: "4"
-      memory: 16G
+      cpu: "2"
+      memory: 8G
     requests:
-      cpu: "4"
-      memory: 16G
+      cpu: "500m"
+      memory: 2G
   # -- Environment variables for the `qdrant` container
   env: {}
   # -- Security context for the `qdrant` container,

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -336,11 +336,11 @@ qdrant:
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
     limits:
-      cpu: "8"
-      memory: 32G
+      cpu: "4"
+      memory: 16G
     requests:
-      cpu: "8"
-      memory: 32G
+      cpu: "4"
+      memory: 16G
   # -- Environment variables for the `qdrant` container
   env: {}
   # -- Security context for the `qdrant` container,
@@ -349,10 +349,14 @@ qdrant:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
-    readOnlyRootFilesystem: true
+    fsGroup: 101
   # -- Security context for the `qdrant` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsUser: 100
+    runAsGroup: 101
+    fsGroup: 101
+    fsGroupChangePolicy: "Always"
   serviceAccount:
     # -- Enable creation of ServiceAccount for `embeddings`
     create: false

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -334,6 +334,9 @@ qdrant:
     defaultTag: "239247_2023-08-18_5.1-433e1b1c997f@sha256:eafcd7af2aca699fa9c9ce8e6aa674cc0470441f794baf031296d5d1cdadd0bc"
   # -- Resource requests & limits for the `qdrant` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  config:
+    debug: true
+    log_level: INFO
   resources:
     limits:
       cpu: "2"

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -292,7 +292,7 @@ embeddings:
     name: "embeddings"
     # -- Docker image tag for the `embeddings` image
     defaultTag: "5.1.6@sha256:e849f52e38637882e5d2ba3d7d27a656d897c4b4e2905e1fdb843536d9c948ab"
-  # -- Resource requests & limits for the `qdrant` container,
+  # -- Resource requests & limits for the `embeddings` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
     limits:
@@ -303,7 +303,7 @@ embeddings:
       memory: 32G
   # -- Environment variables for the `embeddings` container
   env: {}
-  # -- Security context for the `worker` container,
+  # -- Security context for the `embeddings` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
   containerSecurityContext:
     allowPrivilegeEscalation: false
@@ -356,7 +356,7 @@ qdrant:
     runAsUser: 100
     runAsGroup: 101
     fsGroup: 101
-    fsGroupChangePolicy: "Always"
+    fsGroupChangePolicy: "OnRootMismatch"
   serviceAccount:
     # -- Enable creation of ServiceAccount for `embeddings`
     create: false

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -292,7 +292,7 @@ embeddings:
     name: "embeddings"
     # -- Docker image tag for the `embeddings` image
     defaultTag: "5.1.6@sha256:e849f52e38637882e5d2ba3d7d27a656d897c4b4e2905e1fdb843536d9c948ab"
-  # -- Resource requests & limits for the `worker` container,
+  # -- Resource requests & limits for the `qdrant` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
     limits:
@@ -311,6 +311,46 @@ embeddings:
     runAsGroup: 101
     readOnlyRootFilesystem: true
   # -- Security context for the `embeddings` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  podSecurityContext: {}
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `embeddings`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
+    annotations: {}
+  extraVolumeMounts: {}
+  extraVolumes: {}
+
+qdrant:
+  # -- Enable `qdrant`
+  enabled: false
+  # -- Name of the `qdrant` service
+  name: qdrant
+  image:
+    # -- Docker image name for the `embeddings` image
+    name: "qdrant"
+    # -- Docker image tag for the `embeddings` image
+    defaultTag: "239247_2023-08-18_5.1-433e1b1c997f@sha256:eafcd7af2aca699fa9c9ce8e6aa674cc0470441f794baf031296d5d1cdadd0bc"
+  # -- Resource requests & limits for the `qdrant` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  resources:
+    limits:
+      cpu: "8"
+      memory: 32G
+    requests:
+      cpu: "8"
+      memory: 32G
+  # -- Environment variables for the `qdrant` container
+  env: {}
+  # -- Security context for the `qdrant` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 100
+    runAsGroup: 101
+    readOnlyRootFilesystem: true
+  # -- Security context for the `qdrant` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
   podSecurityContext: {}
   serviceAccount:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -361,6 +361,8 @@ qdrant:
     annotations: {}
   extraVolumeMounts: {}
   extraVolumes: {}
+  # -- PVC Storage Request for `qdrant` data volume
+  storageSize: 100Gi
 
 frontend:
   # -- Environment variables for the `frontend` container


### PR DESCRIPTION
This implements helm charts to add a Qdrant deployment to our cloud deployments. The intent is to replace the `embeddings` service entirely and to stop depending on blobstore for embeddings storage. 

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

I ran the cluster locally, ensuring that I can generate and search embeddings with Qdrant. 

I tested with the following `override.yaml`:
```yaml
# Disable SC creation
storageClass:
  create: false
  name: standard

# Disable resources requests/limits
sourcegraph:
  localDevMode: true
  image:
    defaultTag: insiders
    useGlobalTagAsDefault: true
# More values to be added in order to test your change

qdrant:
  enabled: true

gitserver:
  env:
    SRC_REPOS_DESIRED_PERCENT_FREE:
      value: "0"

frontend:
  env:
    QDRANT_ENDPOINT:
      value: "qdrant:6334"

```

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
