### PR TITLE
Revert "fix: redis readiness probe needs to export the password env var"

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,10 +8,6 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
-- Redis readiness probe needs to be exported
-
-## 5.4.0
-
 - Updated redis readiness check to fix NOAUTH on password'd redis servers #458
 - Removed qdrant from deployment #459
 

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - |
               #!/bin/bash
               if [ -f /etc/redis/redis.conf ]; then
-                export REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
               fi
               response=$(
                 redis-cli ping

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - |
               #!/bin/bash
               if [ -f /etc/redis/redis.conf ]; then
-                export REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
               fi
               response=$(
                 redis-cli ping


### PR DESCRIPTION
INC-305

Reverts sourcegraph/deploy-sourcegraph-helm#470

### Test plan

CI