### PR TITLE
Support migrator.databaseAuthOverrideEnvVars in sourcegraph-migrator chart job

### DIFF
--- a/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
+++ b/charts/sourcegraph-migrator/templates/migrator/sourcegraph-migrator.Job.yaml
@@ -40,9 +40,11 @@ spec:
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
         args: {{- default (list "up") .Values.migrator.args | toYaml | nindent 8 }}
         env:
+        {{- if not .Values.migrator.databaseAuthOverrideEnvVars }}
         {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
         {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "CODEINTEL_PG") | nindent 8 }}
         {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "CODEINSIGHTS_PG") | nindent 8 }}
+        {{- end }}
         {{- range $name, $item := .Values.migrator.env }}
         - name: {{ $name }}
         {{- $item | toYaml | nindent 10 }}


### PR DESCRIPTION
Allowing override of migrator auth ENVs (`.Values.migrator.databaseAuthOverrideEnvVars`) in the `sourcegraph-migrator` chart's `sourcegraph-migrator` job template, consistent with the `sourcegraph` chart's `sourcegraph-frontend` Deployment `migrator` initContainer
https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/v5.8.1579/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml#L57

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

CI
