### PR TITLE
Comment out runAsUser and runAsGroup in values.yaml

### DIFF
--- a/charts/sourcegraph-executor/k8s/README.md
+++ b/charts/sourcegraph-executor/k8s/README.md
@@ -77,8 +77,8 @@ In addition to the documented values, the `executor` and `private-docker-registr
 | executor.kubernetesJob.resources.limits.memory | string | `"12Gi"` | The maximum memory for a job. |
 | executor.kubernetesJob.resources.requests.cpu | string | `""` | The requested CPU for a job. |
 | executor.kubernetesJob.resources.requests.memory | string | `"1Gi"` | The requested memory for a job. |
-| executor.kubernetesJob.runAsGroup | int | `-1` | The group ID to run Kubernetes jobs as. |
-| executor.kubernetesJob.runAsUser | int | `-1` | The user ID to run Kubernetes jobs as. |
+| executor.kubernetesJob.runAsGroup | int | `nil` | The group ID to run Kubernetes jobs as. |
+| executor.kubernetesJob.runAsUser | int | `nil` | The user ID to run Kubernetes jobs as. |
 | executor.log.format | string | `"condensed"` |  |
 | executor.log.level | string | `"warn"` | Possible values are `dbug`, `info`, `warn`, `eror`, `crit`. |
 | executor.log.trace | string | `"false"` |  |

--- a/charts/sourcegraph-executor/k8s/README.md
+++ b/charts/sourcegraph-executor/k8s/README.md
@@ -77,8 +77,8 @@ In addition to the documented values, the `executor` and `private-docker-registr
 | executor.kubernetesJob.resources.limits.memory | string | `"12Gi"` | The maximum memory for a job. |
 | executor.kubernetesJob.resources.requests.cpu | string | `""` | The requested CPU for a job. |
 | executor.kubernetesJob.resources.requests.memory | string | `"1Gi"` | The requested memory for a job. |
-| executor.kubernetesJob.runAsGroup | int | `nil` | The group ID to run Kubernetes jobs as. |
-| executor.kubernetesJob.runAsUser | int | `nil` | The user ID to run Kubernetes jobs as. |
+| executor.kubernetesJob.runAsGroup | int | `nil`; accepts [0, 2147483647] | The group ID to run Kubernetes jobs as. |
+| executor.kubernetesJob.runAsUser | int | `nil`; accepts [0, 2147483647] | The user ID to run Kubernetes jobs as. |
 | executor.log.format | string | `"condensed"` |  |
 | executor.log.level | string | `"warn"` | Possible values are `dbug`, `info`, `warn`, `eror`, `crit`. |
 | executor.log.trace | string | `"false"` |  |

--- a/charts/sourcegraph-executor/k8s/values.yaml
+++ b/charts/sourcegraph-executor/k8s/values.yaml
@@ -94,12 +94,10 @@ executor:
   kubernetesJob:
     # -- The number of seconds after which a Kubernetes job will be terminated.
     deadline: "1200"
-    # -- The user ID to run Kubernetes jobs as.
-    # -- Set only if used. The `sourcegraph` UID is 100.
-    # runAsUser: 100
-    # -- The group ID to run Kubernetes jobs as.
-    # -- Set only if used. The `sourcegraph` GID is 101.
-    # runAsGroup: 101
+    # -- (int) The user ID to run Kubernetes jobs as.
+    runAsUser: 
+    # -- (int) The group ID to run Kubernetes jobs as.
+    runAsGroup: 
     # -- The group ID which is set on the job PVC file system. 
     fsGroup: "1000"
     resources:

--- a/charts/sourcegraph-executor/k8s/values.yaml
+++ b/charts/sourcegraph-executor/k8s/values.yaml
@@ -95,8 +95,10 @@ executor:
     # -- The number of seconds after which a Kubernetes job will be terminated.
     deadline: "1200"
     # -- (int) The user ID to run Kubernetes jobs as.
+    # @default -- `nil`; accepts [0, 2147483647]
     runAsUser: 
     # -- (int) The group ID to run Kubernetes jobs as.
+    # @default -- `nil`; accepts [0, 2147483647]
     runAsGroup: 
     # -- The group ID which is set on the job PVC file system. 
     fsGroup: "1000"

--- a/charts/sourcegraph-executor/k8s/values.yaml
+++ b/charts/sourcegraph-executor/k8s/values.yaml
@@ -95,9 +95,11 @@ executor:
     # -- The number of seconds after which a Kubernetes job will be terminated.
     deadline: "1200"
     # -- The user ID to run Kubernetes jobs as.
-    runAsUser: -1
+    # -- Set only if used. The `sourcegraph` UID is 100.
+    # runAsUser: 100
     # -- The group ID to run Kubernetes jobs as.
-    runAsGroup: -1
+    # -- Set only if used. The `sourcegraph` GID is 101.
+    # runAsGroup: 101
     # -- The group ID which is set on the job PVC file system. 
     fsGroup: "1000"
     resources:


### PR DESCRIPTION
Since [PR 2456](https://github.com/sourcegraph/sourcegraph/pull/2456) in the Sourcegraph repo, support for the default value of -1 for  the `KUBERNETES_RUN_AS_USER` and `KUBERNETES_RUN_AS_GROUP` Executor environment variables has been removed - those environment variables now require either blank values or non-negative integers in the range [0, 2147483647], to match the range for Unix UIDs and GIDs.

This PR updates `charts/sourcegraph-executor/k8s/values.yaml` so that `runAsUser` and `runAsGroup` are commented out, with comments to explain that the user can uncomment them to use them. Having those settings commented out causes `KUBERNETES_RUN_AS_USER` and `KUBERNETES_RUN_AS_GROUP` in `charts/sourcegraph-executor/k8s/templates/executor.ConfigMap.yaml` to be blank, which is the new default value.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

A Helm deployment is successful and does not fail with errors like `KUBERNETES_RUN_AS_USER must be a UID in the range 0 to 2,147,483,647, but got "-1".`
