### PR TITLE
feat: otel tolerations for helm chart

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -202,6 +202,7 @@ In addition to the documented values, all services also support the following va
 | openTelemetry.agent.resources.requests.memory | string | `"100Mi"` |  |
 | openTelemetry.agent.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `otel-agent` |
 | openTelemetry.agent.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| openTelemetry.agent.tolerations | list | `[]` | Tolerations for the `otel-agent` pods |
 | openTelemetry.enabled | bool | `true` |  |
 | openTelemetry.gateway.config.traces.exporters | object | `{}` | Define where traces should be exported to. Read how to configure different backends in the [OpenTelemetry documentation](https://opentelemetry.io/docs/collector/configuration/#exporters) |
 | openTelemetry.gateway.config.traces.exportersTlsSecretName | string | `""` | Define the name of a preexisting secret containing TLS certificates for exporters, which will be mounted under "/tls". Read more about TLS configuration of exporters in the [OpenTelemetry Collector documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md) |
@@ -213,6 +214,7 @@ In addition to the documented values, all services also support the following va
 | openTelemetry.gateway.resources | object | `{"limits":{"cpu":"3","memory":"3Gi"},"requests":{"cpu":"1","memory":"1Gi"}}` | Resource requests & limits for the `otel-collector` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | openTelemetry.gateway.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `otel-collector` |
 | openTelemetry.gateway.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| openTelemetry.gateway.tolerations | list | `[]` | Tolerations for the `otel-collector` pods |
 | openTelemetry.image.defaultTag | string | `"6.0.0@sha256:ef3e61a4f0a624523ecdee57d8b7757436c2389e0cf12401b4764d19c826ff8a"` | Docker image tag for the `otel-collector` image |
 | openTelemetry.image.name | string | `"opentelemetry-collector"` | Docker image name for the `otel-collector` image |
 | pgsql.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from our [recommended PostgreSQL configuration](https://docs.sourcegraph.com/admin/config/postgres-conf) and [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -146,6 +146,25 @@ tolerations:
 {{- end }}
 
 {{/*
+OpenTelemetry tolerations - supports separate tolerations for agent and gateway
+*/}}
+{{- define "sourcegraph.openTelemetry.tolerations" -}}
+{{- $top := index . 0 }}
+{{- $component := index . 1 }}
+{{- $globalTolerations := (index $top.Values "sourcegraph" "tolerations") }}
+{{- $openTelemetryTolerations := (index $top.Values "openTelemetry" "tolerations") }}
+{{- $componentTolerations := (index $top.Values "openTelemetry" $component "tolerations") }}
+tolerations:
+{{- if $componentTolerations }}
+{{- $componentTolerations | toYaml | trim | nindent 2 }}
+{{- else if $openTelemetryTolerations }}
+{{- $openTelemetryTolerations | toYaml | trim | nindent 2 }}
+{{- else if $globalTolerations }}
+{{- $globalTolerations | toYaml | trim | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
 Jaeger common labels
 */}}
 {{- define "sourcegraph.jaeger.labels" -}}

--- a/charts/sourcegraph/templates/otel-collector/otel-agent.DaemonSet.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-agent.DaemonSet.yaml
@@ -84,7 +84,7 @@ spec:
       terminationGracePeriodSeconds: 120
       {{- include "sourcegraph.nodeSelector" (list . "openTelemetry" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "openTelemetry" ) | trim | nindent 6 }}
-      {{- include "sourcegraph.tolerations" (list . "openTelemetry" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.openTelemetry.tolerations" (list . "agent" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/templates/otel-collector/otel-collector.Deployment.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-collector.Deployment.yaml
@@ -105,7 +105,7 @@ spec:
       terminationGracePeriodSeconds: 120
       {{- include "sourcegraph.nodeSelector" (list . "openTelemetry" ) | trim | nindent 6 }}
       {{- include "sourcegraph.affinity" (list . "openTelemetry" ) | trim | nindent 6 }}
-      {{- include "sourcegraph.tolerations" (list . "openTelemetry" ) | trim | nindent 6 }}
+      {{- include "sourcegraph.openTelemetry.tolerations" (list . "gateway" ) | trim | nindent 6 }}
       {{- with .Values.sourcegraph.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -632,6 +632,8 @@ openTelemetry:
       allowPrivilegeEscalation: false
       runAsUser: 100
       runAsGroup: 101
+    # -- Tolerations for the `otel-collector` pods
+    tolerations: []
 
   agent:
     # -- Name used by resources. Does not affect service names or PVCs.
@@ -658,6 +660,8 @@ openTelemetry:
       allowPrivilegeEscalation: false
       runAsUser: 100
       runAsGroup: 101
+    # -- Tolerations for the `otel-agent` pods
+    tolerations: []
 
 nodeExporter:
   # -- Enable `node-exporter`


### PR DESCRIPTION
Resolves [REL-772](https://linear.app/sourcegraph/issue/REL-772/add-separate-tolerations-config-for-otel-agent-and-otel-collector)

Still needs testing so it's in draft

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan
Manually install and test?
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
