### PR TITLE
release: quote commit sha in release config

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -325,7 +325,7 @@ internal:
           body=$(curl -s --fail-with-body -X POST "https://releaseregistry.sourcegraph.com/v1/releases" -H "Content-Type: application/json" -H "Authorization: ${RELEASE_REGISTRY_TOKEN}" -d '{
               "name": "helm",
               "version": "{{version}}",
-              "git_sha": "${COMMIT_SHA}"
+              "git_sha": "'${COMMIT_SHA}'"
             }')
           exit_code=$?
 


### PR DESCRIPTION
### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Fixing so we don't run into the issue with non-interpolated strings.
Local test.
