### PR TITLE
Add support for deploying without using Kubernetes secrets

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -249,8 +249,9 @@ In addition to the documented values, all services also support the following va
 | preciseCodeIntel.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `precise-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | preciseCodeIntel.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `precise-code-intel-worker` |
 | preciseCodeIntel.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
-| priorityClasses | list | `[]` | Additional priorityClasses minimise re-scheduling downtime for StatefulSets. Each StatefulSets might use different priority class. learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) Sample class definition: - name: gitserver-class   value: 100   preemptionPolicy: Never   description: "gitserver priority class" |
+| priorityClasses | list | `[]` | Additional priorityClasses minimize re-scheduling downtime for StatefulSets. Each StatefulSets might use different priority class. learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) Sample class definition: - name: gitserver-class   value: 100   preemptionPolicy: Never   description: "gitserver priority class" |
 | prometheus.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":false,"runAsGroup":100,"runAsUser":100}` | Security context for the `prometheus` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| prometheus.createRoleBinding | bool | `true` | Disable the creation of a RoleBinding object, for customers who block all RBAC resource creation |
 | prometheus.enabled | bool | `true` | Enable `prometheus` (recommended) |
 | prometheus.existingConfig | string | `""` | Name of existing ConfigMap for `pgsql`. It must contain a `prometheus.yml` key |
 | prometheus.image.defaultTag | string | `"6.0.0@sha256:86a315720fd9813d9ef9746d92e637bc20cd9ebd90da78d8cc6906062252891f"` | Docker image tag for the `prometheus` image |
@@ -302,6 +303,7 @@ In addition to the documented values, all services also support the following va
 | searcher.storageSize | string | `"26Gi"` | Size of the PVC for searcher pods to store cache data |
 | sgTestConnection | object | `{"enabled":true}` | Enable the busybox connection test after deployment |
 | sourcegraph.affinity | object | `{}` | Global Affinity, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| sourcegraph.disableKubernetesSecrets | bool | `false` | Disable the creation of Kubernetes secrets objects |
 | sourcegraph.image.defaultTag | string | `"{{ .Chart.AppVersion }}"` | Global docker image tag |
 | sourcegraph.image.pullPolicy | string | `"IfNotPresent"` | Global docker image pull policy |
 | sourcegraph.image.repository | string | `"index.docker.io/sourcegraph"` | Global docker image registry or prefix |
@@ -313,6 +315,8 @@ In addition to the documented values, all services also support the following va
 | sourcegraph.nodeSelector | object | `{}` | Global NodeSelector, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) |
 | sourcegraph.podAnnotations | object | `{}` | Add extra annotations to attach to all pods |
 | sourcegraph.podLabels | object | `{}` | Add extra labels to attach to all pods |
+| sourcegraph.redisCacheEndpoint | string | `""` | Set the value of the REDIS_CACHE_ENDPOINT environment variable on the needed containers, when Kubernetes secrets are disabled |
+| sourcegraph.redisStoreEndpoint | string | `""` | Set the value of the REDIS_STORE_ENDPOINT environment variable on the needed containers, when Kubernetes secrets are disabled |
 | sourcegraph.revisionHistoryLimit | int | `10` | Global deployment clean up policy, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | sourcegraph.serviceLabels | object | `{}` | Add extra labels to all services |
 | sourcegraph.tolerations | list | `[]` | Global Tolerations, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -45,7 +45,7 @@ For top-level services, pass in the top-level values:
 {{ include "sourcegraph.serviceAccountName" (list . "frontend") }}
 
 frontend:
-  serivceAccount:
+  serviceAccount:
     create: false
 
 For nested services, pass in the nested values:
@@ -249,6 +249,12 @@ app.kubernetes.io/name: jaeger
 {{- end }}
 
 {{- define "sourcegraph.redisConnection" -}}
+{{- if .Values.sourcegraph.disableKubernetesSecrets -}}
+- name: REDIS_CACHE_ENDPOINT
+  value: {{ .Values.sourcegraph.redisCacheEndpoint }}
+- name: REDIS_STORE_ENDPOINT
+  value: {{ .Values.sourcegraph.redisStoreEndpoint }}
+{{- else -}}
 - name: REDIS_CACHE_ENDPOINT
   valueFrom:
     secretKeyRef:
@@ -259,7 +265,8 @@ app.kubernetes.io/name: jaeger
     secretKeyRef:
       key: endpoint
       name: {{ default .Values.redisStore.name .Values.redisStore.connection.existingSecret }}
-{{- end }}
+{{- end -}}
+{{- end -}}
 
 {{- define "sourcegraph.authChecksum" -}}
 {{- $checksum := list .Values.codeInsightsDB.auth -}}

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Secret.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.Secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.codeInsightsDB.auth.existingSecret }}
+{{- if and (not .Values.sourcegraph.disableKubernetesSecrets) (not .Values.codeInsightsDB.auth.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.Secret.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.Secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.codeIntelDB.auth.existingSecret }}
+{{- if and (not .Values.sourcegraph.disableKubernetesSecrets) (not .Values.codeIntelDB.auth.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -52,9 +52,12 @@ spec:
       - name: migrator
         image: {{ include "sourcegraph.image" (list . "migrator") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        {{- if .Values.migrator.command }}
+        command: {{ .Values.migrator.command }}
+        {{- end }}
         args: {{- default (list "up") .Values.migrator.args | toYaml | nindent 8 }}
         env:
-        {{- if not .Values.migrator.databaseAuthOverrideEnvVars }}
+        {{- if and (not .Values.migrator.databaseAuthOverrideEnvVars) (not .Values.sourcegraph.disableKubernetesSecrets) }}
         {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
         {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "CODEINTEL_PG") | nindent 8 }}
         {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "CODEINSIGHTS_PG") | nindent 8 }}
@@ -78,11 +81,16 @@ spec:
       - name: frontend
         image: {{ include "sourcegraph.image" (list . "frontend") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
+        {{- if .Values.frontend.command }}
+        command: {{ .Values.frontend.command }}
+        {{- end }}
         args: {{- default (list "serve") .Values.frontend.args | toYaml | nindent 8 }}
         env:
+        {{- if not .Values.sourcegraph.disableKubernetesSecrets }}
         {{- include "sourcegraph.databaseAuth" (list . "pgsql" "PG") | nindent 8 }}
         {{- include "sourcegraph.databaseAuth" (list . "codeIntelDB" "CODEINTEL_PG") | nindent 8 }}
         {{- include "sourcegraph.databaseAuth" (list . "codeInsightsDB" "CODEINSIGHTS_PG") | nindent 8 }}
+        {{- end }}
         {{- range $name, $item := .Values.frontend.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -52,7 +52,9 @@ spec:
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         env:
+        {{- if not .Values.sourcegraph.disableKubernetesSecrets -}}
         {{- include "sourcegraph.databaseAuth" (list . "grafana" "GRAFANA_PGSQL_") | nindent 8 }}
+        {{- end -}}
         {{- range $name, $item := .Values.grafana.env}}
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}

--- a/charts/sourcegraph/templates/grafana/grafana.pgsql.Secret.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.pgsql.Secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.grafana.auth (not .Values.grafana.auth.existingSecret) }}
+{{- if and (not .Values.sourcegraph.disableKubernetesSecrets) .Values.grafana.auth (not .Values.grafana.auth.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sourcegraph/templates/pgsql/pgsql.Secret.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.Secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.pgsql.auth.existingSecret }}
+{{- if and (not .Values.sourcegraph.disableKubernetesSecrets) (not .Values.pgsql.auth.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheus.enabled .Values.prometheus.privileged -}}
+{{- if and .Values.prometheus.enabled .Values.prometheus.privileged .Values.prometheus.createRoleBinding -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/sourcegraph/templates/prometheus/prometheus.RoleBinding.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.RoleBinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheus.enabled (not .Values.prometheus.privileged) -}}
+{{- if and .Values.prometheus.enabled (not .Values.prometheus.privileged) .Values.prometheus.createRoleBinding -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/sourcegraph/templates/redis/redis-cache.Secret.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.redisCache.connection.existingSecret }}
+{{- if and (not .Values.sourcegraph.disableKubernetesSecrets) (not .Values.redisCache.connection.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sourcegraph/templates/redis/redis-store.Secret.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.redisStore.connection.existingSecret }}
+{{- if and (not .Values.sourcegraph.disableKubernetesSecrets) (not .Values.redisStore.connection.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -38,6 +38,12 @@ sourcegraph:
   revisionHistoryLimit: 10
   # -- Add extra labels to all services
   serviceLabels: {}
+  # -- Disable the creation of Kubernetes secrets objects
+  disableKubernetesSecrets: false
+  # -- Set the value of the REDIS_CACHE_ENDPOINT environment variable on the needed containers, when Kubernetes secrets are disabled
+  redisCacheEndpoint: ""
+  # -- Set the value of the REDIS_STORE_ENDPOINT environment variable on the needed containers, when Kubernetes secrets are disabled
+  redisStoreEndpoint: ""
 
 # Generic application configuration options, used by most applications below
 # app: # Generally matches directory name
@@ -893,6 +899,8 @@ prometheus:
   name: "prometheus"
   # -- Enable RBAC for `prometheus`
   privileged: true
+  # -- Disable the creation of a RoleBinding object, for customers who block all RBAC resource creation
+  createRoleBinding: true
   # -- Resource requests & limits for the `prometheus` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   # Prometheus is relied upon to monitor services for sending alerts to site admins when
@@ -1258,7 +1266,7 @@ worker:
 # -- Additional resources to include in the rendered manifest. Templates are supported.
 extraResources: []
 
-# -- Additional priorityClasses minimise re-scheduling downtime for StatefulSets. Each StatefulSets might use different priority class.
+# -- Additional priorityClasses minimize re-scheduling downtime for StatefulSets. Each StatefulSets might use different priority class.
 # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass)
 # Sample class definition:
 # - name: gitserver-class


### PR DESCRIPTION
...and to disable RBAC resources.

Customer's Kubernetes security policies block the creation of secrets and RBAC resources

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Tested with customer

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
