### PR TITLE
Set syntactic address unconditionally

### DIFF
--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
@@ -62,9 +62,9 @@ spec:
           value: blobstore
         - name: SYNTACTIC_CODE_INTEL_UPLOAD_AWS_ENDPOINT
           value: http://blobstore:9000
+        {{- end }}
         - name: SYNTACTIC_CODE_INTEL_WORKER_ADDR
           value: ":{{ .Values.syntacticCodeIntel.properties.workerPort }}"
-        {{- end }}
         {{- include "sourcegraph.openTelemetryEnv" . | nindent 8 }}
         image: {{ include "sourcegraph.image" (list . "syntacticCodeIntel") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}


### PR DESCRIPTION
This was a mistake, the _ADDR env variable should always be set, not just when blobstore is enabled.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

- N/A

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
