### PR TITLE
fix: otel agent is not picking up traces

### DIFF
--- a/charts/sourcegraph/templates/otel-collector/otel-agent.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-agent.ConfigMap.yaml
@@ -12,8 +12,13 @@ data:
     receivers:
       otlp:
         protocols:
-          grpc: # port 4317
-          http: # port 4318
+          grpc:
+            # Bind to all interfaces. Since v0.104.0, the collector defaults the OTLP
+            # receiver to 127.0.0.1 (CVE-2024-36129 hardening), which silently drops
+            # traffic from other pods. See https://opentelemetry.io/blog/2024/hardening-the-collector-one/
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
 
     exporters:
       otlp:


### PR DESCRIPTION
needs https://github.com/sourcegraph/sourcegraph/pull/12299

both jaeger and otel agent needs to permit incoming traffic at `0.0.0.0` in order to receive traces

### Test plan

<img width="1446" height="902" alt="CleanShot 2026-05-07 at 18 42 40" src="https://github.com/user-attachments/assets/4872c482-2d80-457f-8b0c-fb85ee70683e" />

