### PR TITLE
fix(appliance): fix service selector

### DIFF
--- a/charts/sourcegraph-appliance/templates/deployment.yaml
+++ b/charts/sourcegraph-appliance/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "sourcegraph-appliance.fullname" . }}
+  name: {{ include "sourcegraph-appliance.name" . }}
   labels:
     {{- include "sourcegraph-appliance.labels" . | nindent 4 }}
 spec:
@@ -20,6 +20,7 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      app: sourcegraph-appliance
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/sourcegraph-appliance/templates/service.yaml
+++ b/charts/sourcegraph-appliance/templates/service.yaml
@@ -21,6 +21,5 @@ spec:
     port: 30080
     targetPort: http
   selector:
-    {{- include "sourcegraph-appliance.selectorLabels" . | nindent 4 }}
     app: sourcegraph-appliance
   type: {{ .Values.service.serviceType | default "ClusterIP" }}


### PR DESCRIPTION
It was already using simple `app: sourcegraph-appliance`, but this label wasn't on the pod template. Add it, and also remove the rest of the service selector just because we can. This simplifies the code we need to write on the appliance side.

Also simplify the deployment metadata.name, so that it can be well-known, independent of the helm release name, like the other resources here (since the release will be a singleton in namespace scope).

Relates to https://linear.app/sourcegraph/issue/REL-78/when-sourcegraph-frontend-is-down-a-user-trying-to-access-sourcegraph but does not close it.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Templated out the helm chart, observed the default renders.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
