### PR TITLE
revert #348 (Remove Github Proxy)

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,11 +8,12 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- The GitHub Proxy service has been removed and is no longer required. Remove all `githubProxy` fields from config, if set.
+
 
 ## 5.2.1
 
 - Sourcegraph 5.2.1 is now available
-- The GitHub Proxy service has been removed and is no longer required. Remove all `githubProxy` fields from config, if set.
 
 
 ## 5.2.0

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -121,6 +121,14 @@ In addition to the documented values, all services also support the following va
 | frontend.resources | object | `{"limits":{"cpu":"2","ephemeral-storage":"8Gi","memory":"4G"},"requests":{"cpu":"2","ephemeral-storage":"4Gi","memory":"2G"}}` | Resource requests & limits for the `frontend` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | frontend.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `frontend` |
 | frontend.serviceAccount.name | string | `"sourcegraph-frontend"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| githubProxy.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `github-proxy` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| githubProxy.image.defaultTag | string | `"5.2.0@sha256:2012a1c18550bd7d5c450f48d25c7673273c290cf9fda19d630947dacf4d43ba"` | Docker image tag for the `github-proxy` image |
+| githubProxy.image.name | string | `"github-proxy"` | Docker image name for the `github-proxy` image |
+| githubProxy.name | string | `"github-proxy"` | Name used by resources. Does not affect service names or PVCs. |
+| githubProxy.podSecurityContext | object | `{}` | Security context for the `github-proxy` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| githubProxy.resources | object | `{"limits":{"cpu":"1","memory":"1G"},"requests":{"cpu":"100m","memory":"250M"}}` | Resource requests & limits for the `github-proxy` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| githubProxy.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `github-proxy` |
+| githubProxy.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | gitserver.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `gitserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | gitserver.image.defaultTag | string | `"5.2.0@sha256:d7e3e0ef8c144239d76641048291854ad2c49c27770dbf42a9d710655cba93b7"` | Docker image tag for the `gitserver` image |
 | gitserver.image.name | string | `"gitserver"` | Docker image name for the `gitserver` image |

--- a/charts/sourcegraph/examples/common-modifications/override.yaml
+++ b/charts/sourcegraph/examples/common-modifications/override.yaml
@@ -52,6 +52,15 @@ migrator:
       cpu: 100m
       memory: 50M
 
+githubProxy:
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1G
+    requests:
+      cpu: 100m
+      memory: 250M
+
 gitserver:
   replicaCount: 1
   resources:

--- a/charts/sourcegraph/examples/gcp/override.yaml
+++ b/charts/sourcegraph/examples/gcp/override.yaml
@@ -39,6 +39,11 @@ migrator:
     SRC_LOG_FORMAT: 
       value: json_gcp
 
+githubProxy:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
 gitserver:
   env:
     SRC_LOG_FORMAT: 

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: Rate-limiting proxy for the GitHub API.
+  labels:
+    {{- include "sourcegraph.labels" . | nindent 4 }}
+    {{- if .Values.githubProxy.labels }}
+      {{- toYaml .Values.githubProxy.labels | nindent 4 }}
+    {{- end }}
+    deploy: sourcegraph
+    app.kubernetes.io/component: github-proxy
+  name: {{ .Values.githubProxy.name }}
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: github-proxy
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: github-proxy
+      {{- if .Values.sourcegraph.podAnnotations }}
+      {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.githubProxy.podAnnotations }}
+      {{- toYaml .Values.githubProxy.podAnnotations | nindent 8 }}
+      {{- end }}
+      labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
+      {{- if .Values.sourcegraph.podLabels }}
+      {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
+      {{- end }}
+      {{- if .Values.githubProxy.podLabels }}
+      {{- toYaml .Values.githubProxy.podLabels | nindent 8 }}
+      {{- end }}
+        app: github-proxy
+        deploy: sourcegraph
+    spec:
+      containers:
+      - name: github-proxy
+        image: {{ include "sourcegraph.image" (list . "githubProxy") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        {{- with .Values.githubProxy.args }}
+        args:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        {{- range $name, $item := .Values.githubProxy.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
+        {{- include "sourcegraph.openTelemetryEnv" . | nindent 8 }}
+        ports:
+        - containerPort: 3180
+          name: http
+        {{- if not .Values.sourcegraph.localDevMode }}
+        resources:
+          {{- toYaml .Values.githubProxy.resources | nindent 10 }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.githubProxy.containerSecurityContext | nindent 10 }}
+        volumeMounts:
+        {{- if .Values.githubProxy.extraVolumeMounts }}
+        {{- toYaml .Values.githubProxy.extraVolumeMounts | nindent 8 }}
+        {{- end }}
+      {{- if .Values.githubProxy.extraContainers }}
+        {{- toYaml .Values.githubProxy.extraContainers | nindent 6 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.githubProxy.podSecurityContext | nindent 8 }}
+      {{- include "sourcegraph.nodeSelector" (list . "githubProxy" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "githubProxy" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "githubProxy" ) | trim | nindent 6 }}
+      {{- with .Values.sourcegraph.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "githubProxy") | trim | nindent 6 }}
+      volumes:
+      {{- if .Values.githubProxy.extraVolumes }}
+      {{- toYaml .Values.githubProxy.extraVolumes | nindent 6 }}
+      {{- end }}

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "6060"
+    sourcegraph.prometheus/scrape: "true"
+    {{- if .Values.githubProxy.serviceAnnotations }}
+    {{- toYaml .Values.githubProxy.serviceAnnotations | nindent 4 }}
+    {{- end }}
+  labels:
+    app: github-proxy
+    deploy: sourcegraph
+    app.kubernetes.io/component: github-proxy
+    {{- if .Values.githubProxy.serviceLabels }}
+      {{- toYaml .Values.githubProxy.serviceLabels | nindent 4 }}
+    {{- end }}
+  name: github-proxy
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
+    app: github-proxy
+  type: {{ .Values.githubProxy.serviceType | default "ClusterIP" }}

--- a/charts/sourcegraph/templates/github-proxy/github-proxy.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/github-proxy/github-proxy.ServiceAccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.githubProxy.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: github-proxy
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "githubProxy") | trim | nindent 2 }}
+  name: {{ include "sourcegraph.serviceAccountName" (list . "githubProxy") }}
+{{- end }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -464,6 +464,39 @@ migrator:
     runAsGroup: 101
     readOnlyRootFilesystem: true
 
+githubProxy:
+  image:
+    # -- Docker image tag for the `github-proxy` image
+    defaultTag: 5.2.0@sha256:2012a1c18550bd7d5c450f48d25c7673273c290cf9fda19d630947dacf4d43ba
+    # -- Docker image name for the `github-proxy` image
+    name: "github-proxy"
+  # -- Security context for the `github-proxy` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 100
+    runAsGroup: 101
+    readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
+  name: "github-proxy"
+  # -- Security context for the `github-proxy` pod,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  podSecurityContext: {}
+  # -- Resource requests & limits for the `github-proxy` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1G
+    requests:
+      cpu: 100m
+      memory: 250M
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `github-proxy`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
+
 gitserver:
   image:
     # -- Docker image tag for the `gitserver` image


### PR DESCRIPTION
### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Reverting #348 as this PR shouldn't be merged until the next major / minor release.
We currently cherry-pick release artifacts from patch releases into the `main` branch and #348 isn't included in `5.2.x`