### PR TITLE
Fix(release): promoteToPublic.finalize github:pr update main target bug

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -618,11 +618,11 @@ promoteToPublic:
       - name: "github:pr"
         cmd: |
           set -eu
-          internal_branch="promote/release-{{version}}-update-main"
+          # Create PR to merge release updates into main branch
           gh pr create \
             --fill \
             --draft \
-            --base "$internal_branch" \
+            --base main \
             --title "Update main: build {{version}}" \
             --body "Test plan: automated release PR, CI will perform additional checks"
           echo "🚢 Please check the associated CI build to ensure the process completed".


### PR DESCRIPTION
Closes REL-1068

## Problem

The release pipeline has been systematically failing in the `promoteToPublic.finalize` workflow with this error:
```
Warning: 1 uncommitted change
must be on a branch named differently than 'promote/release-v6.4.3889-update-main'
```

## Root Cause

The final `github:pr` step in the `promoteToPublic.finalize` workflow was incorrectly trying to create a PR from the current branch to itself:

- **Current branch**: `promote/release-{{version}}-update-main`
- **Target branch**: `promote/release-{{version}}-update-main` ❌ (same branch!)
- **Should target**: `main` ✅

This happened because the variable `internal_branch` was set to the current branch name instead of the intended target branch.

### Test plan
This will have to be tested on a release