### PR TITLE
Add volumeMounts option for frontend init container

### DIFF
--- a/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
+++ b/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
@@ -51,6 +51,10 @@ spec:
           {{- toYaml .Values.migrator.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.migrator.containerSecurityContext | nindent 10 }}
+        volumeMounts:
+        {{- if .Values.migrator.extraVolumeMounts }}
+        {{- toYaml .Values.migrator.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       {{- if .Values.migrator.extraContainers }}
         {{- toYaml .Values.migrator.extraContainers | nindent 6 }}
       {{- end }}

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -6,13 +6,15 @@ Use `**BREAKING**:` to denote a breaking change
 
 <!-- START CHANGELOG -->
 
+## Unreleased
+
 - Fixed unable to scrape `syntect-server` metrics [#385](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/385)
+
+- Add `volumeMounts` option to frontend init container [#387](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/387)
 
 ## 5.2.5
 
 - Sourcegraph 5.2.5 is now available
-
-## Unreleased
 
 ## 5.2.4
 

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -73,6 +73,10 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.migrator.containerSecurityContext | nindent 10 }}
+        volumeMounts:
+        {{- if .Values.migrator.extraVolumeMounts }}
+        {{- toYaml .Values.migrator.extraVolumeMounts | nindent 8 }}
+        {{- end}}
       {{- end }}
       containers:
       - name: frontend

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -76,7 +76,7 @@ spec:
         volumeMounts:
         {{- if .Values.migrator.extraVolumeMounts }}
         {{- toYaml .Values.migrator.extraVolumeMounts | nindent 8 }}
-        {{- end}}
+        {{- end }}
       {{- end }}
       containers:
       - name: frontend


### PR DESCRIPTION
Allow for `volumeMounts` in the frontend init container.

* Allows mounting TLS certificates needed to establish encrypted TLS connections to PostgreSQL databases. 

Values can be set in a override file as follows:
```yaml
frontend:
  extraVolumes:
  - name: migrator-tls
    secret:
      secretName: migrator-tls-secret

migrator:
  extraVolumeMounts:
  - name: migrator-tls
    mountPath: /etc/tls
    readOnly: true
  env:
    PGSSLCERT:
      value: /etc/tls/tls.crt
    PGSSLKEY:
      value: /etc/tls/tls.key
```

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan
Manual test and Helm lint

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
