### PR TITLE
Qdrant: fix invalid field

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -265,7 +265,7 @@ In addition to the documented values, all services also support the following va
 | prometheus.serviceAccount.name | string | `"prometheus"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | prometheus.storageSize | string | `"200Gi"` | PVC Storage Request for `prometheus` data volume |
 | qdrant.config | object | `{"debug":true,"log_level":"INFO"}` | Resource requests & limits for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
-| qdrant.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"fsGroup":101,"runAsGroup":101,"runAsUser":100}` | Security context for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| qdrant.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsGroup":101,"runAsUser":100}` | Security context for the `qdrant` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | qdrant.enabled | bool | `false` | Enable `qdrant` |
 | qdrant.env | object | `{}` | Environment variables for the `qdrant` container |
 | qdrant.extraVolumeMounts | object | `{}` |  |

--- a/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
@@ -20,8 +20,8 @@ spec:
     matchLabels:
       {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
       app: {{ .Values.qdrant.name }}
-  strategy:
-    type: Recreate
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/qdrant/qdrant.StatefulSet.yaml
@@ -20,6 +20,7 @@ spec:
     matchLabels:
       {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
       app: {{ .Values.qdrant.name }}
+  serviceName: qdrant
   updateStrategy:
     type: RollingUpdate
   template:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -352,7 +352,6 @@ qdrant:
     allowPrivilegeEscalation: false
     runAsUser: 100
     runAsGroup: 101
-    fsGroup: 101
   # -- Security context for the `qdrant` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
   podSecurityContext:

--- a/override.yaml
+++ b/override.yaml
@@ -1,0 +1,30 @@
+# Disable SC creation
+storageClass:
+  create: true
+  name: standard
+  provisioner: docker.io/hostpath
+  parameters:
+    reclaimPolicy: Retain
+
+
+# Disable resources requests/limits
+sourcegraph:
+  localDevMode: true
+  image:
+    defaultTag: insiders
+    useGlobalTagAsDefault: true
+# More values to be added in order to test your change
+
+qdrant:
+  enabled: true
+
+gitserver:
+  env:
+    SRC_REPOS_DESIRED_PERCENT_FREE:
+      value: "0"
+
+frontend:
+  env:
+    QDRANT_ENDPOINT:
+      value: "qdrant:6334"
+


### PR DESCRIPTION
Apparently `strategy` is not a valid field for `StatefulSet` (only `Deployment`). I caught this when trying to port the rendered helm template to the dotcom deployment, which uses `kubectl apply` rather than `helm upgrade`. `kubectl apply` returns a validation error for that field.

This fixes `strategy` and two other invalid fields which are ignored with helm, but get caught by the `kubectl apply` validator. 

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

Ran the cluster locally, inspected the running service  to ensure it had an update strategy of `RollingUpdate`

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
