### PR TITLE
Cody Airgapped Analytics - Configure Grafana to use default sg database user

### DIFF
--- a/charts/sourcegraph/templates/grafana/grafana.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.ConfigMap.yaml
@@ -15,6 +15,16 @@ data:
         type: Jaeger
         access: proxy
         url: http://{{ default "jaeger-query" .Values.jaeger.query.name }}:16686/-/debug/jaeger
+      - name: pgsql
+        type: postgres
+        access: proxy
+        url: $PGHOST:$PGPORT
+        user: $PGUSER
+        secureJsonData:
+          password: $PGPASSWORD
+        jsonData:
+          database: $PGDATABASE
+          sslmode: 'disable'
 kind: ConfigMap
 metadata:
   labels:

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -56,6 +56,7 @@ spec:
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}
         {{- end }}
+        {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
         ports:
         - containerPort: 3370
           name: http

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -52,7 +52,6 @@ spec:
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         env:
-        {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
         {{- range $name, $item := .Values.grafana.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -52,6 +52,7 @@ spec:
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         env:
+        {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
         {{- range $name, $item := .Values.grafana.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}


### PR DESCRIPTION
### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
