### PR TITLE
feat(appliance): enable ingress by default

### DIFF
--- a/charts/sourcegraph-appliance/Chart.yaml
+++ b/charts/sourcegraph-appliance/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.5.2463"
+appVersion: "5.5.3738"

--- a/charts/sourcegraph-appliance/README.md
+++ b/charts/sourcegraph-appliance/README.md
@@ -39,7 +39,7 @@ In addition to the documented values, all services also support the following va
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
-| ingress.enabled | bool | `false` |  |
+| ingress.enabled | bool | `true` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |

--- a/charts/sourcegraph-appliance/values.yaml
+++ b/charts/sourcegraph-appliance/values.yaml
@@ -54,7 +54,7 @@ service:
   port: 8080
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations:
     {}


### PR DESCRIPTION
Once this is merged, let's remove the newly no-op declarations of this default from https://www.notion.so/sourcegraph/Appliance-User-Manual-8f9f8ce28aba440a8134d295890b824a.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

`helm template`

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
