### PR TITLE
Update redis health checks based on dot-com

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,8 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Updated redis liveness/readiness probes [#419](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/419)
+
 
 ## 5.3.0
 

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -53,6 +53,13 @@ spec:
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          failureThreshold: 2
+          timeoutSeconds: 5
+          tcpSocket:
+            port: redis
+        readinessProbe:
           initialDelaySeconds: 5
           exec:
             command:
@@ -75,10 +82,6 @@ spec:
         ports:
         - containerPort: 6379
           name: redis
-        readinessProbe:
-          initialDelaySeconds: 5
-          tcpSocket:
-            port: redis
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.redisCache.resources | nindent 10 }}

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -53,9 +53,11 @@ spec:
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
-          initialDelaySeconds: 30
-          tcpSocket:
-            port: redis
+          initialDelaySeconds: 5
+          exec:
+            command:
+            - redis-cli
+            - ping
         env:
         {{- range $name, $item := .Values.redisCache.env}}
         - name: {{ $name }}

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -56,8 +56,17 @@ spec:
           initialDelaySeconds: 5
           exec:
             command:
-            - redis-cli
-            - ping
+            - /bin/sh
+            - -c
+            - |
+              #!/bin/bash
+              response=$(
+                redis-cli ping
+              )
+              if [ "$response" != "PONG" ]; then
+                echo "$response"
+                exit 1
+              fi
         env:
         {{- range $name, $item := .Values.redisCache.env}}
         - name: {{ $name }}

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -58,12 +58,12 @@ spec:
           {{- $item | toYaml | nindent 10 }}
         {{- end }}
         livenessProbe:
-          initialDelaySeconds: 30
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          failureThreshold: 2
+          timeoutSeconds: 5
           tcpSocket:
             port: redis
-        ports:
-        - containerPort: 6379
-          name: redis
         readinessProbe:
           initialDelaySeconds: 5
           exec:
@@ -79,6 +79,9 @@ spec:
                 echo "$response"
                 exit 1
               fi
+        ports:
+        - containerPort: 6379
+          name: redis
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.redisStore.resources | nindent 10 }}

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -68,8 +68,17 @@ spec:
           initialDelaySeconds: 5
           exec:
             command:
-            - redis-cli
-            - ping
+            - /bin/sh
+            - -c
+            - |
+              #!/bin/bash
+              response=$(
+                redis-cli ping
+              )
+              if [ "$response" != "PONG" ]; then
+                echo "$response"
+                exit 1
+              fi
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.redisStore.resources | nindent 10 }}

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -66,8 +66,10 @@ spec:
           name: redis
         readinessProbe:
           initialDelaySeconds: 5
-          tcpSocket:
-            port: redis
+          exec:
+            command:
+            - redis-cli
+            - ping
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.redisStore.resources | nindent 10 }}


### PR DESCRIPTION
From #inc-270

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
We should try to match the config on dot-com and keep our learnings

