### PR TITLE
fix(ci): deploy-sourcegraph-helm doesn't have releases, just tags

### DIFF
--- a/.github/workflows/release-amis.yml
+++ b/.github/workflows/release-amis.yml
@@ -1,8 +1,9 @@
 name: build-ami
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   trigger-build:


### PR DESCRIPTION
Since we moved this action from the monorepo to here, we need to change it to match the semantics of this repo. 
The monorepo had "actual" github releases, but this repo only has tagged commits that contain the release artifact. 

This PR changes the action so that it runs on push of `v<VERSION_NUMBER>` instead of creation of a release. 

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Run manually
