### PR TITLE
fix(sourcegraph): unable to block job when running replicas

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -355,6 +355,7 @@ In addition to the documented values, all services also support the following va
 | syntectServer.resources | object | `{"limits":{"cpu":"4","memory":"6G"},"requests":{"cpu":"250m","memory":"2G"}}` | Resource requests & limits for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | syntectServer.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `syntect-server` |
 | syntectServer.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| worker.blocklist | list | `[]` | List of jobs to block globally If replicas are configured, use this values to block jobs instead of manually setting WORKER_JOB_BLOCKLIST |
 | worker.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | worker.env | object | `{}` | Environment variables for the `worker` container |
 | worker.image.defaultTag | string | `"5.9.1590@sha256:b258021d297a7a562982a5606507d4e4ddb27ebe010f3fdbbda20ab7f0a9f4fc"` | Docker image tag for the `worker` image |

--- a/charts/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -1,7 +1,13 @@
+{{- $globalBlocklist := "" }}
+{{- if .Values.worker.blocklist }}
+{{- $globalBlocklist = join "," (.Values.worker.blocklist | uniq | sortAlpha) }}
+{{- end }}
+
 {{- if not .Values.worker.replicas }}
-  {{- include "sourcegraph.worker" (list . "" "" "" .Values.worker.resources ) | nindent 0 }}
+  {{- include "sourcegraph.worker" (list . "" "" $globalBlocklist .Values.worker.resources ) | nindent 0 }}
 {{- else }}
   {{- $dedicatedJobs := list }}
+  {{- $dedicatedJobs = $dedicatedJobs | concat .Values.worker.blocklist }}
   {{- range .Values.worker.replicas }}
     {{- $dedicatedJobs = $dedicatedJobs | concat .jobs }}
   {{- end }}

--- a/charts/sourcegraph/tests/worker_test.yaml
+++ b/charts/sourcegraph/tests/worker_test.yaml
@@ -33,6 +33,9 @@ tests:
   template: worker/worker.Deployment.yaml
   set:
     worker:
+      blocklist:
+      - rogue-job-1
+      - rogue-job-2
       replicas:
       - jobs: ["job1", "job2"]
       - jobs: ["job3", "job4"]
@@ -47,7 +50,7 @@ tests:
       path: spec.template.spec.containers[0].env
       content:
         name: WORKER_JOB_BLOCKLIST
-        value: job1,job2,job3,job4
+        value: job1,job2,job3,job4,rogue-job-1,rogue-job-2
   - isEmpty:
       path: spec.selector.matchLabels.worker-replica
 - it: should have the correct worker-0 deployment
@@ -61,6 +64,9 @@ tests:
         requests:
           cpu: 500m
           memory: 2G
+      blocklist:
+      - rogue-job-1
+      - rogue-job-2
       replicas:
       - jobs: ["job1", "job2"]
       - jobs: ["job3", "job4"]
@@ -98,6 +104,9 @@ tests:
   template: worker/worker.Deployment.yaml
   set:
     worker:
+      blocklist:
+      - rogue-job-1
+      - rogue-job-2
       replicas:
       - jobs: ["job1", "job2"]
       - jobs: ["job3", "job4"]

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1282,6 +1282,9 @@ worker:
   podSecurityContext: {}
   # -- Number of `worker` pod
   replicaCount: 1
+  # -- List of jobs to block globally
+  # If replicas are configured, use this values to block jobs instead of manually setting WORKER_JOB_BLOCKLIST
+  blocklist: []
   # -- Scale worker horizontally by configuring additional replicas dedicated to specific jobs.
   # for each replica, configure the dedicated jobs to run on this replica.
   # learn more from https://sourcegraph.com/docs/admin/workers#3-split-jobs-and-scale-independently


### PR DESCRIPTION
when having replicas, the env var `WORKER_JOB_BLOCKLIST` is now managed by the template. hence we need an override so we can merge them together.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

unit tests

tested with below overrides in a kind cluster

```
worker:
  blocklist:
    - "aggregated-users-statistics"
  replicas:
  - jobs:
    - workspaces-reconciler
    resources:
      limits:
        cpu: 200m
        memory: 256Mi
      requests:
        cpu: 200m
        memory: 256Mi
```