### PR TITLE
feat(appliance): airgap fallback

### DIFF
--- a/charts/sourcegraph-appliance/README.md
+++ b/charts/sourcegraph-appliance/README.md
@@ -29,6 +29,7 @@ In addition to the documented values, all services also support the following va
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| airgap.enabled | bool | `false` |  |
 | frontend.image.image | string | `"appliance-frontend"` |  |
 | frontend.image.tag | string | `"5.5.3738"` |  |
 | fullnameOverride | string | `""` |  |
@@ -66,5 +67,3 @@ In addition to the documented values, all services also support the following va
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `"sourcegraph-appliance"` |  |
 | tolerations | list | `[]` |  |
-| volumeMounts | list | `[]` |  |
-| volumes | list | `[]` |  |

--- a/charts/sourcegraph-appliance/templates/deployment.yaml
+++ b/charts/sourcegraph-appliance/templates/deployment.yaml
@@ -52,19 +52,29 @@ spec:
             - name: APPLIANCE_NO_RESOURCE_RESTRICTIONS
               value: "true"
             {{- end }}
+            {{- if .Values.airgap.enabled }}
+            - name: APPLIANCE_PINNED_RELEASES_FILE
+              value: /etc/releases/releases.json
+            {{- end }}
           ports:
             - name: http
               containerPort: 8888
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
+          {{- if .Values.airgap.enabled }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
+            - name: releases
+              mountPath: /etc/releases
           {{- end }}
-      {{- with .Values.volumes }}
+      {{- if .Values.airgap.enabled }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        - name: releases
+          configMap:
+            name: pinned-releases
+            items:
+              - key: releases.json
+                path: releases.json
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/sourcegraph-appliance/values.yaml
+++ b/charts/sourcegraph-appliance/values.yaml
@@ -92,19 +92,6 @@ readinessProbe:
     path: /
     port: http
 
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
-
 nodeSelector: {}
 
 tolerations: []
@@ -123,3 +110,6 @@ selfUpdate:
 # Set to true to remove all resource requests and limits from the deployed SG.
 # Only recommended for development use.
 noResourceRestrictions: false
+
+airgap:
+  enabled: false


### PR DESCRIPTION
Requires the admin to create a particular configmap first:

```
kubectl create configmap pinned-releases --from-file releases.json
```

`releases.json` must be formed like a release registry response, the same schema as what is returned by `curl
https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph`.

Relates to https://linear.app/sourcegraph/issue/REL-200/airgap-fallback-for-appliance-dependency-on-release-registry, https://linear.app/sourcegraph/issue/REL-268/airgap-fallback-for-appliance-self-update, and https://github.com/sourcegraph/sourcegraph/pull/64441.

If approved, I'll edit the appliance user manual to document this configmap creation process for airgap users.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Manual verification with and without the new flag.
