### PR TITLE
fix/indexed-search: add livenessProbe to zoekt-webserver to prevent hung pods

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Added livenessProbe to zoekt-webserver in indexed-search to detect and restart hung pods
 - Fix Pod Disruption Budget for sourcegraph-frontend
 - Added a startup probe to the gitserver statefulset to give it time to run the on-disk migration from repo names to repo IDs
 - The repo-updater service is no longer needed and has been removed from the chart.

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -63,6 +63,15 @@ spec:
         ports:
         - name: grpc
           containerPort: 6070
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: grpc
+            scheme: HTTP
+          initialDelaySeconds: 120
+          timeoutSeconds: 5
+          periodSeconds: 60
+          failureThreshold: 10
         readinessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
zoekt-webserver was unhealthy for long time

```
NAME               READY   STATUS    RESTARTS   AGE    
indexed-search-0   1/2     Running   0          6h18m  
indexed-search-1   1/2     Running   0          6h19m  
indexed-search-2   1/2     Running   0          6h21m  
indexed-search-3   1/2     Running   0          6h23m  
indexed-search-4   1/2     Running   0          6h25m  
indexed-search-5   1/2     Running   0          6h27m  
indexed-search-6   1/2     Running   0          6h29m  
indexed-search-7   1/2     Running   0          6h31m  
```

```
  Warning  Unhealthy  4m20s (x3300 over 4h39m)  kubelet  Readiness probe failed: Get "http://192.168.11.20:6070/healthz": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

ref https://linear.app/sourcegraph/issue/PLAT-509/incident-indexed-search-pods-were-unhealthy-for-long-time PLAT-509

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)


### Test plan

- [x] Manual Verification - local with kind cluster

<img width="1920" height="1080" alt="Screenshot 2026-03-27 at 11 52 41 AM" src="https://github.com/user-attachments/assets/173876e7-8ca3-476b-ac6b-63cc1c29a76c" />

- [x] Tested against cloud-dev-qa with mi2 generate kustomize and kustomize apply