### PR TITLE
Fix: Redis Readiness Check with password

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -6,6 +6,10 @@ Use `**BREAKING**:` to denote a breaking change
 
 <!-- START CHANGELOG -->
 
+## Unreleased
+
+- Updated redis readiness check to fix NOAUTH on password'd redis servers #458
+
 ## 5.3.3
 
 - Updated redis liveness/readiness probes [#419](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/419)

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -67,6 +67,9 @@ spec:
             - -c
             - |
               #!/bin/bash
+              if [ -f /etc/redis/redis.conf ]; then
+                REDISCLI_AUTH=$(grep --no-filename --no-heading --no-line-number "requirepass" /etc/redis/redis.conf | \tr -s ' '| cut -d ' ' -f 3)
+              fi
               response=$(
                 redis-cli ping
               )

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - |
               #!/bin/bash
               if [ -f /etc/redis/redis.conf ]; then
-                REDISCLI_AUTH=$(grep --no-filename --no-heading --no-line-number "requirepass" /etc/redis/redis.conf | \tr -s ' '| cut -d ' ' -f 3)
+                REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
               fi
               response=$(
                 redis-cli ping

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -72,6 +72,9 @@ spec:
             - -c
             - |
               #!/bin/bash
+              if [ -f /etc/redis/redis.conf ]; then
+                REDISCLI_AUTH=$(grep --no-filename --no-heading --no-line-number "requirepass" /etc/redis/redis.conf | \tr -s ' '| cut -d ' ' -f 3)
+              fi
               response=$(
                 redis-cli ping
               )

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - |
               #!/bin/bash
               if [ -f /etc/redis/redis.conf ]; then
-                REDISCLI_AUTH=$(grep --no-filename --no-heading --no-line-number "requirepass" /etc/redis/redis.conf | \tr -s ' '| cut -d ' ' -f 3)
+                REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
               fi
               response=$(
                 redis-cli ping


### PR DESCRIPTION
Should resolve https://github.com/sourcegraph/deploy-sourcegraph-helm/issues/457

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Tested locally
