### PR TITLE
Change name of repo-updater port to reflect protocol

### DIFF
--- a/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -65,7 +65,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3182
-          name: http
+          name: grpc
         - containerPort: 6060
           name: debug
         readinessProbe:

--- a/charts/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/charts/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -17,9 +17,9 @@ metadata:
   name: repo-updater
 spec:
   ports:
-  - name: http
+  - name: grpc
     port: 3182
-    targetPort: http
+    targetPort: grpc
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: repo-updater


### PR DESCRIPTION
Repo updater doesn't speak HTTP on this port anymore (well, gRPC via HTTP/2, but you get it) so this is a small naming adjustment, that could also help with istio.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
