### PR TITLE
frontend: specify databaseAuth consistently first in env

### DIFF
--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -84,13 +84,13 @@ spec:
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         args: {{- default (list "serve") .Values.frontend.args | toYaml | nindent 8 }}
         env:
+        {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
+        {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "CODEINTEL_PG") | nindent 8 }}
+        {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "CODEINSIGHTS_PG") | nindent 8 }}
         {{- range $name, $item := .Values.frontend.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
-        {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "CODEINTEL_PG") | nindent 8 }}
-        {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "CODEINSIGHTS_PG") | nindent 8 }}
         {{- include "sourcegraph.redisConnection" .| nindent 8 }}
         {{- include "sourcegraph.openTelemetryEnv" . | nindent 8 }}
         {{- if .Values.blobstore.enabled }}


### PR DESCRIPTION
In all places we include the databaseAuth we add it first in the env list, except for the frontend pod. This updates it to be consistently first.

Context: For multitenant deployments we want to override the DB user the frontend uses to connect such that it is different to the migrator. This allows us to do that.

Test Plan: TODO Need some guidence here. I don't think this should break any existing use cases, except if someone previously tried to override db envvars and it didn't work. Now it will work.

cc @eseliger 

Part of https://linear.app/sourcegraph/issue/SRC-593/figure-out-how-to-separate-rls-user-and-migrations-user