### PR TITLE
fix: jaeger port on 4317

### DIFF
--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1225,7 +1225,7 @@ jaeger:
       "--memory.max-traces=20000",
       "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json",
       "--collector.otlp.enabled",
-      "--collector.otlp.grpc.host-port=:4320",
+      "--collector.otlp.grpc.host-port=:4317",
       "--collector.otlp.http.host-port=:4321",
     ]
   # -- Security context for the `jaeger` container,


### PR DESCRIPTION
As requested by @marcleblanc2 updating jaeger port to 4317 in accordance with their docs

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
