### PR TITLE
fix(appliance): change nginx container port to 8080

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 target/*
+
+# MacOS system files
+.DS_Store
+
+# Jetbrains
+.idea/

--- a/charts/sourcegraph-appliance/templates/deployment-frontend.yaml
+++ b/charts/sourcegraph-appliance/templates/deployment-frontend.yaml
@@ -44,7 +44,7 @@ spec:
               value: http://sourcegraph-appliance-backend:8080
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
Change nginx container port to `8080` to avoid permission issues.

See https://linear.app/sourcegraph/issue/REL-372/nginx-port-permissions-issue

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan
Tested locally
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
