### PR TITLE
sourcegraph: add "matchLabels" to frontend PDB selector - fixes #355

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -10,6 +10,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 - Updated redis readiness check to fix NOAUTH on password'd redis servers #458, #471
 - Removed qdrant from deployment #459
+- Add missing "matchLabels" to frontend PDB selector #355
 
 ## 5.3.3
 

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.PodDisruptionBudget.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.PodDisruptionBudget.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   {{- toYaml .Values.frontend.podDisruptionBudget | nindent 2 }}
   selector:
-    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
-    app: sourcegraph-frontend
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: sourcegraph-frontend
 {{- end }}


### PR DESCRIPTION
### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Description
This adds the missing "matchLabels" to the PDB selector for the frontend deployment. Fixes #355.

### Test Plan
Ran the Unit tests + helm template + helm lint