### PR TITLE
Syntactic code intel worker deployment

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -335,11 +335,12 @@ In addition to the documented values, all services also support the following va
 | symbols.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | symbols.storageSize | string | `"12Gi"` | Size of the PVC for symbols pods to store cache data |
 | syntacticCodeIntel.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `syntactic-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
-| syntacticCodeIntel.env | object | `{"NUM_WORKERS":{"value":"1"}}` | Environment variables for the `syntactic-code-intel-worker` container |
+| syntacticCodeIntel.enabled | bool | `false` |  |
 | syntacticCodeIntel.image.defaultTag | string | `"5.3.2@sha256:ce2181fe845e359e5a1d603dd7d7d4f17bfd73d382a9a5e52149e19c0cc2fdfe"` | Docker image tag for the `syntactic-code-intel-worker` image |
 | syntacticCodeIntel.image.name | string | `"syntactic-code-intel-worker"` | Docker image name for the `syntactic-code-intel-worker` image |
 | syntacticCodeIntel.name | string | `"syntactic-code-intel-worker"` | Name used by resources. Does not affect service names or PVCs. |
 | syntacticCodeIntel.podSecurityContext | object | `{}` | Security context for the `syntactic-code-intel-worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| syntacticCodeIntel.properties.workerPort | int | `3188` | port to whick worker API will bind |
 | syntacticCodeIntel.replicaCount | int | `2` | Number of `syntactic-code-intel-worker` pod |
 | syntacticCodeIntel.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `syntactic-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | syntacticCodeIntel.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `syntactic-code-intel-worker` |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -334,6 +334,16 @@ In addition to the documented values, all services also support the following va
 | symbols.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `symbols` |
 | symbols.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | symbols.storageSize | string | `"12Gi"` | Size of the PVC for symbols pods to store cache data |
+| syntacticCodeIntel.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `syntactic-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| syntacticCodeIntel.env | object | `{"NUM_WORKERS":{"value":"1"}}` | Environment variables for the `syntactic-code-intel-worker` container |
+| syntacticCodeIntel.image.defaultTag | string | `"5.3.2@sha256:ce2181fe845e359e5a1d603dd7d7d4f17bfd73d382a9a5e52149e19c0cc2fdfe"` | Docker image tag for the `syntactic-code-intel-worker` image |
+| syntacticCodeIntel.image.name | string | `"syntactic-code-intel-worker"` | Docker image name for the `syntactic-code-intel-worker` image |
+| syntacticCodeIntel.name | string | `"syntactic-code-intel-worker"` | Name used by resources. Does not affect service names or PVCs. |
+| syntacticCodeIntel.podSecurityContext | object | `{}` | Security context for the `syntactic-code-intel-worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| syntacticCodeIntel.replicaCount | int | `2` | Number of `syntactic-code-intel-worker` pod |
+| syntacticCodeIntel.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `syntactic-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| syntacticCodeIntel.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `syntactic-code-intel-worker` |
+| syntacticCodeIntel.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | syntectServer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | syntectServer.image.defaultTag | string | `"5.3.2@sha256:3d16ab2a0203fea85063dcfe2e9d476540ef3274c28881dc4bbd5ca77933d8e8"` | Docker image tag for the `syntect-server` image |
 | syntectServer.image.name | string | `"syntax-highlighter"` | Docker image name for the `syntect-server` image |

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
@@ -62,8 +62,8 @@ spec:
           value: blobstore
         - name: SYNTACTIC_CODE_INTEL_UPLOAD_AWS_ENDPOINT
           value: http://blobstore:9000
-        - name: SYNTACTIC_CODE_INTEL_WORKER_PORT
-          value: "{{ .Values.syntacticCodeIntel.properties.workerPort }}"
+        - name: SYNTACTIC_CODE_INTEL_WORKER_ADDR
+          value: ":{{ .Values.syntacticCodeIntel.properties.workerPort }}"
         {{- end }}
         {{- include "sourcegraph.openTelemetryEnv" . | nindent 8 }}
         image: {{ include "sourcegraph.image" (list . "syntacticCodeIntel") }}

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: Handles syntactic code intelligence indexing
+  labels:
+    {{- include "sourcegraph.labels" . | nindent 4 }}
+    {{- if .Values.syntacticCodeIntel.labels }}
+      {{- toYaml .Values.syntacticCodeIntel.labels | nindent 4 }}
+    {{- end }}
+    deploy: sourcegraph
+    app.kubernetes.io/component: syntactic-code-intel
+  name: {{ .Values.syntacticCodeIntel.name }}
+spec:
+  minReadySeconds: 10
+  replicas: {{ .Values.syntacticCodeIntel.replicaCount }}
+  revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: syntactic-code-intel-worker
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: syntactic-code-intel-worker
+      {{- if .Values.sourcegraph.podAnnotations }}
+      {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.syntacticCodeIntel.podAnnotations }}
+      {{- toYaml .Values.syntacticCodeIntel.podAnnotations | nindent 8 }}
+      {{- end }}
+      labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
+      {{- if .Values.sourcegraph.podLabels }}
+      {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
+      {{- end }}
+      {{- if .Values.syntacticCodeIntel.podLabels }}
+      {{- toYaml .Values.syntacticCodeIntel.podLabels | nindent 8 }}
+      {{- end }}
+        deploy: sourcegraph
+        app: syntactic-code-intel-worker
+    spec:
+      containers:
+      - name: syntactic-code-intel-worker
+        env:
+        {{- range $name, $item := .Values.syntacticCodeIntel.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        {{- if .Values.blobstore.enabled }}
+        - name: SYNTACTIC_CODE_INTEL_UPLOAD_BACKEND
+          value: blobstore
+        - name: SYNTACTIC_CODE_INTEL_UPLOAD_AWS_ENDPOINT
+          value: http://blobstore:9000
+        {{- end }}
+        {{- include "sourcegraph.openTelemetryEnv" . | nindent 8 }}
+        image: {{ include "sourcegraph.image" (list . "syntacticCodeIntel") }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        {{- with .Values.syntacticCodeIntel.args }}
+        args:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: debug
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: debug
+            scheme: HTTP
+          periodSeconds: 5
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 3188
+          name: http
+        - containerPort: 6060
+          name: debug
+        {{- if not .Values.sourcegraph.localDevMode }}
+        resources:
+          {{- toYaml .Values.syntacticCodeIntel.resources | nindent 10 }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.syntacticCodeIntel.containerSecurityContext | nindent 10 }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmpdir
+        {{- if .Values.syntacticCodeIntel.extraVolumeMounts }}
+        {{- toYaml .Values.syntacticCodeIntel.extraVolumeMounts | nindent 8 }}
+        {{- end }}
+      {{- if .Values.syntacticCodeIntel.extraContainers }}
+        {{- toYaml .Values.syntacticCodeIntel.extraContainers | nindent 6 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.syntacticCodeIntel.podSecurityContext | nindent 8 }}
+      {{- include "sourcegraph.nodeSelector" (list . "syntacticCodeIntel" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "syntacticCodeIntel" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "syntacticCodeIntel" ) | trim | nindent 6 }}
+      {{- with .Values.sourcegraph.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "syntacticCodeIntel") | trim | nindent 6 }}
+      volumes:
+      - emptyDir: {}
+        name: tmpdir
+      {{- if .Values.syntacticCodeIntel.extraVolumes }}
+      {{- toYaml .Values.syntacticCodeIntel.extraVolumes | nindent 6 }}
+      {{- end }}

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
@@ -85,7 +85,7 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 5
         ports:
-        - containerPort: 3188
+        - containerPort: 3288
           name: http
         - containerPort: 6060
           name: debug

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
@@ -62,7 +62,7 @@ spec:
         - name: SYNTACTIC_CODE_INTEL_UPLOAD_AWS_ENDPOINT
           value: http://blobstore:9000
         - name: SYNTACTIC_CODE_INTEL_WORKER_PORT
-          value: {{ .Values.syntacticCodeIntel.properties.workerPort }}
+          value: "{{ .Values.syntacticCodeIntel.properties.workerPort }}"
         {{- end }}
         {{- include "sourcegraph.openTelemetryEnv" . | nindent 8 }}
         image: {{ include "sourcegraph.image" (list . "syntacticCodeIntel") }}

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
@@ -61,6 +61,8 @@ spec:
           value: blobstore
         - name: SYNTACTIC_CODE_INTEL_UPLOAD_AWS_ENDPOINT
           value: http://blobstore:9000
+        - name: SYNTACTIC_CODE_INTEL_WORKER_PORT
+          value: {{ .Values.syntacticCodeIntel.properties.workerPort }}
         {{- end }}
         {{- include "sourcegraph.openTelemetryEnv" . | nindent 8 }}
         image: {{ include "sourcegraph.image" (list . "syntacticCodeIntel") }}
@@ -85,7 +87,7 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 5
         ports:
-        - containerPort: 3288
+        - containerPort: {{ .Values.syntacticCodeIntel.properties.workerPort }}
           name: http
         - containerPort: 6060
           name: debug

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.syntacticCodeIntel.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -122,3 +123,4 @@ spec:
       {{- if .Values.syntacticCodeIntel.extraVolumes }}
       {{- toYaml .Values.syntacticCodeIntel.extraVolumes | nindent 6 }}
       {{- end }}
+{{- end }}

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
@@ -75,7 +75,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: debug
+            port: http
             scheme: HTTP
           initialDelaySeconds: 60
           timeoutSeconds: 5

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 3288
+    port: 3188
     targetPort: http
   - name: debug
     port: 6060

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "6060"
+    sourcegraph.prometheus/scrape: "true"
+    {{- if .Values.syntacticCodeIntel.serviceAnnotations }}
+    {{- toYaml .Values.syntacticCodeIntel.serviceAnnotations | nindent 4 }}
+    {{- end }}
+  labels:
+    app: syntactic-code-intel-worker
+    deploy: sourcegraph
+    app.kubernetes.io/component: syntactic-code-intel
+    {{- if .Values.syntacticCodeIntel.serviceLabels }}
+      {{- toYaml .Values.syntacticCodeIntel.serviceLabels | nindent 4 }}
+    {{- end }}
+  name: precise-code-intel-worker
+spec:
+  ports:
+  - name: http
+    port: 3288
+    targetPort: http
+  - name: debug
+    port: 6060
+    targetPort: debug
+  selector:
+    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
+    app: syntactic-code-intel-worker
+  type: {{ .Values.syntacticCodeIntel.serviceType | default "ClusterIP" }}

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.syntacticCodeIntel.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,3 +28,4 @@ spec:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: syntactic-code-intel-worker
   type: {{ .Values.syntacticCodeIntel.serviceType | default "ClusterIP" }}
+{{- end }}

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- if .Values.syntacticCodeIntel.serviceLabels }}
       {{- toYaml .Values.syntacticCodeIntel.serviceLabels | nindent 4 }}
     {{- end }}
-  name: precise-code-intel-worker
+  name: syntactic-code-intel-worker
 spec:
   ports:
   - name: http

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 3188
+    port: {{ .Values.syntacticCodeIntel.properties.workerPort }}
     targetPort: http
   - name: debug
     port: 6060

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.ServiceAccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.syntacticCodeIntel.serviceAccount.create -}}
+{{- if and .Values.syntacticCodeIntel.enabled .Values.syntacticCodeIntel.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.ServiceAccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.syntacticCodeIntel.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: syntactic-code-intel
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "syntacticCodeIntel") | trim | nindent 2 }}
+  name: {{ include "sourcegraph.serviceAccountName" (list . "syntacticCodeIntel") }}
+{{- end }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -798,10 +798,9 @@ postgresExporter:
       memory: 50Mi
 
 syntacticCodeIntel:
-  # -- Environment variables for the `syntactic-code-intel-worker` container
-  env:
-    NUM_WORKERS:
-      value: "1"
+  properties:
+    # -- port to whick worker API will bind
+    workerPort: 3188
   image:
     # -- Docker image tag for the `syntactic-code-intel-worker` image
     defaultTag: 5.3.2@sha256:ce2181fe845e359e5a1d603dd7d7d4f17bfd73d382a9a5e52149e19c0cc2fdfe

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -797,6 +797,46 @@ postgresExporter:
       cpu: 10m
       memory: 50Mi
 
+syntacticCodeIntel:
+  # -- Environment variables for the `precise-code-intel-worker` container
+  env:
+    NUM_WORKERS:
+      value: "1"
+  image:
+    # -- Docker image tag for the `precise-code-intel-worker` image
+    defaultTag: 5.3.2@sha256:6142093097f5757afe772cffd131c1be54bb77335232011254733f51ffb2d6c6
+    # -- Docker image name for the `precise-code-intel-worker` image
+    name: "syntactic-code-intel-worker"
+  # -- Security context for the `precise-code-intel-worker` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 100
+    runAsGroup: 101
+    readOnlyRootFilesystem: true
+  # -- Name used by resources. Does not affect service names or PVCs.
+  name: "syntactic-code-intel-worker"
+  # -- Security context for the `precise-code-intel-worker` pod,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  podSecurityContext: {}
+  # -- Number of `precise-code-intel-worker` pod
+  replicaCount: 2
+  # -- Resource requests & limits for the `precise-code-intel-worker` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  resources:
+    limits:
+      cpu: "2"
+      memory: 4G
+    requests:
+      cpu: 500m
+      memory: 2G
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `precise-code-intel-worker`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
+
+
 preciseCodeIntel:
   # -- Environment variables for the `precise-code-intel-worker` container
   env:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -798,16 +798,16 @@ postgresExporter:
       memory: 50Mi
 
 syntacticCodeIntel:
-  # -- Environment variables for the `precise-code-intel-worker` container
+  # -- Environment variables for the `syntactic-code-intel-worker` container
   env:
     NUM_WORKERS:
       value: "1"
   image:
-    # -- Docker image tag for the `precise-code-intel-worker` image
-    defaultTag: 5.3.2@sha256:6142093097f5757afe772cffd131c1be54bb77335232011254733f51ffb2d6c6
-    # -- Docker image name for the `precise-code-intel-worker` image
+    # -- Docker image tag for the `syntactic-code-intel-worker` image
+    defaultTag: 5.3.2@sha256:ce2181fe845e359e5a1d603dd7d7d4f17bfd73d382a9a5e52149e19c0cc2fdfe
+    # -- Docker image name for the `syntactic-code-intel-worker` image
     name: "syntactic-code-intel-worker"
-  # -- Security context for the `precise-code-intel-worker` container,
+  # -- Security context for the `syntactic-code-intel-worker` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
   containerSecurityContext:
     allowPrivilegeEscalation: false
@@ -816,12 +816,12 @@ syntacticCodeIntel:
     readOnlyRootFilesystem: true
   # -- Name used by resources. Does not affect service names or PVCs.
   name: "syntactic-code-intel-worker"
-  # -- Security context for the `precise-code-intel-worker` pod,
+  # -- Security context for the `syntactic-code-intel-worker` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}
-  # -- Number of `precise-code-intel-worker` pod
+  # -- Number of `syntactic-code-intel-worker` pod
   replicaCount: 2
-  # -- Resource requests & limits for the `precise-code-intel-worker` container,
+  # -- Resource requests & limits for the `syntactic-code-intel-worker` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
     limits:
@@ -831,7 +831,7 @@ syntacticCodeIntel:
       cpu: 500m
       memory: 2G
   serviceAccount:
-    # -- Enable creation of ServiceAccount for `precise-code-intel-worker`
+    # -- Enable creation of ServiceAccount for `syntactic-code-intel-worker`
     create: false
     # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: ""

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -798,6 +798,7 @@ postgresExporter:
       memory: 50Mi
 
 syntacticCodeIntel:
+  enabled: false
   properties:
     # -- port to whick worker API will bind
     workerPort: 3188


### PR DESCRIPTION
Fixes GRAPH-786

This adds experimental syntactic worker to our helm charts.
The configuration is similar in structure to the precise code intel worker (and was copied from it) but has a few modifications, removing unused env variables.

Resource usage is so far copied from precise worker but it's not scientific - we'll adjust the ceiling and number of workers after testing on real instances.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

- Tested manually on my local kind cluster