### PR TITLE
sourcegraph: make sure we set replicacount

### DIFF
--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -17,6 +17,7 @@ spec:
   selector:
     matchLabels:
       app: grafana
+  replicas: 1
   serviceName: grafana
   updateStrategy:
      type: RollingUpdate

--- a/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -19,6 +19,7 @@ spec:
     matchLabels:
       {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
       app: prometheus
+  replicas: 1
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
interesting thing could happy if we don't track this in manifest

- if using `helm template | kubectl apply` to deploy
- scale these deploy to 0
- `helm template | kubectl apply` will not scale it back to 1

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

CI