### PR TITLE
Create config for sgTestConnection enabled

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -300,6 +300,7 @@ In addition to the documented values, all services also support the following va
 | searcher.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `searcher` |
 | searcher.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | searcher.storageSize | string | `"26Gi"` | Size of the PVC for searcher pods to store cache data |
+| sgTestConnection | object | `{"enabled":true}` | Enable the busybox connection test after deployment |
 | sourcegraph.affinity | object | `{}` | Global Affinity, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | sourcegraph.image.defaultTag | string | `"{{ .Chart.AppVersion }}"` | Global docker image tag |
 | sourcegraph.image.pullPolicy | string | `"IfNotPresent"` | Global docker image pull policy |

--- a/charts/sourcegraph/templates/tests/test-connection.yaml
+++ b/charts/sourcegraph/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.sgTestConnection.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,3 +14,4 @@ spec:
       command: ['wget']
       args: ['sourcegraph-frontend:30080/']
   restartPolicy: Never
+{{- end }}

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1266,3 +1266,7 @@ extraResources: []
 #   preemptionPolicy: Never
 #   description: "gitserver priority class"
 priorityClasses: []
+
+# -- Enable the busybox connection test after deployment
+sgTestConnection:
+  enabled: true


### PR DESCRIPTION
Allow self-hosted customers to disable the sg-test-connection pod, similar to how the Cloud instances do (https://github.com/sourcegraph/cloud/pull/8)

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan
Ran `helm template`, `helm lint`, and `helm unittest`, all passed

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
