### PR TITLE
ci: add break glass releasae method

### DIFF
--- a/.github/workflows/gcs_chart_publish_release.yml
+++ b/.github/workflows/gcs_chart_publish_release.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout (break glass)
-        if: ${{ inputs.ref == '' }}
+        if: ${{ inputs.ref != '' }}
         uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/gcs_chart_publish_release.yml
+++ b/.github/workflows/gcs_chart_publish_release.yml
@@ -8,6 +8,13 @@ on:
     paths:
       - .github/workflows/gcs_chart_publish_release.yml
       - 'charts/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        description: |
+          BREAK GLASS ONLY. The branch to forcefully trigger a new release from
+        required: false
 
 env:
   HELM_VERSION: v3.4.0
@@ -21,9 +28,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        if: ${{ inputs.ref == '' }}
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Checkout (break glass)
+        if: ${{ inputs.ref == '' }}
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
 
       - name: Install Helm
         uses: azure/setup-helm@v1


### PR DESCRIPTION
INC-293

release is not being trigger. let's add a manual trigger

needs to back port

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

n/a