### PR TITLE
sourcegraph: fix unable to scrape syntect-server metrics

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -6,6 +6,8 @@ Use `**BREAKING**:` to denote a breaking change
 
 <!-- START CHANGELOG -->
 
+- Fixed unable to scrape `syntect-server` metrics [#385](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/385)
+
 ## 5.2.5
 
 - Sourcegraph 5.2.5 is now available

--- a/charts/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/charts/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -1,10 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.syntectServer.serviceAnnotations }}
   annotations:
+    prometheus.io/port: "6060"
+    sourcegraph.prometheus/scrape: "true"
+    {{- if .Values.syntectServer.serviceAnnotations }}
     {{- toYaml .Values.syntectServer.serviceAnnotations | nindent 4 }}
-  {{- end }}
+    {{- end }}
   labels:
     app: syntect-server
     deploy: sourcegraph


### PR DESCRIPTION
Due to our prom config, service without specific labels are ignroed and won't be scraped.

https://github.com/sourcegraph/deploy-sourcegraph/blob/242be7c36d7b1b2481d62a2a95b07053311cdf54/base/prometheus/prometheus.ConfigMap.yaml#L131-L134

This PR added the missing required annotations, `sourcegraph.prometheus/scrape=true`, to `syntect-server` svc.

https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/5faa5c5d577e96657dd33961b5c9776eec7665e2/charts/sourcegraph/templates/searcher/searcher.Service.yaml#L4-L10

https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/5faa5c5d577e96657dd33961b5c9776eec7665e2/charts/sourcegraph/templates/syntect-server/syntect-server.Service.yaml#L4-L7

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

```
helm upgrade --install --create-namespace -n sourcegraph -f ./override.yaml sourcegraph charts/sourcegraph/.
```

```
k port-forward svc/sourcegraph-frontend 30080
```

Run `up{}` in explorer,

![Grafana](https://github.com/sourcegraph/deploy-sourcegraph-helm/assets/8373004/d3e4f08b-e9b5-4f1c-8b7f-80381bb736b9)

```sh
k port-forward svc/prometheus 30090
```

![CleanShot 2023-12-20 at 12 43 14](https://github.com/sourcegraph/deploy-sourcegraph-helm/assets/8373004/857479bd-3fa7-4229-8e0b-84f9d2e7c23c)
