### PR TITLE
fix: update internal registry from legacy to new revamp registry

### DIFF
--- a/batch-change/release.yaml
+++ b/batch-change/release.yaml
@@ -30,7 +30,7 @@ internal:
         - name: sg ops:sourcegraph
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -43,7 +43,7 @@ internal:
         - name: sg ops:dind
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -56,7 +56,7 @@ internal:
         - name: sg ops:k8s
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -69,7 +69,7 @@ internal:
         - name: sg ops:migrator
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -102,7 +102,7 @@ internal:
         - name: sg ops:sourcegraph
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             echo "updating sourcegraph images"
             sg ops update-images \
@@ -116,7 +116,7 @@ internal:
         - name: sg ops:dind
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -129,7 +129,7 @@ internal:
         - name: sg ops:k8s
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -142,7 +142,7 @@ internal:
         - name: sg ops:migrator
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -174,7 +174,7 @@ internal:
         - name: sg ops:sourcegraph
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             echo "updating sourcegraph images"
             sg ops update-images \
@@ -188,7 +188,7 @@ internal:
         - name: sg ops:dind
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -201,7 +201,7 @@ internal:
         - name: sg ops:k8s
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -214,7 +214,7 @@ internal:
         - name: sg ops:migrator
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \

--- a/release.yaml
+++ b/release.yaml
@@ -30,7 +30,7 @@ internal:
         - name: sg ops:sourcegraph
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -43,7 +43,7 @@ internal:
         - name: sg ops:dind
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -56,7 +56,7 @@ internal:
         - name: sg ops:k8s
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -69,7 +69,7 @@ internal:
         - name: sg ops:migrator
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -127,7 +127,7 @@ internal:
         - name: sg ops:sourcegraph
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             echo "updating sourcegraph images"
             sg ops update-images \
@@ -141,7 +141,7 @@ internal:
         - name: sg ops:dind
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -154,7 +154,7 @@ internal:
         - name: sg ops:k8s
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -167,7 +167,7 @@ internal:
         - name: sg ops:migrator
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -225,7 +225,7 @@ internal:
         - name: sg ops:sourcegraph
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             echo "updating sourcegraph images"
             sg ops update-images \
@@ -239,7 +239,7 @@ internal:
         - name: sg ops:dind
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -252,7 +252,7 @@ internal:
         - name: sg ops:k8s
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \
@@ -265,7 +265,7 @@ internal:
         - name: sg ops:migrator
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
 
             sg ops update-images \
               -t {{inputs.server.tag}} \


### PR DESCRIPTION
## Problem
The release creation process was failing with 404 errors when trying to fetch images like cadvisor:6.6.2517 from the legacy internal registry.

## Root Cause
Recent changes in the main sourcegraph repo migrated from legacy registries to new 'revamp' registries, but the deploy repos were still hardcoded to use the old registry.

## Solution
- Replace `us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal` with `us-docker.pkg.dev/sourcegraph-images/internal`
- Updated release.yaml with all registry references
- Tested and confirmed images exist in the new registry

## Test Plan
- Validated that cadvisor:6.6.2517 exists in new registry but not in old registry
- Successfully tested sg ops update-images command with new registry
- Confirmed this fixes the original 404 errors during release creation