### PR TITLE
Fix: Check for the existence of a redis password, not config file. 

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,7 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
-- Updated redis readiness check to fix NOAUTH on password'd redis servers #458
+- Updated redis readiness check to fix NOAUTH on password'd redis servers #458, #471
 - Removed qdrant from deployment #459
 
 ## 5.3.3

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -60,15 +60,17 @@ spec:
           tcpSocket:
             port: redis
         readinessProbe:
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
           exec:
             command:
             - /bin/sh
             - -c
             - |
               #!/bin/bash
-              if [ -f /etc/redis/redis.conf ]; then
-                REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+              PASS_CHECK=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+              if [ ! -z "$PASS_CHECK" ]; then
+                export REDISCLI_AUTH="$PASS_CHECK"
               fi
               response=$(
                 redis-cli ping

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -65,15 +65,17 @@ spec:
           tcpSocket:
             port: redis
         readinessProbe:
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
           exec:
             command:
             - /bin/sh
             - -c
             - |
               #!/bin/bash
-              if [ -f /etc/redis/redis.conf ]; then
-                REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+              PASS_CHECK=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+              if [ ! -z "$PASS_CHECK" ]; then
+                export REDISCLI_AUTH="$PASS_CHECK"
               fi
               response=$(
                 redis-cli ping


### PR DESCRIPTION
does

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Tested manually on kind. Tested against both having a password, and having no password set. 