### PR TITLE
feat(appliance): update image tags and chart version on release

### DIFF
--- a/charts/sourcegraph-appliance/Chart.yaml
+++ b/charts/sourcegraph-appliance/Chart.yaml
@@ -1,24 +1,10 @@
 apiVersion: v2
 name: sourcegraph-appliance
 description: The Sourcegraph Appliance
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.5.3738
+# Chart version, separate from Sourcegraph
+version: "5.6.185"
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "5.5.3738"
+# Version of Sourcegraph release
+appVersion: "5.6.185"

--- a/charts/sourcegraph-appliance/README.md
+++ b/charts/sourcegraph-appliance/README.md
@@ -30,13 +30,11 @@ In addition to the documented values, all services also support the following va
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | airgap.enabled | bool | `false` |  |
-| frontend.image.image | string | `"appliance-frontend"` |  |
-| frontend.image.tag | string | `"5.5.3738"` |  |
+| backend.image.defaultTag | string | `"5.6.0@sha256:ace022ecd58fdbca9a51b4100afacd19ecf2afca5dbe62ccb087c66639fb130f"` |  |
+| backend.image.name | string | `"appliance"` |  |
+| frontend.image.defaultTag | string | `"5.6.0@sha256:812c91b6551bab5894fa2cd9c35ff636652d00c7272841d67310d440543cafbe"` |  |
+| frontend.image.name | string | `"appliance-frontend"` |  |
 | fullnameOverride | string | `""` |  |
-| image.image | string | `"appliance"` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"index.docker.io/sourcegraph"` |  |
-| image.tag | string | `"5.5.3738"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
@@ -66,4 +64,6 @@ In addition to the documented values, all services also support the following va
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `"sourcegraph-appliance"` |  |
+| sourcegraph.image.pullPolicy | string | `"IfNotPresent"` |  |
+| sourcegraph.image.repository | string | `"index.docker.io/sourcegraph"` |  |
 | tolerations | list | `[]` |  |

--- a/charts/sourcegraph-appliance/templates/deployment-frontend.yaml
+++ b/charts/sourcegraph-appliance/templates/deployment-frontend.yaml
@@ -26,7 +26,7 @@ spec:
         {{- end }}
         app: sourcegraph-appliance-frontend
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -37,8 +37,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}/{{ .Values.frontend.image.image }}:{{ .Values.frontend.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.sourcegraph.image.repository }}/{{ .Values.frontend.image.name }}:{{ .Values.frontend.image.defaultTag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
           env:
             - name: API_ENDPOINT
               value: http://sourcegraph-appliance-backend:8080

--- a/charts/sourcegraph-appliance/templates/deployment.yaml
+++ b/charts/sourcegraph-appliance/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- end }}
         app: sourcegraph-appliance
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -33,13 +33,13 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}/{{ .Values.image.image}}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.sourcegraph.image.repository }}/{{ .Values.backend.image.name}}:{{ .Values.backend.image.defaultTag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
           env:
             - name: SRC_LOG_LEVEL
-              value: {{ default "info" .Values.image.log_level }}
+              value: {{ default "info" .Values.sourcegraph.image.log_level }}
             - name: APPLIANCE_VERSION
-              value: "{{ .Values.image.version | default .Chart.AppVersion }}"
+              value: "{{ .Values.sourcegraph.image.version | default .Chart.AppVersion }}"
             - name: APPLIANCE_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/sourcegraph-appliance/values.yaml
+++ b/charts/sourcegraph-appliance/values.yaml
@@ -3,12 +3,11 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 
-image:
-  repository: index.docker.io/sourcegraph
-  image: appliance
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: &version "5.5.3738"
+sourcegraph:
+  image:
+    repository: index.docker.io/sourcegraph
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
   # Version and Tag (above) are subtley different
   # Tag is the docker container tag
   # Version is the internal version number as understood by appliance
@@ -16,6 +15,12 @@ image:
   # But for dev version we would need to specify it, since 0.0.0+dev is the default when built locally
   # version: 5.4.7765
   # log_level: debug
+
+
+backend:
+  image:
+    name: appliance
+    defaultTag: "5.6.0@sha256:ace022ecd58fdbca9a51b4100afacd19ecf2afca5dbe62ccb087c66639fb130f"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -100,9 +105,9 @@ affinity: {}
 
 frontend:
   image:
-    image: appliance-frontend
+    name: appliance-frontend
     # Overrides the image tag whose default is the chart appVersion.
-    tag: *version
+    defaultTag: "5.6.0@sha256:812c91b6551bab5894fa2cd9c35ff636652d00c7272841d67310d440543cafbe"
 
 selfUpdate:
   enabled: true

--- a/release.yaml
+++ b/release.yaml
@@ -79,6 +79,19 @@ internal:
               --docker-password $DOCKER_PASSWORD \
               charts/sourcegraph-migrator/
 
+        - name: sg ops:appliance
+          cmd: |
+            set -eu
+            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+
+            sg ops update-images \
+              -t {{inputs.server.tag}} \
+              -k helm \
+              --registry "${registry}" \
+              --docker-username $DOCKER_USERNAME \
+              --docker-password $DOCKER_PASSWORD \
+              charts/sourcegraph-appliance/
+
         - name: "chart:version"
           cmd: |
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph/Chart.yaml
@@ -86,6 +99,7 @@ internal:
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/dind/Chart.yaml
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/k8s/Chart.yaml
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-migrator/Chart.yaml
+            comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-appliance/Chart.yaml
           
         - name: "chart:appVersion"
           cmd: |
@@ -93,6 +107,7 @@ internal:
             comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/dind/Chart.yaml
             comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/k8s/Chart.yaml
             comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-migrator/Chart.yaml
+            comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-appliance/Chart.yaml
         
         - name: "helm:docs"
           cmd: ./scripts/helm-docs.sh
@@ -297,6 +312,7 @@ internal:
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/dind/Chart.yaml
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/k8s/Chart.yaml
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-migrator/Chart.yaml
+            comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-appliance/Chart.yaml
          
         - name: "chart:appVersion"
           cmd: |
@@ -304,6 +320,7 @@ internal:
             comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/dind/Chart.yaml
             comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/k8s/Chart.yaml
             comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-migrator/Chart.yaml
+            comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-appliance/Chart.yaml
           
         - name: "helm:docs"
           cmd: ./scripts/helm-docs.sh
@@ -452,6 +469,17 @@ promoteToPublic:
             --docker-username $DOCKER_USERNAME \
             --docker-password $DOCKER_PASSWORD \
             charts/sourcegraph-migrator/
+      - name: sg ops:appliance
+        cmd: |
+          set -eu
+          registry=index.docker.io/sourcegraph
+          sg ops update-images \
+            -t {{inputs.server.tag}} \
+            -k helm \
+            --registry "${registry}" \
+            --docker-username $DOCKER_USERNAME \
+            --docker-password $DOCKER_PASSWORD \
+            charts/sourcegraph-appliance/
       - name: "update helm docs"
         cmd: ./scripts/helm-docs.sh
       - name: "git:branch"

--- a/release.yaml
+++ b/release.yaml
@@ -177,6 +177,19 @@ internal:
               --docker-password $DOCKER_PASSWORD \
               charts/sourcegraph-migrator/
 
+        - name: sg ops:appliance
+          cmd: |
+            set -eu
+            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+
+            sg ops update-images \
+              -t {{inputs.server.tag}} \
+              -k helm \
+              --registry "${registry}" \
+              --docker-username $DOCKER_USERNAME \
+              --docker-password $DOCKER_PASSWORD \
+              charts/sourcegraph-appliance/
+
         - name: "chart:version"
           cmd: |
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph/Chart.yaml
@@ -184,6 +197,7 @@ internal:
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/dind/Chart.yaml
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/k8s/Chart.yaml
             comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-migrator/Chart.yaml
+            comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-appliance/Chart.yaml
           
         - name: "chart:appVersion"
           cmd: |
@@ -191,6 +205,7 @@ internal:
             comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/dind/Chart.yaml
             comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/k8s/Chart.yaml
             comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-migrator/Chart.yaml
+            comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-appliance/Chart.yaml
           
         - name: "helm:docs"
           cmd: ./scripts/helm-docs.sh


### PR DESCRIPTION

**appliance: value schema conforms to what sg-ops expects**

sg-ops-update-images expects a certain value schema in order to agree to operate on it. This includes tags that contain digests.


**release: update appliance artifacts**




Closes https://linear.app/sourcegraph/issue/REL-322/appliance-helm-chart-should-be-versioned

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

1. Check out https://github.com/sourcegraph/sourcegraph/pull/64512
2. Build sg: `go build -o sg ./dev/sg`
3. In this repository, run:

```
export registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
export DOCKER_USERNAME=<value from 1p>
export DOCKER_PASSWORD=<value from 1p>

/path/to/custom/sg ops update-images \
  -t 5.6.185 \
  -k helm \
  --registry "${registry}" \
  --docker-username $DOCKER_USERNAME \
  --docker-password $DOCKER_PASSWORD \
  charts/sourcegraph-appliance

git diff
# check it out
```

Digest pinning is something we have discussed removing, but at the moment it's embedded in sg-ops-update-images' logic, and doesn't work without it.

This mimics the release scripting added in the 2nd commit of this PR, which executes when we create an internal reelase. We won't know for sure this works until we do that next...

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
