### PR TITLE
Revert "Remove symbols statefulset"

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -11,7 +11,6 @@ Use `**BREAKING**:` to denote a breaking change
 - Fix Pod Disruption Budget for sourcegraph-frontend
 - Added a startup probe to the gitserver statefulset to give it time to run the on-disk migration from repo names to repo IDs
 - The repo-updater service is no longer needed and has been removed from the chart.
-- The symbols service is no longer needed and has been removed from the chart. Consider merging env vars and resource overrides given to symbols into searcher before upgrading.
 
 ## 5.10.0
 

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -298,7 +298,7 @@ In addition to the documented values, all services also support the following va
 | searcher.resources | object | `{"limits":{"cpu":"2","memory":"2G"},"requests":{"cpu":"500m","memory":"500M"}}` | Resource requests & limits for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | searcher.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `searcher` |
 | searcher.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
-| searcher.storageSize | string | `"52Gi"` | Size of the PVC for searcher pods to store cache data |
+| searcher.storageSize | string | `"26Gi"` | Size of the PVC for searcher pods to store cache data |
 | sourcegraph.affinity | object | `{}` | Global Affinity, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | sourcegraph.image.defaultTag | string | `"{{ .Chart.AppVersion }}"` | Global docker image tag |
 | sourcegraph.image.pullPolicy | string | `"IfNotPresent"` | Global docker image pull policy |
@@ -320,6 +320,16 @@ In addition to the documented values, all services also support the following va
 | storageClass.parameters | object | `{}` | Extra parameters of storageClass, consult your cloud provider persistent storage documentation |
 | storageClass.provisioner | string | `"kubernetes.io/gce-pd"` | Name of the storageClass provisioner, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#provisioner) and consult your cloud provider persistent storage documentation |
 | storageClass.type | string | `"pd-ssd"` | Value of `type` key in storageClass `parameters`, consult your cloud provider persistent storage documentation |
+| symbols.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `symbols` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| symbols.image.defaultTag | string | `"6.0.0@sha256:7f91048d1966add54b199755c77a5c3ca84b7f57bb5d2ffb65113da7f100b051"` | Docker image tag for the `symbols` image |
+| symbols.image.name | string | `"symbols"` | Docker image name for the `symbols` image |
+| symbols.name | string | `"symbols"` | Name used by resources. Does not affect service names or PVCs. |
+| symbols.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":100}` | Security context for the `symbols` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| symbols.replicaCount | int | `1` | Number of `symbols` pod |
+| symbols.resources | object | `{"limits":{"cpu":"2","memory":"2G"},"requests":{"cpu":"500m","memory":"500M"}}` | Resource requests & limits for the `symbols` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| symbols.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `symbols` |
+| symbols.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| symbols.storageSize | string | `"12Gi"` | Size of the PVC for symbols pods to store cache data |
 | syntacticCodeIntel.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `syntactic-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | syntacticCodeIntel.enabled | bool | `false` |  |
 | syntacticCodeIntel.image.defaultTag | string | `"6.0.0@sha256:50bdeb38b196f0fc21404969016bf8263f78144292e905867e93480f66c8251c"` | Docker image tag for the `syntactic-code-intel-worker` image |

--- a/charts/sourcegraph/examples/advanced-scheduling/override.yaml
+++ b/charts/sourcegraph/examples/advanced-scheduling/override.yaml
@@ -93,6 +93,19 @@ searcher:
                 app: searcher
           weight: 100
 
+symbols:
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                <<: *commonSelectorLabels
+                app: symbols
+          weight: 100
+
 worker:
   replicaCount: 3
   affinity:

--- a/charts/sourcegraph/examples/basic/override.yaml
+++ b/charts/sourcegraph/examples/basic/override.yaml
@@ -64,3 +64,14 @@ searcher:
     requests:
       cpu: 500m
       memory: 1G
+
+symbols:
+  resources:
+    limits:
+      cpu: "4"
+      memory: 4G
+      ephemeral-storage: "10G"
+    requests:
+      cpu: "1"
+      memory: 1G
+      ephemeral-storage: "10G"

--- a/charts/sourcegraph/examples/common-modifications/override.yaml
+++ b/charts/sourcegraph/examples/common-modifications/override.yaml
@@ -183,6 +183,19 @@ searcher:
       ephemeral-storage: 25G
       memory: 500M
 
+
+symbols:
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "2"
+      ephemeral-storage: 12G
+      memory: 2G
+    requests:
+      cpu: 500m
+      ephemeral-storage: 10G
+      memory: 500M
+
 syntectServer:
   replicaCount: 1
   resources:

--- a/charts/sourcegraph/examples/gcp/override.yaml
+++ b/charts/sourcegraph/examples/gcp/override.yaml
@@ -74,6 +74,11 @@ searcher:
     SRC_LOG_FORMAT: 
       value: json_gcp
 
+symbols:
+  env:
+    SRC_LOG_FORMAT: 
+      value: json_gcp
+
 syntectServer:
   env:
     SRC_LOG_FORMAT: 

--- a/charts/sourcegraph/templates/searcher/searcher.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.StatefulSet.yaml
@@ -56,20 +56,11 @@ spec:
           {{- $item | toYaml | nindent 10 }}
         {{- end }}
         - name: SEARCHER_CACHE_SIZE_MB
-          # Set the cache size to ~45% of the PVC size
+          # Set the cache size to ~90% of the PVC size
           {{- if .Values.searcher.storageSize }}
-          value: {{ trimSuffix "Gi" .Values.searcher.storageSize | mul 450 | quote }}
+          value: {{ trimSuffix "Gi" .Values.searcher.storageSize | mul 900 | quote }}
           {{- else }}
-          # This value is ~45% of the default value for
-          # storageSize in the VolumeClaimTemplate below
-          value: "23400"  
-          {{- end }}
-        - name: SYMBOLS_CACHE_SIZE_MB
-          # Set the cache size to ~45% of the PVC size
-          {{- if .Values.searcher.storageSize }}
-          value: {{ trimSuffix "Gi" .Values.searcher.storageSize | mul 450 | quote }}
-          {{- else }}
-          # This value is ~45% of the default value for
+          # This value is ~90% of the default value for
           # storageSize in the VolumeClaimTemplate below
           value: "23400"  
           {{- end }}

--- a/charts/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "6060"
+    sourcegraph.prometheus/scrape: "true"
+    {{- if .Values.symbols.serviceAnnotations }}
+    {{- toYaml .Values.symbols.serviceAnnotations | nindent 4 }}
+    {{- end }}
+  labels:
+    app: symbols
+    deploy: sourcegraph
+    app.kubernetes.io/component: symbols
+    {{- if .Values.symbols.serviceLabels }}
+      {{- toYaml .Values.symbols.serviceLabels | nindent 4 }}
+    {{- end }}
+  name: symbols
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 3184
+    targetPort: http
+  - name: debug
+    port: 6060
+    targetPort: debug
+  selector:
+    {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
+    app: symbols

--- a/charts/sourcegraph/templates/symbols/symbols.ServiceAccount.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.ServiceAccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.symbols.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    category: rbac
+    deploy: sourcegraph
+    app.kubernetes.io/component: symbols
+  {{- include "sourcegraph.serviceAccountAnnotations" (list . "symbols") | trim | nindent 2 }}
+  name: {{ include "sourcegraph.serviceAccountName" (list . "symbols") }}
+{{- end }}

--- a/charts/sourcegraph/templates/symbols/symbols.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/symbols/symbols.StatefulSet.yaml
@@ -1,0 +1,145 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    description: Backend for symbols operations.
+  labels:
+    {{- include "sourcegraph.labels" . | nindent 4 }}
+    {{- if .Values.symbols.labels }}
+      {{- toYaml .Values.symbols.labels | nindent 4 }}
+    {{- end }}
+    deploy: sourcegraph
+    app.kubernetes.io/component: symbols
+  name: {{ .Values.symbols.name }}
+spec:
+  replicas: {{ .Values.symbols.replicaCount }}
+  revisionHistoryLimit: {{ .Values.sourcegraph.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: symbols
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: symbols
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: symbols
+      {{- include "sourcegraph.redisChecksum" . | nindent 8 }}
+      {{- if .Values.sourcegraph.podAnnotations }}
+      {{- toYaml .Values.sourcegraph.podAnnotations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.symbols.podAnnotations }}
+      {{- toYaml .Values.symbols.podAnnotations | nindent 8 }}
+      {{- end }}
+      labels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 8 }}
+      {{- if .Values.sourcegraph.podLabels }}
+      {{- toYaml .Values.sourcegraph.podLabels | nindent 8 }}
+      {{- end }}
+      {{- if .Values.symbols.podLabels }}
+      {{- toYaml .Values.symbols.podLabels | nindent 8 }}
+      {{- end }}
+        deploy: sourcegraph
+        app: symbols
+    spec:
+      containers:
+      - name: symbols
+        env:
+        {{- include "sourcegraph.redisConnection" .| nindent 8 }}
+        {{- range $name, $item := .Values.symbols.env}}
+        - name: {{ $name }}
+          {{- $item | toYaml | nindent 10 }}
+        {{- end }}
+        - name: SYMBOLS_CACHE_SIZE_MB
+          # Set the cache size to ~90% of the PVC size
+          {{- if .Values.symbols.storageSize }}
+          value: {{ trimSuffix "Gi" .Values.symbols.storageSize | mul 900 | quote }}
+          {{- else }}
+          # This value is ~90% of the default value for
+          # storageSize in the VolumeClaimTemplate below
+          value: "10800"
+          {{- end }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SYMBOLS_CACHE_DIR
+          value: /mnt/cache/$(POD_NAME)
+        - name: TMPDIR
+          value: /mnt/tmp
+        {{- include "sourcegraph.openTelemetryEnv" . | nindent 8 }}
+        image: {{ include "sourcegraph.image" (list . "symbols" ) }}
+        imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        {{- with .Values.symbols.args }}
+        args:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+            scheme: HTTP
+          periodSeconds: 5
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 3184
+          name: http
+        - containerPort: 6060
+          name: debug
+        volumeMounts:
+        - mountPath: /mnt/cache
+          name: cache
+        - mountPath: /mnt/tmp
+          name: tmp
+        {{- if .Values.symbols.extraVolumeMounts }}
+        {{- toYaml .Values.symbols.extraVolumeMounts | nindent 8 }}
+        {{- end }}
+        {{- if not .Values.sourcegraph.localDevMode }}
+        resources:
+          {{- toYaml .Values.symbols.resources | nindent 10 }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.symbols.containerSecurityContext | nindent 10 }}
+      {{- if .Values.symbols.extraContainers }}
+        {{- toYaml .Values.symbols.extraContainers | nindent 6 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.symbols.podSecurityContext | nindent 8 }}
+      {{- include "sourcegraph.nodeSelector" (list . "symbols" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.affinity" (list . "symbols" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.tolerations" (list . "symbols" ) | trim | nindent 6 }}
+      {{- with .Values.sourcegraph.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "symbols") | trim | nindent 6 }}
+      volumes:
+      - emptyDir: {}
+        name: cache
+      - emptyDir: {}
+        name: tmp
+      {{- if .Values.symbols.extraVolumes }}
+      {{- toYaml .Values.symbols.extraVolumes | nindent 6 }}
+      {{- end }}
+      {{- if .Values.symbols.priorityClassName }}
+      priorityClassName: {{ .Values.symbols.priorityClassName }}
+      {{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: cache
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.symbols.storageSize | default "12Gi" }}
+      storageClassName: {{ .Values.storageClass.name }}

--- a/charts/sourcegraph/tests/priorityClass_test.yaml
+++ b/charts/sourcegraph/tests/priorityClass_test.yaml
@@ -96,6 +96,15 @@ tests:
   - equal:
       path: spec.template.spec.priorityClassName
       value: searcher-class
+- it: set priority class on symbols
+  template: symbols/symbols.StatefulSet.yaml
+  set:
+    symbols:
+      priorityClassName: symbols-class
+  asserts:
+  - equal:
+      path: spec.template.spec.priorityClassName
+      value: symbols-class
 - it: set priority class on redisCache
   template: redis/redis-cache.Deployment.yaml
   set:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1073,7 +1073,7 @@ searcher:
     # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: ""
   # -- Size of the PVC for searcher pods to store cache data
-  storageSize: 52Gi
+  storageSize: 26Gi
 
 storageClass:
   # -- Enable creation of storageClass.
@@ -1095,6 +1095,46 @@ storageClass:
   # -- Persistent volumes topology configuration,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies)
   allowedTopologies: []
+
+symbols:
+  image:
+    # -- Docker image tag for the `symbols` image
+    defaultTag: 6.0.0@sha256:7f91048d1966add54b199755c77a5c3ca84b7f57bb5d2ffb65113da7f100b051
+    # -- Docker image name for the `symbols` image
+    name: "symbols"
+  # -- Security context for the `symbols` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 100
+    runAsGroup: 101
+    readOnlyRootFilesystem: true
+  # -- Security context for the `symbols` pod,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  podSecurityContext:
+    runAsUser: 100
+    fsGroup: 101
+    fsGroupChangePolicy: "OnRootMismatch"
+  # -- Name used by resources. Does not affect service names or PVCs.
+  name: "symbols"
+  # -- Number of `symbols` pod
+  replicaCount: 1
+  # -- Resource requests & limits for the `symbols` container,
+  # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2G
+    requests:
+      cpu: 500m
+      memory: 500M
+  serviceAccount:
+    # -- Enable creation of ServiceAccount for `symbols`
+    create: false
+    # -- Name of the ServiceAccount to be created or an existing ServiceAccount
+    name: ""
+  # -- Size of the PVC for symbols pods to store cache data
+  storageSize: 12Gi
 
 syntectServer:
   image:


### PR DESCRIPTION
Reverts sourcegraph/deploy-sourcegraph-helm#675

```
The StatefulSet "searcher" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
```

![CleanShot 2025-05-12 at 10 01 40](https://github.com/user-attachments/assets/66b8b554-1f94-41e9-835d-57bc29088d04)

pvc template is immutable in STS and the PR changed the value. it will break for all existing deployment

Test plan: CI