### PR TITLE
Fix: helm chart publishing action

### DIFF
--- a/.github/workflows/gcs_chart_publish_release.yml
+++ b/.github/workflows/gcs_chart_publish_release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - release/**
+      - release-**
     paths:
       - .github/workflows/gcs_chart_publish_release.yml
       - 'charts/**'


### PR DESCRIPTION
Adds the new `release-` syntax to the GH action that publishes Helm charts.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan
N/A
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
