### PR TITLE
Update unit tests to be current with most recent helm unittest syntax

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -12,12 +12,12 @@ helm lint charts/sourcegraph/.
 
 ## Unit testing
 
-We utilize [helm-unittest](https://github.com/quintush/helm-unittest/), a BDD styled unit test framework, to validate our helm chart.
+We utilize [helm-unittest](https://github.com/helm-unittest/helm-unittest/), a BDD styled unit test framework, to validate our helm chart.
 
 helm-unittest can be installed with:
 
 ```bash
-helm plugin install https://github.com/quintush/helm-unittest
+helm plugin install https://github.com/helm-unittest/helm-unittest
 ```
 
 Once the plugin is installed, you can run the unit tests using the following:
@@ -28,7 +28,7 @@ helm unittest --helm3 ./charts/sourcegraph/.
 
 We currently do not have testing best practices or require unit tests for new changes, so add test cases at your best judgement if possible.
 
-You may check out our [existing test cases](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/tests) and helm-unittest [docs](https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md).
+You may check out our [existing test cases](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/tests) and helm-unittest [docs](https://github.com/helm-unittest/helm-unittest/blob/master/DOCUMENT.md).
 
 ## Manual testing
 

--- a/charts/sourcegraph/tests/checksum_test.yaml
+++ b/charts/sourcegraph/tests/checksum_test.yaml
@@ -10,7 +10,7 @@ tests:
         existingSecret: "my-secret"
   asserts:
     - matchSnapshot:
-          path: spec.template.metadata.annotations.[checksum/auth]
+          path: spec.template.metadata.annotations["checksum/auth"]
 - it: should update checksum when codeintel-db secret is modified
   set:
     codeIntelDB:
@@ -18,7 +18,7 @@ tests:
         newkey: "blank"
   asserts:
     - matchSnapshot:
-          path: spec.template.metadata.annotations.[checksum/auth]
+          path: spec.template.metadata.annotations["checksum/auth"]
 - it: should update checksum when codeinsights-db secret is modified
   set:
     codeInsightsDB:
@@ -27,7 +27,7 @@ tests:
         database: "anotherdb"
   asserts:
     - matchSnapshot:
-          path: spec.template.metadata.annotations.[checksum/auth]
+          path: spec.template.metadata.annotations["checksum/auth"]
 - it: should update checksum when redis-store secret is modified
   set:
     redisStore:
@@ -35,7 +35,7 @@ tests:
         endpoint: "external-redis:6379"
   asserts:
     - matchSnapshot:
-          path: spec.template.metadata.annotations.[checksum/auth]
+          path: spec.template.metadata.annotations["checksum/auth"]
 - it: should update checksum when redis-cache secret is modified
   set:
     redisCache:
@@ -43,4 +43,4 @@ tests:
         endpoint: "external-redis:6379"
   asserts:
     - matchSnapshot:
-          path: spec.template.metadata.annotations.[checksum/auth]
+          path: spec.template.metadata.annotations["checksum/auth"]

--- a/charts/sourcegraph/tests/codeInsightsDBAdditionalConfig_test.yaml
+++ b/charts/sourcegraph/tests/codeInsightsDBAdditionalConfig_test.yaml
@@ -15,7 +15,7 @@ tests:
         max_connections = 3000000000000000000
   asserts:
   - matchRegex:
-      path: data.postgresql\.conf
+      path: data["postgresql.conf"]
       pattern: max_connections = 3000000000000000000
 - it: should fail to render when both codeInsightsDB.additionalConfig and codeInsightsDB.existingConfig are defined
   set:

--- a/charts/sourcegraph/tests/codeIntelDBAdditionalConfig_test.yaml
+++ b/charts/sourcegraph/tests/codeIntelDBAdditionalConfig_test.yaml
@@ -15,7 +15,7 @@ tests:
         max_connections = 3000000000000000000
   asserts:
   - matchRegex:
-      path: data.postgresql\.conf
+      path: data["postgresql.conf"]
       pattern: max_connections = 2000000000000000000
 - it: should fail to render when both codeIntelDB.additionalConfig and codeIntelDB.existingConfig are defined
   set:

--- a/charts/sourcegraph/tests/defaultTagPrefix_test.yaml
+++ b/charts/sourcegraph/tests/defaultTagPrefix_test.yaml
@@ -9,10 +9,10 @@ tests:
     frontend:
       image:
         defaultTag: test
-  matchRegexRaw:
-    path: "spec.template.spec.containers[0].image"
-    pattern: |
-      "[\w-]+\.\w+\.\w+\/.+\/.+:test"
+  asserts:
+    - matchRegex:
+        path: "spec.template.spec.containers[0].image"
+        pattern: ^[\w-]+\.\w+\.\w+\/.+\/.+:test$
 - it: should add defaultTagPrefix
   template: frontend/sourcegraph-frontend.Deployment.yaml
   set:
@@ -20,7 +20,7 @@ tests:
       image:
         defaultTag: test
         defaultTagPrefix: "prefix-"
-  matchRegexRaw:
-    path: "spec.template.spec.containers[0].image"
-    pattern: |
-      "[\w-]+\.\w+\.\w+\/.+\/.+:prefix-test"
+  asserts:
+    - matchRegex:
+        path: "spec.template.spec.containers[0].image"
+        pattern: ^[\w-]+\.\w+\.\w+\/.+\/.+:prefix-test$

--- a/charts/sourcegraph/tests/localDevMode_test.yaml
+++ b/charts/sourcegraph/tests/localDevMode_test.yaml
@@ -6,12 +6,12 @@ tests:
     set:
       sourcegraph.localDevMode: true
     asserts:
-      - isEmpty:
-          path: spec.template.spec.containers[0].resources
+      - notExists:
+          path: "spec.template.spec.containers[0].resources"
 
   - it: should have a resource block when localDevMode=false
     set:
       sourcegraph.localDevMode: false
     asserts:
-      - isNotEmpty:
-          path: spec.template.spec.containers[0].resources
+      - exists:
+          path: "spec.template.spec.containers[0].resources"

--- a/charts/sourcegraph/tests/nodeExporter_test.yaml
+++ b/charts/sourcegraph/tests/nodeExporter_test.yaml
@@ -102,7 +102,7 @@ tests:
           create: false
           name: "test-service-account-name"
     asserts:
-      - isEmpty:
+      - notExists:
           path: spec.template.spec.serviceAccountName
         template: node-exporter/node-exporter.DaemonSet.yaml
   

--- a/charts/sourcegraph/tests/otelCollectorJaeger_test.yaml
+++ b/charts/sourcegraph/tests/otelCollectorJaeger_test.yaml
@@ -65,7 +65,7 @@ tests:
           count: 1 # ConfigMap is rendered
         template: otel-collector/otel-collector.ConfigMap.yaml
       - matchRegex:
-          path: data.[config.yaml]
+          path: data["config.yaml"]
           pattern: "endpoint: otlp.service.com:443" # check if element of config is substituted correctly
         template: otel-collector/otel-collector.ConfigMap.yaml
   - it: should fail if a configuration is provided and jaeger is enabled

--- a/charts/sourcegraph/tests/pgsqlAdditionalConfig_test.yaml
+++ b/charts/sourcegraph/tests/pgsqlAdditionalConfig_test.yaml
@@ -16,7 +16,7 @@ tests:
         max_connections = 3000000000000000000
   asserts:
   - matchRegex:
-      path: data.postgresql\.conf
+      path: data["postgresql.conf"]
       pattern: max_connections = 1000000000000000000
 - it: should fail to render when both pgsql.additionalConfig and pgsql.existingConfig are defined
   set:

--- a/charts/sourcegraph/tests/pgsqlAuth_test.yaml
+++ b/charts/sourcegraph/tests/pgsqlAuth_test.yaml
@@ -18,7 +18,7 @@ tests:
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
           value: "my-secret"
       - matchSnapshot:
-            path: spec.template.metadata.annotations.[checksum/pgsql.secret]
+            path: spec.template.metadata.annotations["checksum/pgsql.secret"]
 - it: should not generate a secret when existingSecret is passed
   template: pgsql/pgsql.Secret.yaml
   set:
@@ -62,4 +62,4 @@ tests:
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
           value: "pgsql-auth"
       - matchSnapshot:
-            path: spec.template.metadata.annotations.[checksum/pgsql.secret]
+            path: spec.template.metadata.annotations["checksum/pgsql.secret"]

--- a/charts/sourcegraph/tests/storageClass_test.yaml
+++ b/charts/sourcegraph/tests/storageClass_test.yaml
@@ -18,8 +18,8 @@ tests:
       create: true
       type: null
   asserts:
-  - isNull:
-      path: parameters
+  - notExists:
+      path: parameters.type
 - it: should have 'allowedTopologies` when storageClass.allowedTopologies is set
   set:
     storageClass:

--- a/charts/sourcegraph/tests/worker_test.yaml
+++ b/charts/sourcegraph/tests/worker_test.yaml
@@ -51,7 +51,7 @@ tests:
       content:
         name: WORKER_JOB_BLOCKLIST
         value: job1,job2,job3,job4,rogue-job-1,rogue-job-2
-  - isEmpty:
+  - notExists:
       path: spec.selector.matchLabels.worker-replica
 - it: should have the correct worker-0 deployment
   template: worker/worker.Deployment.yaml

--- a/scripts/ci/helm-unittest.sh
+++ b/scripts/ci/helm-unittest.sh
@@ -6,4 +6,4 @@ set -euf -o pipefail
 helm plugin install https://github.com/helm-unittest/helm-unittest
 
 ### Run the helm tests
-helm unittest -3q charts/sourcegraph
+helm unittest -q charts/sourcegraph

--- a/scripts/ci/helm-unittest.sh
+++ b/scripts/ci/helm-unittest.sh
@@ -3,7 +3,7 @@
 set -euf -o pipefail
 
 ### Install the helm-unittest plugin
-helm plugin install https://github.com/quintush/helm-unittest --version v0.2.11
+helm plugin install https://github.com/helm-unittest/helm-unittest
 
 ### Run the helm tests
 helm unittest -3q charts/sourcegraph


### PR DESCRIPTION
- Switch to the canonical helm unittest isntead of an outdated fork.
- Update the tests to work with latest syntax.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)

### Test plan

1. uninstall the outdated helm unittest fork: `helm plugin uninstall unittest`
2. install the canonical tool: `helm plugin install https://github.com/helm-unittest/helm-unittest`
3. run the unit tests: `helm unittest ./charts/sourcegraph/.`