### PR TITLE
feat(rel): add steps to update main with latest versions

### DIFF
--- a/.github/workflows/helm_lint_test.yml
+++ b/.github/workflows/helm_lint_test.yml
@@ -18,9 +18,9 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: v3.9.1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.13'
       - uses: azure/setup-kubectl@v2.0
         id: install
       - name: Set up chart-testing

--- a/release.yaml
+++ b/release.yaml
@@ -549,6 +549,7 @@ promoteToPublic:
           branch="promote/release-{{version}}-update-main"
           echo "Checking out origin/main"
           git fetch origin main
+          git switch main
           echo "Creating branch origin/${branch}"
           git switch -c "${branch}"
 

--- a/release.yaml
+++ b/release.yaml
@@ -543,6 +543,23 @@ promoteToPublic:
           Promoted release is **publicly available** through a git tag at [\`{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/{{version}}).
           EOF
 
+      - name: 'Promote on release registry'
+        cmd: |
+          echo "Promoting deploy-sourcegraph-helm {{version}} release on release registry"
+          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/helm/{{version}}/promote")
+          exit_code=$?
+
+          if [ $exit_code != 0 ]; then
+            echo "❌ Failed to promote release on release registry, got:"
+            echo "--- raw body ---"
+            echo $body
+            echo "--- raw body ---"
+            exit $exit_code
+          else
+            echo "Build created, see:"
+            echo $body | jq .web_url
+          fi
+
       - name: "update main with latest version"
         cmd: |
           set -eu
@@ -653,19 +670,3 @@ promoteToPublic:
             --body "Test plan: automated release PR, CI will perform additional checks"
           echo "🚢 Please check the associated CI build to ensure the process completed".
 
-      - name: 'Promote on release registry'
-        cmd: |
-          echo "Promoting deploy-sourcegraph-helm {{version}} release on release registry"
-          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/helm/{{version}}/promote")
-          exit_code=$?
-
-          if [ $exit_code != 0 ]; then
-            echo "❌ Failed to promote release on release registry, got:"
-            echo "--- raw body ---"
-            echo $body
-            echo "--- raw body ---"
-            exit $exit_code
-          else
-            echo "Build created, see:"
-            echo $body | jq .web_url
-          fi

--- a/release.yaml
+++ b/release.yaml
@@ -548,7 +548,7 @@ promoteToPublic:
           set -eu
           branch="promote/release-{{version}}-update-main"
           echo "Checking out origin/main"
-          git fetch origin "${branch}"
+          git fetch origin main
           echo "Creating branch origin/${branch}"
           git switch -c "${branch}"
 

--- a/release.yaml
+++ b/release.yaml
@@ -543,6 +543,115 @@ promoteToPublic:
           Promoted release is **publicly available** through a git tag at [\`{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/{{version}}).
           EOF
 
+      - name: "update main with latest version"
+        cmd: |
+          set -eu
+          branch="promote/release-{{version}}-update-main"
+          echo "Checking out origin/main"
+          git fetch origin "${branch}"
+          echo "Creating branch origin/${branch}"
+          git switch -c "${branch}"
+
+      - name: sg ops:sourcegraph
+        cmd: |
+          set -eu
+          registry=index.docker.io/sourcegraph
+          sg ops update-images \
+            -t {{inputs.server.tag}} \
+            -k helm \
+            --registry "${registry}" \
+            --docker-username $DOCKER_USERNAME \
+            --docker-password $DOCKER_PASSWORD \
+            charts/sourcegraph/
+
+      - name: sg ops:dind
+        cmd: |
+          set -eu
+          registry=index.docker.io/sourcegraph
+          sg ops update-images \
+            -t {{inputs.server.tag}} \
+            -k helm \
+            --registry "${registry}" \
+            --docker-username $DOCKER_USERNAME \
+            --docker-password $DOCKER_PASSWORD \
+            charts/sourcegraph-executor/dind/
+
+      - name: sg ops:k8s
+        cmd: |
+          set -eu
+          registry=index.docker.io/sourcegraph
+          sg ops update-images \
+            -t {{inputs.server.tag}} \
+            -k helm \
+            --registry "${registry}" \
+            --docker-username $DOCKER_USERNAME \
+            --docker-password $DOCKER_PASSWORD \
+            charts/sourcegraph-executor/k8s/
+
+      - name: sg ops:migrator
+        cmd: |
+          set -eu
+          registry=index.docker.io/sourcegraph
+          sg ops update-images \
+            -t {{inputs.server.tag}} \
+            -k helm \
+            --registry "${registry}" \
+            --docker-username $DOCKER_USERNAME \
+            --docker-password $DOCKER_PASSWORD \
+            charts/sourcegraph-migrator/
+
+      - name: sg ops:appliance
+        cmd: |
+          set -eu
+          registry=index.docker.io/sourcegraph
+          sg ops update-images \
+            -t {{inputs.server.tag}} \
+            -k helm \
+            --registry "${registry}" \
+            --docker-username $DOCKER_USERNAME \
+            --docker-password $DOCKER_PASSWORD \
+            charts/sourcegraph-appliance/
+
+      - name: "chart:version"
+        cmd: |
+          comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph/Chart.yaml
+          comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph/examples/subchart/Chart.yaml
+          comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/dind/Chart.yaml
+          comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/k8s/Chart.yaml
+          comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-migrator/Chart.yaml
+          comby -matcher ".generic" -in-place "version: \":[~\d+\.\d+\.\d+]\"" 'version: "{{inputs.server.tag}}"' -f charts/sourcegraph-appliance/Chart.yaml
+
+      - name: "chart:appVersion"
+        cmd: |
+          comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph/Chart.yaml
+          comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/dind/Chart.yaml
+          comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-executor/k8s/Chart.yaml
+          comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-migrator/Chart.yaml
+          comby -matcher ".generic" -in-place "appVersion: \":[~\d+\.\d+\.\d+]\"" 'appVersion: "{{inputs.server.tag}}"' -f charts/sourcegraph-appliance/Chart.yaml
+
+      - name: "update helm docs"
+        cmd: ./scripts/helm-docs.sh
+
+      - name: "git:commit"
+        cmd: |
+          set -eu
+          branch="promote/release-{{version}}-update-main"
+
+          git commit -am "prep update main: {{version}}" -m 'update main with latest release'
+          git push origin "${branch}"
+
+      - name: "github:pr"
+        cmd: |
+          set -eu
+          internal_branch="promote/release-{{version}}-update-main"
+          gh pr create \
+            --fill \
+            --draft \
+            --base "$internal_branch" \
+            --title "Update main: build {{version}}" \
+            --body "Test plan: automated release PR, CI will perform additional checks"
+          echo "🚢 Please check the associated CI build to ensure the process completed".
+
       - name: 'Promote on release registry'
         cmd: |
           echo "Promoting deploy-sourcegraph-helm {{version}} release on release registry"


### PR DESCRIPTION
Add a step to our build process that creates a PR with the latest release version to merge back into `main`.

Also updates broken Github action Python dependency in CI. 

### Checklist

- [NA] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [NA] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [NA] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Part of CI steps during release process.
