### PR TITLE
fix: add references to sslmode for postgres dbs

### DIFF
--- a/charts/sourcegraph-migrator/templates/_helpers.tpl
+++ b/charts/sourcegraph-migrator/templates/_helpers.tpl
@@ -91,4 +91,9 @@ useGlobalTagAsDefault configuration
     secretKeyRef:
       key: user
       name: {{ $secretName }}
+- name: {{ printf "%sSSLMODE" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: sslmode
+      name: {{ $secretName }}
 {{- end }}

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -56,6 +56,7 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.auth.host | string | `"codeinsights-db"` | Sets codeinsights-db host |
 | codeInsightsDB.auth.password | string | `"password"` | Sets codeinsights-db password |
 | codeInsightsDB.auth.port | string | `"5432"` | Sets codeinsights-db port |
+| codeInsightsDB.auth.sslmode | string | `"disable"` | Sets codeinsights-db SSL mode |
 | codeInsightsDB.auth.user | string | `"postgres"` | Sets codeinsights-db username |
 | codeInsightsDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":70,"runAsUser":70}` | Security context for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeInsightsDB.enabled | bool | `true` | Enable `codeinsights-db` PostgreSQL server |
@@ -77,6 +78,7 @@ In addition to the documented values, all services also support the following va
 | codeIntelDB.auth.host | string | `"codeintel-db"` | Sets codeintel-db host |
 | codeIntelDB.auth.password | string | `"password"` | Sets codeintel-db password |
 | codeIntelDB.auth.port | string | `"5432"` | Sets codeintel-db port |
+| codeIntelDB.auth.sslmode | string | `"disable"` | Sets codeintel-db SSL mode |
 | codeIntelDB.auth.user | string | `"sg"` | Sets codeintel-db username |
 | codeIntelDB.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `codeintel-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | codeIntelDB.enabled | bool | `true` | Enable `codeintel-db` PostgreSQL server |
@@ -219,6 +221,7 @@ In addition to the documented values, all services also support the following va
 | pgsql.auth.host | string | `"pgsql"` | Sets postgres host |
 | pgsql.auth.password | string | `"password"` | Sets postgres password |
 | pgsql.auth.port | string | `"5432"` | Sets postgres port |
+| pgsql.auth.sslmode | string | `"disable"` | Sets postgres SSL mode |
 | pgsql.auth.user | string | `"sg"` | Sets postgres username |
 | pgsql.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsUser":999}` | Security context for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | pgsql.enabled | bool | `true` | Enable `pgsql` PostgreSQL server |

--- a/charts/sourcegraph/examples/external-databases/README.md
+++ b/charts/sourcegraph/examples/external-databases/README.md
@@ -30,6 +30,7 @@ data:
   password: ""
   port: ""
   user: ""
+  pgsslmode: "require" # optional, enable if using SSL
 ```
 
 The Secret name should be set in your override file in the `auth.existingSecret` key for each database. See the [override.yaml] for an example.

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -211,6 +211,11 @@ app.kubernetes.io/name: jaeger
     secretKeyRef:
       key: user
       name: {{ $secretName }}
+- name: {{ printf "%sSSLMODE" $prefix }}
+  valueFrom:
+    secretKeyRef:
+      key: sslmode
+      name: {{ $secretName }}
 {{- if eq $service "grafana" }}
 - name: {{ printf "%sSSLMODE" $prefix }}
   valueFrom:

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Secret.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Secret.yaml
@@ -14,4 +14,5 @@ data:
   password: {{ .Values.codeInsightsDB.auth.password | toString | b64enc | quote }}
   port: {{ .Values.codeInsightsDB.auth.port | toString | b64enc | quote }}
   user: {{ .Values.codeInsightsDB.auth.user | toString | b64enc | quote }}
+  sslmode: {{ .Values.codeInsightsDB.auth.sslmode | toString | b64enc | quote }}
 {{- end -}}

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.Secret.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.Secret.yaml
@@ -14,4 +14,5 @@ data:
   password: {{ .Values.codeIntelDB.auth.password | toString | b64enc | quote }}
   port: {{ .Values.codeIntelDB.auth.port | toString | b64enc | quote }}
   user: {{ .Values.codeIntelDB.auth.user | toString | b64enc | quote }}
+  sslmode: {{ .Values.codeIntelDB.auth.sslmode | toString | b64enc | quote }}
 {{- end -}}

--- a/charts/sourcegraph/templates/pgsql/pgsql.Secret.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Secret.yaml
@@ -14,4 +14,5 @@ data:
   password: {{ .Values.pgsql.auth.password | toString | b64enc | quote }}
   port: {{ .Values.pgsql.auth.port | toString | b64enc | quote }}
   user: {{ .Values.pgsql.auth.user | toString | b64enc | quote }}
+  sslmode: {{ .Values.pgsql.auth.sslmode | toString | b64enc | quote }}
 {{- end -}}

--- a/charts/sourcegraph/tests/__snapshot__/checksum_test.yaml.snap
+++ b/charts/sourcegraph/tests/__snapshot__/checksum_test.yaml.snap
@@ -1,15 +1,15 @@
 should update checksum when codeinsights-db secret is modified:
   1: |
-    b60668796ecf6c0c43c250feeb4f61583494b50c518d145753612c0f3e10d2d1
+    29f56ffb20b2f033b6f54a3b8e4f049734a9330390bc4e4b162a792e073b9447
 should update checksum when codeintel-db secret is modified:
   1: |
-    393b4697f158c0151c67f84d2caf81894565f9928a68fe4cea86de62c2784c3c
+    839b4e7703dfa58ea8513e436a017af6183d7e5c3d8560a8d580bef8299242fb
 should update checksum when pgsql secret is modified:
   1: |
-    9edce55c26da40c6a2f12025db322495f2f2a50183f234d7476d486134434aa2
+    54b0ee5944d429d618699fa4e18a406fb817668d9111bb43b46eac363415e5b2
 should update checksum when redis-cache secret is modified:
   1: |
-    cffe7781e068ed7f9b5cff231361a3973a2a3378a28cf047a9a5ad77c832732c
+    97d7112d6b8b0d3e6251d9062aaba1a7205fda567b701d70eecc4540878228c0
 should update checksum when redis-store secret is modified:
   1: |
-    cffe7781e068ed7f9b5cff231361a3973a2a3378a28cf047a9a5ad77c832732c
+    97d7112d6b8b0d3e6251d9062aaba1a7205fda567b701d70eecc4540878228c0

--- a/charts/sourcegraph/tests/__snapshot__/pgsqlAuth_test.yaml.snap
+++ b/charts/sourcegraph/tests/__snapshot__/pgsqlAuth_test.yaml.snap
@@ -1,6 +1,6 @@
 should reference default secret name when existingSecret is blank:
   1: |
-    180940fdb956526d197a8efaf15bc2f14a3db83e09610917f8b9040fa5232d39
+    0fa09c505c8e425627c62e0bb13c3ecb575b6c117a2b976fd1a4e71dd41561f6
 should reference existing secret name when existingSecret is passed:
   1: |
-    e5de6930e808d2ef402f404c12b53ff96e57ac6818a72ed19ab0aa4caf588596
+    75d732cb063b4c32166d42a620df3c0b2b9fa139f28a560c9c566d36b150e6c3

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -164,6 +164,8 @@ codeInsightsDB:
     password: "password"
     # -- Sets codeinsights-db port
     port: "5432"
+    # -- Sets codeinsights-db SSL mode
+    sslmode: "disable"  # set to "require" to enable SSL
   # -- Environment variables for the `codeinsights-db` container
   env: {}
   # -- Name of existing ConfigMap for `codeinsights-db`. It must contain a `postgresql.conf` key.
@@ -237,6 +239,8 @@ codeIntelDB:
     password: "password"
     # -- Sets codeintel-db port
     port: "5432"
+    # -- Sets codeintel-db SSL mode
+    sslmode: "disable"  # set to "require" to enable SSL
   # -- Name of existing ConfigMap for `codeintel-db`. It must contain a `postgresql.conf` key
   existingConfig: ""
   # -- Additional PostgreSQL configuration. This will override or extend our default configuration.
@@ -721,8 +725,10 @@ pgsql:
     password: "password"
     # -- Sets postgres port
     port: "5432"
+    # -- Sets postgres SSL mode
+    sslmode: "disable"  # set to "require" to enable SSL
   # -- Name of existing ConfigMap for `pgsql`. It must contain a `postgresql.conf` key
-  existingConfig: "" # Name of an existing configmap
+  existingConfig: ""  # Name of an existing configmap
   # -- Additional PostgreSQL configuration. This will override or extend our default configuration.
   # Notes: This is expecting a multiline string.
   # Learn more from our [recommended PostgreSQL configuration](https://docs.sourcegraph.com/admin/config/postgres-conf) and [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html)


### PR DESCRIPTION
[REL-638](https://linear.app/sourcegraph/issue/REL-638/configure-aws-rds-databases-for-tls-connections-in-helm-chart)
raised issues that this flag did not get mentioned in the docs where a
customer wanted to use TLS. It also outlined the recommended fixes that
this commit implements.

This PR has an accompanying [docs PR](https://github.com/sourcegraph/docs/pull/900) 

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan
Manually test this out? Would require spinning up an RDS instance or something, but that's fine.
I'm in the process of doing so now.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
