### PR TITLE
Added executor.frontendExistingSecret for k8s executor helm chart

### DIFF
--- a/charts/sourcegraph-executor/k8s/README.md
+++ b/charts/sourcegraph-executor/k8s/README.md
@@ -57,9 +57,9 @@ In addition to the documented values, the `executor` and `private-docker-registr
 | executor.debug.keepJobs | string | `"false"` | If true, Kubernetes jobs will not be deleted after they complete. Not recommended for production use as it can hit cluster limits. |
 | executor.debug.keepWorkspaces | string | `"false"` |  |
 | executor.dockerAddHostGateway | string | `"false"` | For local deployments the host is 'host.docker.internal' and this needs to be true |
-| executor.enabled | bool | `true` |  |
 | executor.extraEnv | string | `nil` | Sets extra environment variables on the executor deployment. See `values.yaml` for the format. |
-| executor.frontendPassword | string | `""` | The shared secret configured in the Sourcegraph instance site config under executors.accessToken. Required. |
+| executor.frontendExistingSecret | string | `""` | Name of existing k8s Secret to use for frontend password The name of the secret must match `executor.name`, i.e., the name of the helm release used to deploy the helm chart. The k8s Secret must contain the key `EXECUTOR_FRONTEND_PASSWORD` matching the site config `executors.accessToken` value. `executor.frontendPassword` is ignored if this is enabled. |
+| executor.frontendPassword | string | `""` | The shared secret configured in the Sourcegraph instance site config under executors.accessToken. Required if `executor.frontendExistingSecret`` is not configured. |
 | executor.frontendUrl | string | `""` | The external URL of the Sourcegraph instance. Required. **Recommended:** set to the internal service endpoint (e.g. `http://sourcegraph-frontend.sourcegraph.svc.cluster.local:30080` if Sourcegraph is deployed in the `sourcegraph` namespace).  This will avoid unnecessary network charges as traffic will stay within the local network. |
 | executor.image.defaultTag | string | `"5.2.6@sha256:5f952f54885e1eb24d96d84f23a504f9885c19ad135128b270c44cba0eeacb56"` |  |
 | executor.image.name | string | `"executor-kubernetes"` |  |

--- a/charts/sourcegraph-executor/k8s/templates/executor.ConfigMap.yaml
+++ b/charts/sourcegraph-executor/k8s/templates/executor.ConfigMap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.executor.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,4 +42,3 @@ data:
   EXECUTOR_DOCKER_ADD_HOST_GATEWAY: "{{.Values.executor.dockerAddHostGateway }}"
   KUBERNETES_KEEP_JOBS: "{{ .Values.executor.debug.keepJobs }}"
   EXECUTOR_KEEP_WORKSPACES: "{{ .Values.executor.debug.keepWorkspaces }}"
-{{- end }}

--- a/charts/sourcegraph-executor/k8s/templates/executor.Deployment.yaml
+++ b/charts/sourcegraph-executor/k8s/templates/executor.Deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.executor.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -104,4 +103,3 @@ spec:
         - name: "sg-{{include "executor.name" . }}"
           persistentVolumeClaim:
             claimName: "sg-{{include "executor.name" . }}"
-{{- end }}

--- a/charts/sourcegraph-executor/k8s/templates/executor.PersistentVolumeClaim.yaml
+++ b/charts/sourcegraph-executor/k8s/templates/executor.PersistentVolumeClaim.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.executor.enabled -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,4 +11,3 @@ spec:
   resources:
     requests:
       storage: {{ .Values.executor.storageSize }}
-{{- end}}

--- a/charts/sourcegraph-executor/k8s/templates/executor.Secret.yaml
+++ b/charts/sourcegraph-executor/k8s/templates/executor.Secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.executor.enabled -}}
+{{- if not .Values.executor.frontendExistingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sourcegraph-executor/k8s/templates/executor.Service.yaml
+++ b/charts/sourcegraph-executor/k8s/templates/executor.Service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.executor.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,4 +22,3 @@ spec:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: {{ include "executor.name" . }}
   type: {{ .Values.executor.serviceType | default "ClusterIP" }}
-{{- end }}

--- a/charts/sourcegraph-executor/k8s/values.yaml
+++ b/charts/sourcegraph-executor/k8s/values.yaml
@@ -56,14 +56,18 @@ executor:
   # -- Whether to configure the necessary RBAC resources. Required only once for all executor deployments.
   configureRbac: true
   replicas: 1
-  enabled: true
   image:
     defaultTag: 5.2.6@sha256:5f952f54885e1eb24d96d84f23a504f9885c19ad135128b270c44cba0eeacb56
     name: "executor-kubernetes"
   # -- The external URL of the Sourcegraph instance. Required. **Recommended:** set to the internal service endpoint (e.g. `http://sourcegraph-frontend.sourcegraph.svc.cluster.local:30080` if Sourcegraph is deployed in the `sourcegraph` namespace). 
   # This will avoid unnecessary network charges as traffic will stay within the local network.
   frontendUrl: ""
-  # -- The shared secret configured in the Sourcegraph instance site config under executors.accessToken. Required.
+  # -- Name of existing k8s Secret to use for frontend password
+  # The name of the secret must match `executor.name`, i.e., the name of the helm release used to deploy the helm chart.
+  # The k8s Secret must contain the key `EXECUTOR_FRONTEND_PASSWORD` matching the site config `executors.accessToken` value.
+  # `executor.frontendPassword` is ignored if this is enabled.
+  frontendExistingSecret: ""
+  # -- The shared secret configured in the Sourcegraph instance site config under executors.accessToken. Required if `executor.frontendExistingSecret`` is not configured.
   frontendPassword: ""
   # -- The name of the queue to pull jobs from to. Possible values: batches and codeintel. **Either this or queueNames is required.**
   queueName: ""


### PR DESCRIPTION
- Backport for #403 
- Fix for https://github.com/sourcegraph/deploy-sourcegraph-helm/issues/402
- Removed the `Values.executor.enabled`  boolean
  - if you don't want to enable executors, you probably shouldn't be deploying this helm chart to begin with...
  - deploying this chart with `executor.enabled=false` will only deploy RBAC resources (unless `executor.configureRbac=false` as well)

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

- templated out `sourcegraph/sourcegraph-executor-k8s` using both `frontendPassword` and `frontendExistingSecret`
