### PR TITLE
release: disable promotion criteria validation

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -367,25 +367,25 @@ test:
 promoteToPublic:
   create:
     steps:
-      - name: 'validate promotion criteria'
-        cmd: |
-          echo "validating promotion criteria"
-          body=$(wget --content-on-error -O- --header="Content-Type: application/json" "https://releaseregistry.sourcegraph.com/v1/releases/helm/{{version}}")
-          exit_code=$?
+      # - name: 'validate promotion criteria'
+      #   cmd: |
+      #     echo "validating promotion criteria"
+      #     body=$(wget --content-on-error -O- --header="Content-Type: application/json" "https://releaseregistry.sourcegraph.com/v1/releases/helm/{{version}}")
+      #     exit_code=$?
 
-          if [ $exit_code != 0 ]; then
-            echo "❌ Failed to fetch release on release registry, got:"
-            echo "--- raw body ---"
-            echo $body
-            echo "--- raw body ---"
-            exit $exit_code
-          fi
+      #     if [ $exit_code != 0 ]; then
+      #       echo "❌ Failed to fetch release on release registry, got:"
+      #       echo "--- raw body ---"
+      #       echo $body
+      #       echo "--- raw body ---"
+      #       exit $exit_code
+      #     fi
 
-          is_development=$(echo "$body" | jq -r '.is_development')
-          if [ "$is_development" = "true" ]; then
-            echo "cannot promote a development release"
-            exit 1
-          fi
+      #     is_development=$(echo "$body" | jq -r '.is_development')
+      #     if [ "$is_development" = "true" ]; then
+      #       echo "cannot promote a development release"
+      #       exit 1
+      #     fi
       - name: "git"
         cmd: |
           set -eu


### PR DESCRIPTION
### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

The introduction of the is_development field makes this logic wrong as we can now have multiple versions of a product in the release registry, albeit with different is_development values.

Plan is to fix this after the current release.
