### PR TITLE
release: add check for gh auth status

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -13,6 +13,9 @@ requirements:
   - name: "GitHub CLI "
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
+  - name: "GH auth status"
+    cmd: "gh auth status"
+    fixInstructions: "gh auth login"
   - name: "Docker username"
     env: "DOCKER_USERNAME"
   - name: "Docker password"
@@ -21,9 +24,6 @@ internal:
   create:
     steps:
       patch:
-          - name: "gh:auth"
-            cmd: |
-              gh auth status
           - name: sg ops:sourcegraph
             cmd: |
               set -eu
@@ -110,9 +110,6 @@ internal:
                   --body "Test plan: automated release PR, CI will perform additional checks"
                 echo "🚢 Please check the associated CI build to ensure the process completed".
       minor:
-          - name: "gh:auth"
-            cmd: |
-              gh auth status
           - name: sg ops:sourcegraph
             cmd: |
               set -eu
@@ -200,9 +197,6 @@ internal:
                   --body "Test plan: automated release PR, CI will perform additional checks"
                 echo "🚢 Please check the associated CI build to ensure the process completed".
       major:
-          - name: "gh:auth"
-            cmd: |
-              gh auth status
           - name: sg ops:sourcegraph
             cmd: |
               set -eu
@@ -316,9 +310,6 @@ test:
 promoteToPublic:
   create:
     steps:
-      - name: "gh:auth"
-        cmd: |
-          gh auth status
       - name: "git"
         cmd: |
           set -eu

--- a/release.yaml
+++ b/release.yaml
@@ -21,6 +21,9 @@ internal:
   create:
     steps:
       patch:
+          - name: "gh:auth"
+            cmd: |
+              gh auth status
           - name: sg ops:sourcegraph
             cmd: |
               set -eu
@@ -107,6 +110,9 @@ internal:
                   --body "Test plan: automated release PR, CI will perform additional checks"
                 echo "🚢 Please check the associated CI build to ensure the process completed".
       minor:
+          - name: "gh:auth"
+            cmd: |
+              gh auth status
           - name: sg ops:sourcegraph
             cmd: |
               set -eu
@@ -194,6 +200,9 @@ internal:
                   --body "Test plan: automated release PR, CI will perform additional checks"
                 echo "🚢 Please check the associated CI build to ensure the process completed".
       major:
+          - name: "gh:auth"
+            cmd: |
+              gh auth status
           - name: sg ops:sourcegraph
             cmd: |
               set -eu
@@ -307,6 +316,9 @@ test:
 promoteToPublic:
   create:
     steps:
+      - name: "gh:auth"
+        cmd: |
+          gh auth status
       - name: "git"
         cmd: |
           set -eu


### PR DESCRIPTION
### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Add step to check that release captain is authenticated via `gh` during the release process.

