### PR TITLE
Update gp2 to gp3 in AWS storage class example

### DIFF
--- a/charts/sourcegraph/examples/aws/override.yaml
+++ b/charts/sourcegraph/examples/aws/override.yaml
@@ -10,7 +10,7 @@ frontend:
 
 storageClass:
   create: true
-  type: gp2 # This configures SSDs (recommended).
+  type: gp3 # This configures SSDs (recommended).
   provisioner: ebs.csi.aws.com
   volumeBindingMode: WaitForFirstConsumer
   reclaimPolicy: Retain


### PR DESCRIPTION
It's been some time since gp3 has been available, with better performance and pricing than gp2. We should update our example to reduce the chances of a customer deploying with gp2. 

https://docs.aws.amazon.com/eks/latest/userguide/create-storage-class.html

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Tested in test instance

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
