### PR TITLE
redis: adjust failureThreshold

### DIFF
--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -55,12 +55,13 @@ spec:
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 30
-          failureThreshold: 2
+          failureThreshold: 5
           timeoutSeconds: 5
           tcpSocket:
             port: redis
         readinessProbe:
           initialDelaySeconds: 10
+          failureThreshold: 5
           timeoutSeconds: 5
           exec:
             command:


### PR DESCRIPTION
The pods get killed too quickly leading to SG repeated thrashing the redis pods with connections and then the probe can't connect which kills the pod ... leading to SG thrashing the pod again.

related: https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/18681
closes DINF-163
### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan
Deployment
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
