### PR TITLE
Updated RBAC for KUBERNETES_SINGLE_JOB_POD mode

### DIFF
--- a/charts/sourcegraph-executor/k8s/templates/executor.Role.yaml
+++ b/charts/sourcegraph-executor/k8s/templates/executor.Role.yaml
@@ -25,4 +25,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
 {{- end }}


### PR DESCRIPTION
`KUBERNETES_SINGLE_JOB_POD` mode was enabled by default in v5.6 with [PR 64088](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64088) which includes a new requirement to manage ephemeral k8s Secrets.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

N/A
