### PR TITLE
configure resource requests and limits for native k8s executors

### DIFF
--- a/charts/sourcegraph-executor/k8s/README.md
+++ b/charts/sourcegraph-executor/k8s/README.md
@@ -89,6 +89,10 @@ In addition to the documented values, the `executor` and `private-docker-registr
 | executor.queueName | string | `""` | The name of the queue to pull jobs from to. Possible values: batches and codeintel. **Either this or queueNames is required.** |
 | executor.queueNames | list | `[]` | The names of multiple queues to pull jobs from to. Possible values: batches and codeintel. **Either this or queueName is required.** |
 | executor.replicas | int | `1` |  |
+| executor.resources.limits.cpu | string | `"1"` |  |
+| executor.resources.limits.memory | string | `"1Gi"` |  |
+| executor.resources.requests.cpu | string | `"500m"` |  |
+| executor.resources.requests.memory | string | `"200Mi"` |  |
 | executor.securityContext | object | `{"fsGroup":null,"privileged":false,"runAsGroup":null,"runAsUser":null}` | The containerSecurityContext for the executor image |
 | executor.storageSize | string | `"10Gi"` | The storage size of the PVC attached to the executor deployment. |
 | executor.tolerations | list | `[]` | Tolerations, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
@@ -99,6 +103,7 @@ In addition to the documented values, the `executor` and `private-docker-registr
 | sourcegraph.image.useGlobalTagAsDefault | bool | `false` | When set to true, sourcegraph.image.defaultTag is used as the default defaultTag for all services, instead of service-specific default defaultTags |
 | sourcegraph.imagePullSecrets | list | `[]` | Mount named secrets containing docker credentials |
 | sourcegraph.labels | object | `{}` | Add a global label to all resources |
+| sourcegraph.localDevMode | bool | `false` | When true, remove all resource stanzas, allowing the scheduler to best-fit pods. Intended for local development with limited resources. |
 | sourcegraph.nameOverride | string | `""` | Set a custom name for the app.kubernetes.io/name annotation |
 | sourcegraph.nodeSelector | object | `{}` | NodeSelector, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) |
 | sourcegraph.podAnnotations | object | `{}` | Add extra annotations to attach to all pods |

--- a/charts/sourcegraph-executor/k8s/templates/executor.Deployment.yaml
+++ b/charts/sourcegraph-executor/k8s/templates/executor.Deployment.yaml
@@ -68,6 +68,10 @@ spec:
           {{- toYaml . | trim | nindent 12 }}
           {{- end }}
           {{- end }}
+          {{- if not .Values.sourcegraph.localDevMode }}
+          resources:
+            {{- toYaml .Values.executor.resources | nindent 12 }}
+          {{- end }}
           livenessProbe:
             exec:
               command:

--- a/charts/sourcegraph-executor/k8s/values.yaml
+++ b/charts/sourcegraph-executor/k8s/values.yaml
@@ -15,6 +15,8 @@ sourcegraph:
   imagePullSecrets: [ ]
   # -- Add a global label to all resources
   labels: { }
+  # -- When true, remove all resource stanzas, allowing the scheduler to best-fit pods. Intended for local development with limited resources.
+  localDevMode: false
   # -- Set a custom name for the app.kubernetes.io/name annotation
   nameOverride: ""
   # -- Affinity,
@@ -59,6 +61,13 @@ executor:
   image:
     defaultTag: 6.0.0@sha256:6dc771a0c281a41ef676213f2f84a63d99045cf2e58d43022554a8022070ed65
     name: "executor-kubernetes"
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 200Mi
   # -- The external URL of the Sourcegraph instance. Required. **Recommended:** set to the internal service endpoint (e.g. `http://sourcegraph-frontend.sourcegraph.svc.cluster.local:30080` if Sourcegraph is deployed in the `sourcegraph` namespace). 
   # This will avoid unnecessary network charges as traffic will stay within the local network.
   frontendUrl: ""


### PR DESCRIPTION
configure resource request and limits for native k8s executors for consistency with other sourcegraph helm charts.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

verified with `helm template . --show-only templates/executor.Deployment.yaml`
