### PR TITLE
Swapped nginx default annotations for their OpenShift HAProxy equival…

### DIFF
--- a/charts/sourcegraph/examples/openshift/override.yaml
+++ b/charts/sourcegraph/examples/openshift/override.yaml
@@ -257,13 +257,17 @@ frontend:
 
   ingress:
     annotations:
-      # If using HAProxy router, add the timeout to prevent SSE / streaming timeouts
-      haproxy.router.openshift.io/timeout: 5m
-      kubernetes.io/ingress.class: openshift-default-example
-      nginx.ingress.kubernetes.io/proxy-body-size: 150m
-      # If terminating TLS on the router
-      route.openshift.io/termination: edge
-    host: sourcegraph.example.com
+    # Null out nginx defaults from values.yaml — not applicable
+    kubernetes.io/ingress.class: null
+    nginx.ingress.kubernetes.io/proxy-body-size: null
+    # HAProxy router: prevent SSE / streaming timeouts
+    haproxy.router.openshift.io/timeout: 5m
+    # HAProxy router: equivalent of nginx proxy-body-size, for large Git pushes / file uploads
+    haproxy.router.openshift.io/request-body-size: 150m
+    # TLS termination at the router
+    route.openshift.io/termination: edge
+  ingressClassName: openshift-default-example
+  host: sourcegraph.example.com
 
 ################################################################################
 # Core services

--- a/charts/sourcegraph/examples/openshift/override.yaml
+++ b/charts/sourcegraph/examples/openshift/override.yaml
@@ -257,17 +257,17 @@ frontend:
 
   ingress:
     annotations:
-    # Null out nginx defaults from values.yaml — not applicable
-    kubernetes.io/ingress.class: null
-    nginx.ingress.kubernetes.io/proxy-body-size: null
-    # HAProxy router: prevent SSE / streaming timeouts
-    haproxy.router.openshift.io/timeout: 5m
-    # HAProxy router: equivalent of nginx proxy-body-size, for large Git pushes / file uploads
-    haproxy.router.openshift.io/request-body-size: 150m
-    # TLS termination at the router
-    route.openshift.io/termination: edge
-  ingressClassName: openshift-default-example
-  host: sourcegraph.example.com
+      # Null out nginx defaults from values.yaml — not applicable
+      kubernetes.io/ingress.class: null
+      nginx.ingress.kubernetes.io/proxy-body-size: null
+      # HAProxy router: prevent SSE / streaming timeouts
+      haproxy.router.openshift.io/timeout: 5m
+      # HAProxy router: equivalent of nginx proxy-body-size, for large Git pushes / file uploads
+      haproxy.router.openshift.io/request-body-size: 150m
+      # TLS termination at the router
+      route.openshift.io/termination: edge
+    ingressClassName: openshift-default-example
+    host: sourcegraph.example.com
 
 ################################################################################
 # Core services


### PR DESCRIPTION
…ents.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
