### PR TITLE
add gitserver startup probe

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -9,6 +9,7 @@ Use `**BREAKING**:` to denote a breaking change
 ## Unreleased
 
 - Fix Pod Disruption Budget for sourcegraph-frontend
+- Added a startup probe to the gitserver statefulset to give it time to run the on-disk migration from repo names to repo IDs
 
 ## 5.10.0
 

--- a/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -56,6 +56,14 @@ spec:
         {{- end }}
         {{- include "sourcegraph.openTelemetryEnv" . | nindent 8 }}
         terminationMessagePolicy: FallbackToLogsOnError
+        # Temporary: when migrating from repo names to repo IDs on disk,
+        # gitserver can take a little while to start up. To avoid killing the
+        # pod because of a failed liveness probe, we give it 2 minutes to start up.
+        startupProbe:
+          tcpSocket:
+            port: rpc
+          failureThreshold: 120
+          periodSeconds: 1
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:


### PR DESCRIPTION
This adds a startup probe to gitserver so that it's not immediately killed while it's starting up and migrating the on-disk format for repos.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [x] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Passed linters, ran it locally, plan to exercise it when we deploy to s2 and dotcom.