### PR TITLE
Ensure that otel-collector and otel-agent run as sourcegraph user

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,8 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Updated OpenTelemetry collector and agent images to run as non-root users [#543](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/543)
+
 ## 5.6.185
 
 - Sourcegraph 5.6.185 is now available

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -194,6 +194,9 @@ In addition to the documented values, all services also support the following va
 | nodeExporter.resources | object | `{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":".2","memory":"100Mi"}}` | Resource requests & limits for the `node-exporter` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | nodeExporter.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `node-exporter` |
 | nodeExporter.serviceAccount.name | string | `"node-exporter"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| openTelemetry.agent.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| openTelemetry.agent.containerSecurityContext.runAsGroup | int | `101` |  |
+| openTelemetry.agent.containerSecurityContext.runAsUser | int | `100` |  |
 | openTelemetry.agent.hostPorts | object | `{"otlpGrpc":4317,"otlpHttp":4318,"zpages":55679}` | Resource requests & limits for the `otel-agent` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | openTelemetry.agent.name | string | `"otel-agent"` | Name used by resources. Does not affect service names or PVCs. |
 | openTelemetry.agent.resources.limits.cpu | string | `"500m"` |  |
@@ -206,6 +209,9 @@ In addition to the documented values, all services also support the following va
 | openTelemetry.gateway.config.traces.exporters | object | `{}` | Define where traces should be exported to. Read how to configure different backends in the [OpenTelemetry documentation](https://opentelemetry.io/docs/collector/configuration/#exporters) |
 | openTelemetry.gateway.config.traces.exportersTlsSecretName | string | `""` | Define the name of a preexisting secret containing TLS certificates for exporters, which will be mounted under "/tls". Read more about TLS configuration of exporters in the [OpenTelemetry Collector documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md) |
 | openTelemetry.gateway.config.traces.processors | object | `{}` | Define trace processors. Read how to configure sampling in the [OpenTelemetry documentation](https://docs.sourcegraph.com/admin/observability/opentelemetry#sampling-traces) |
+| openTelemetry.gateway.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| openTelemetry.gateway.containerSecurityContext.runAsGroup | int | `101` |  |
+| openTelemetry.gateway.containerSecurityContext.runAsUser | int | `100` |  |
 | openTelemetry.gateway.name | string | `"otel-collector"` | Name used by resources. Does not affect service names or PVCs. |
 | openTelemetry.gateway.resources | object | `{"limits":{"cpu":"3","memory":"3Gi"},"requests":{"cpu":"1","memory":"1Gi"}}` | Resource requests & limits for the `otel-collector` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | openTelemetry.gateway.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `otel-collector` |

--- a/charts/sourcegraph/templates/otel-collector/otel-agent.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-agent.DaemonSet.yaml
@@ -58,6 +58,8 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.openTelemetry.agent.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.openTelemetry.agent.containerSecurityContext | nindent 10 }}
         readinessProbe:
           httpGet:
             path: /

--- a/charts/sourcegraph/templates/otel-collector/otel-collector.Deployment.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-collector.Deployment.yaml
@@ -74,6 +74,8 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.openTelemetry.gateway.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.openTelemetry.gateway.containerSecurityContext | nindent 10 }}
         readinessProbe:
           httpGet:
             path: /

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -645,6 +645,10 @@ openTelemetry:
       create: false
       # -- Name of the ServiceAccount to be created or an existing ServiceAccount
       name: ""
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      runAsUser: 100
+      runAsGroup: 101
 
   agent:
     # -- Name used by resources. Does not affect service names or PVCs.
@@ -667,6 +671,10 @@ openTelemetry:
       create: false
       # -- Name of the ServiceAccount to be created or an existing ServiceAccount
       name: ""
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      runAsUser: 100
+      runAsGroup: 101
 
 nodeExporter:
   # -- Enable `node-exporter`


### PR DESCRIPTION
Run the otel-collector and otel-agent containers as the `sourcegraph` user rather than `root`.

One of our customers is asking us to ensure that containers don't run as root.

I haven't been able to identify the original reason why these containers were running as root, so it seems that this was simply an oversight when the containers were originally created. This PR drops the `runAs` user + group IDs to `sourcegraph:sourcegraph`.

otel-collector seems to be broken currently, due to incorrect configuration with jaeger - see https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/542 + linked slack discussion for a fix.

### Reviewer notes

Testing locally requires setting `jaeger.enabled: true` in values.yaml, and applying the fix [linked above](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/542) to ensure telemetry is sent to jaeger.

I've followed the checklist below as best as I can - would appreciate some input on whether this requires any more work on my part.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
  - Linted, manually tested, and checked rendered output
  -  Running `helm unittest --helm3 ./charts/sourcegraph/.` gives error `unknown flag: --helm3` 
  - Unit tests fail even on main - are they expected to pass?
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [x] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)
  - I don't think this change requires an entry 

### Test plan

- Created helm deployment locally with jaeger + opentelemetry enabled, and ran with otel-collector & otel-agent running first as root and then sourcegraph users. No difference in tracing behaviour was observed.
- Reviewed containers and configuration for any potential issues, such as file permissions, relating to change of user. Our opentelemetry containers don't store any state, and all binary + config files are read/executable as needed by non-root users.



<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
