### PR TITLE
sourcegraph: fix otel service account tmpl

### DIFF
--- a/charts/sourcegraph/templates/otel-collector/otel-agent.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-agent.ServiceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: otel-collector
-  {{- include "sourcegraph.serviceAccountAnnotations" (list .Values.openTelemetry "agent") | trim | nindent 2 -}}
+  {{- include "sourcegraph.serviceAccountAnnotations" (list .Values.openTelemetry "agent") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list .Values.openTelemetry "agent") }}
 {{- end }}

--- a/charts/sourcegraph/templates/otel-collector/otel-collector.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-collector.ServiceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
     category: rbac
     deploy: sourcegraph
     app.kubernetes.io/component: otel-collector
-  {{- include "sourcegraph.serviceAccountAnnotations" (list .Values.openTelemetry "gateway") | trim | nindent 2 -}}
+  {{- include "sourcegraph.serviceAccountAnnotations" (list .Values.openTelemetry "gateway") | trim | nindent 2 }}
   name: {{ include "sourcegraph.serviceAccountName" (list .Values.openTelemetry "gateway") }}
 {{- end }}


### PR DESCRIPTION
with below override to enable otel SA

```yaml
openTelemetry:
  gateway:
    serviceAccount:
      create: true
```

you got

```
Error: YAML parse error on sourcegraph/templates/otel-collector/otel-collector.ServiceAccount.yaml: error converting YAML to JSON: yaml: line 9: mapping values are not allowed in this context
helm.go:84: [debug] error converting YAML to JSON: yaml: line 9: mapping values are not allowed in this context
```

```yaml
---
# Source: sourcegraph/templates/otel-collector/otel-collector.ServiceAccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    category: rbac
    deploy: sourcegraph
    app.kubernetes.io/component: otel-collector
  annotations:
    iam.gke.io/gcp-service-account: src-4b18e57abef3ef40@src-747bc765eb31a4873e4b.iam.gserviceaccount.comname: otel-collector
```

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [x] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

actually surprise helm unit test doesn't catch the same error

no more error
