### PR TITLE
fix(appliance): chart version interpolation

### DIFF
--- a/charts/sourcegraph-appliance/README.md
+++ b/charts/sourcegraph-appliance/README.md
@@ -30,12 +30,12 @@ In addition to the documented values, all services also support the following va
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | frontend.image.image | string | `"appliance-frontend"` |  |
-| frontend.image.tag | string | `"{{ .Chart.AppVersion }}"` |  |
+| frontend.image.tag | string | `"5.5.3738"` |  |
 | fullnameOverride | string | `""` |  |
 | image.image | string | `"appliance"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"index.docker.io/sourcegraph"` |  |
-| image.tag | string | `"{{ .Chart.AppVersion }}"` |  |
+| image.tag | string | `"5.5.3738"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/charts/sourcegraph-appliance/values.yaml
+++ b/charts/sourcegraph-appliance/values.yaml
@@ -8,7 +8,7 @@ image:
   image: appliance
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "{{ .Chart.AppVersion }}"
+  tag: &version "5.5.3738"
   # Version and Tag (above) are subtley different
   # Tag is the docker container tag
   # Version is the internal version number as understood by appliance
@@ -115,7 +115,7 @@ frontend:
   image:
     image: appliance-frontend
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "{{ .Chart.AppVersion }}"
+    tag: *version
 
 selfUpdate:
   enabled: true


### PR DESCRIPTION
You can't interpolate in values.yaml, even with things set in Chart.yaml. The old code causes a literal `{{ .Chart.AppVersion }}` to appear in image tags, which is invalid.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

E2E tested the appliance, including deploying SG, using the following command to deploy:

```
helm upgrade --install --namespace test \
  --set noResourceRestrictions=true \
  appliance ./charts/sourcegraph-appliance
```

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
