### PR TITLE
feat: add runAsUser and runAsGroup to executor

### DIFF
--- a/charts/sourcegraph-executor/k8s/README.md
+++ b/charts/sourcegraph-executor/k8s/README.md
@@ -89,6 +89,7 @@ In addition to the documented values, the `executor` and `private-docker-registr
 | executor.queueName | string | `""` | The name of the queue to pull jobs from to. Possible values: batches and codeintel. **Either this or queueNames is required.** |
 | executor.queueNames | list | `[]` | The names of multiple queues to pull jobs from to. Possible values: batches and codeintel. **Either this or queueName is required.** |
 | executor.replicas | int | `1` |  |
+| executor.securityContext | object | `{"fsGroup":null,"privileged":false,"runAsGroup":null,"runAsUser":null}` | The containerSecurityContext for the executor image |
 | executor.storageSize | string | `"10Gi"` | The storage size of the PVC attached to the executor deployment. |
 | executor.tolerations | list | `[]` | Tolerations, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | sourcegraph.affinity | object | `{}` | Affinity, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |

--- a/charts/sourcegraph-executor/k8s/templates/executor.Deployment.yaml
+++ b/charts/sourcegraph-executor/k8s/templates/executor.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
         {{- include "executor.labels" . | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: {{ .Values.executor.kubernetesJob.fsGroup }}
+        fsGroup: {{ .Values.executor.securityContext.fsGroup }}
         runAsUser: {{ .Values.executor.securityContext.runAsUser }}
         runAsGroup: {{ .Values.executor.securityContext.runAsGroup }}
       serviceAccountName: sg-executor
@@ -52,6 +52,8 @@ spec:
         - name: executor
           image: {{ include "sourcegraph.image" (list . "executor") }}
           imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+          securityContext:
+            privileged: {{ .Values.executor.securityContext.privileged }}
           ports:
             - containerPort: 6060
               name: debug

--- a/charts/sourcegraph-executor/k8s/templates/executor.Deployment.yaml
+++ b/charts/sourcegraph-executor/k8s/templates/executor.Deployment.yaml
@@ -45,6 +45,8 @@ spec:
     spec:
       securityContext:
         fsGroup: {{ .Values.executor.kubernetesJob.fsGroup }}
+        runAsUser: {{ .Values.executor.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.executor.securityContext.runAsGroup }}
       serviceAccountName: sg-executor
       containers:
         - name: executor

--- a/charts/sourcegraph-executor/k8s/values.yaml
+++ b/charts/sourcegraph-executor/k8s/values.yaml
@@ -90,6 +90,12 @@ executor:
   namespace: "default"
   # -- The path to the kubeconfig file. If not specified, the in-cluster config is used.
   kubeconfigPath: ""
+  # -- The containerSecurityContext for the executor image
+  containerSecurityContext:
+    # @default -- `100`; accepts [0, 2147483647]
+    runAsUser: 100
+    # @default -- `101`; accepts [0, 2147483647]
+    runAsGroup: 101
   
   kubernetesJob:
     # -- The number of seconds after which a Kubernetes job will be terminated.

--- a/charts/sourcegraph-executor/k8s/values.yaml
+++ b/charts/sourcegraph-executor/k8s/values.yaml
@@ -91,11 +91,15 @@ executor:
   # -- The path to the kubeconfig file. If not specified, the in-cluster config is used.
   kubeconfigPath: ""
   # -- The containerSecurityContext for the executor image
-  containerSecurityContext:
-    # @default -- `100`; accepts [0, 2147483647]
-    runAsUser: 100
-    # @default -- `101`; accepts [0, 2147483647]
-    runAsGroup: 101
+  securityContext:
+    # @default -- nil; accepts [0, 2147483647]
+    runAsUser: 
+    # @default -- nil; accepts [0, 2147483647]
+    runAsGroup: 
+    # @default -- nil; accepts [0, 2147483647]
+    fsGroup:
+    # @default -- false; accepts [true, false]
+    privileged: false
   
   kubernetesJob:
     # -- The number of seconds after which a Kubernetes job will be terminated.


### PR DESCRIPTION
The start of a resolution for [REL-690](https://linear.app/sourcegraph/issue/REL-690/add-runasuser-runasgroup-fsgroup-to-executor-helm-chart). 
Need to test this out to see how it works. There are sample overrides in [this thread](https://sourcegraph.slack.com/archives/C0418GDBT7S/p1738581012896529?thread_ts=1738580801.517539&cid=C0418GDBT7S)

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan
Run the example overrides from the thread and see if the executor runs and doesn't fail. In particular we want a _named_ user that is not privileged.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
