### PR TITLE
Add priorityClassName test coverage for cadvisor (PLAT-483)

### DIFF
--- a/charts/sourcegraph/tests/priorityClass_test.yaml
+++ b/charts/sourcegraph/tests/priorityClass_test.yaml
@@ -114,3 +114,12 @@ tests:
   - equal:
       path: spec.template.spec.priorityClassName
       value: redis-store-class
+- it: set priority class on cadvisor
+  template: cadvisor/cadvisor.DaemonSet.yaml
+  set:
+    cadvisor:
+      priorityClassName: cadvisor-class
+  asserts:
+  - equal:
+      path: spec.template.spec.priorityClassName
+      value: cadvisor-class


### PR DESCRIPTION
## Summary
- Adds test coverage for `priorityClassName` on the cadvisor DaemonSet, which already supports it via the shared `sourcegraph.priorityClassName` helper but had no test case.
- Part of [PLAT-483](https://linear.app/sourcegraph/issue/PLAT-483): add priority class to cadvisor and observe agent to ensure they're scheduled.

## Test plan
`helm unittest` — all 89 tests pass, including the new cadvisor priority class test.