### PR TITLE
fix(sourcegraph): do not render SSLMODE twice for grafana sts

### DIFF
--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -216,13 +216,6 @@ app.kubernetes.io/name: jaeger
     secretKeyRef:
       key: sslmode
       name: {{ $secretName }}
-{{- if eq $service "grafana" }}
-- name: {{ printf "%sSSLMODE" $prefix }}
-  valueFrom:
-    secretKeyRef:
-      key: sslmode
-      name: {{ $secretName }}
-{{- end }}
 {{- end }}
 
 {{- define "sourcegraph.dataSource" -}}


### PR DESCRIPTION
regression from https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/617

it's now rendering `_SSLMODE` twice in the grafana sts

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

CI