### PR TITLE
Extend persistent volume configuration options

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -41,6 +41,7 @@ In addition to the documented values, all services also support the following va
 | blobstore.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `blobstore` |
 | blobstore.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | blobstore.storageSize | string | `"100Gi"` | PVC Storage Request for `blobstore` data volume |
+| blobstore.storageSubPath | string | `""` | Optional subPath for the `blobstore` primary data volume mount |
 | cadvisor.containerSecurityContext | object | `{"privileged":true}` | Security context for the `cadvisor` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | cadvisor.enabled | bool | `true` | Enable `cadvisor` |
 | cadvisor.image.defaultTag | string | `"6.0.0@sha256:48082a2822a727e22c556ae2c3bae5f5bf4528c7b462efc3c085271ee5145be8"` | Docker image tag for the `cadvisor` image |
@@ -72,6 +73,7 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeinsights-db` |
 | codeInsightsDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeInsightsDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeinsights-db` data volume |
+| codeInsightsDB.storageSubPath | string | `""` | Optional subPath for the `codeinsights-db` primary data volume mount |
 | codeIntelDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from our [recommended PostgreSQL configuration](https://docs.sourcegraph.com/admin/config/postgres-conf) and [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
 | codeIntelDB.auth.database | string | `"sg"` | Sets codeintel-db database name |
 | codeIntelDB.auth.existingSecret | string | `""` | Name of existing secret to use for CodeIntel credentials The secret must contain the keys `user`, `password`, `database`, `host` and `port`. `auth.user`, `auth.password`, etc. are ignored if this is enabled |
@@ -92,6 +94,7 @@ In addition to the documented values, all services also support the following va
 | codeIntelDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeintel-db` |
 | codeIntelDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | codeIntelDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeintel-db` data volume |
+| codeIntelDB.storageSubPath | string | `""` | Optional subPath for the `codeintel-db` primary data volume mount |
 | extraResources | list | `[]` | Additional resources to include in the rendered manifest. Templates are supported. |
 | frontend.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `frontend` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | frontend.createRoleBinding | bool | `true` | Disable the roleBinding resource for deployment environments blocking RBAC, ex. OpenShift's default "secure" SCC |
@@ -124,6 +127,7 @@ In addition to the documented values, all services also support the following va
 | gitserver.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | gitserver.sshSecret | string | `""` | Name of existing Secret that contains SSH credentials to clone repositories. It usually contains keys, such as `id_rsa` (private key) and `known_hosts`. Learn more from [documentation](https://docs.sourcegraph.com/admin/install/kubernetes/helm#using-ssh-to-clone-repositories) |
 | gitserver.storageSize | string | `"200Gi"` | PVC Storage Request for `gitserver` data volume |
+| gitserver.storageSubPath | string | `""` | Optional subPath for the `gitserver` primary data volume mount |
 | grafana.auth | object | `{"database":"","existingSecret":"","host":"","password":"","port":"","sslmode":"","user":""}` | NOTE: Create a separate user in the pgsql database with read-only perms on the minimum set of tables |
 | grafana.auth.database | string | `""` | Sets postgres database name |
 | grafana.auth.existingSecret | string | `""` | Name of existing secret to for Grafana to use to connect to the pgsql database The secret must contain the keys `user`, `password`, `database`, `host` and `port`. `auth.user`, `auth.password`, etc. are ignored if this is enabled |
@@ -143,6 +147,7 @@ In addition to the documented values, all services also support the following va
 | grafana.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `grafana` |
 | grafana.serviceAccount.name | string | `"grafana"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | grafana.storageSize | string | `"2Gi"` | PVC Storage Request for `grafana` data volume |
+| grafana.storageSubPath | string | `""` | Optional subPath for the `grafana` primary data volume mount |
 | indexedSearch.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `zoekt-webserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | indexedSearch.image.defaultTag | string | `"6.0.0@sha256:99038e0ec9bef930030c118d774fcdcd67d7fe57ad4c80d216703a4d29d64323"` | Docker image tag for the `zoekt-webserver` image |
 | indexedSearch.image.name | string | `"indexed-searcher"` | Docker image name for the `zoekt-webserver` image |
@@ -153,6 +158,7 @@ In addition to the documented values, all services also support the following va
 | indexedSearch.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `indexed-search` |
 | indexedSearch.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | indexedSearch.storageSize | string | `"200Gi"` | PVC Storage Request for `indexed-search` data volume The size of disk to used for search indexes. This should typically be gitserver disk size multipled by the number of gitserver shards. |
+| indexedSearch.storageSubPath | string | `""` | Optional subPath for the `indexed-search` primary data volume mount |
 | indexedSearchIndexer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `zoekt-indexserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | indexedSearchIndexer.image.defaultTag | string | `"6.0.0@sha256:11539e07040b85045a9aa07f970aa310066e240dc28e6c9627653ee2bc6e0b91"` | Docker image tag for the `zoekt-indexserver` image |
 | indexedSearchIndexer.image.name | string | `"search-indexer"` | Docker image name for the `zoekt-indexserver` image |
@@ -243,6 +249,7 @@ In addition to the documented values, all services also support the following va
 | pgsql.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `pgsql` |
 | pgsql.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | pgsql.storageSize | string | `"200Gi"` | PVC Storage Request for `pgsql` data volume |
+| pgsql.storageSubPath | string | `""` | Optional subPath for the `pgsql` primary data volume mount |
 | postgresExporter.image.defaultTag | string | `"6.0.0@sha256:685a18f482e4a71a54e15814ffd6b8cd62844f6af056a81f7ec0ba5cf23fce27"` | Docker image tag for the `pgsql-exporter` image |
 | postgresExporter.image.name | string | `"postgres_exporter"` | Docker image name for the `pgsql-exporter` image |
 | postgresExporter.resources | object | `{"limits":{"cpu":"10m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Resource requests & limits for the `pgsql-exporter` sidecar container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -270,6 +277,7 @@ In addition to the documented values, all services also support the following va
 | prometheus.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount |
 | prometheus.serviceAccount.name | string | `"prometheus"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | prometheus.storageSize | string | `"200Gi"` | PVC Storage Request for `prometheus` data volume |
+| prometheus.storageSubPath | string | `""` | Optional subPath for the `prometheus` primary data volume mount |
 | redisCache.connection.endpoint | string | `"redis-cache:6379"` | Endpoint to use for redis-cache. Supports either host:port or IANA specification |
 | redisCache.connection.existingSecret | string | `""` | Name of existing secret to use for Redis endpoint The secret must contain the key `endpoint` and should follow IANA specification learn more from the [Helm docs](https://docs.sourcegraph.com/admin/install/kubernetes/helm#using-external-redis-instances) |
 | redisCache.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsUser":999}` | Security context for the `redis-cache` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
@@ -282,6 +290,7 @@ In addition to the documented values, all services also support the following va
 | redisCache.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `redis-cache` |
 | redisCache.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | redisCache.storageSize | string | `"100Gi"` | PVC Storage Request for `redis-cache` data volume |
+| redisCache.storageSubPath | string | `""` | Optional subPath for the `redis-cache` primary data volume mount |
 | redisExporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsUser":999}` | Security context for the `redis-exporter` sidecar container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | redisExporter.image.defaultTag | string | `"6.0.0@sha256:b2ec48fc6adef31f36d525170138dec303c1c0c20c530d659f1fb7c6c54698af"` | Docker image tag for the `redis-exporter` image |
 | redisExporter.image.name | string | `"redis_exporter"` | Docker image name for the `redis-exporter` image |
@@ -298,6 +307,7 @@ In addition to the documented values, all services also support the following va
 | redisStore.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `redis-store` |
 | redisStore.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | redisStore.storageSize | string | `"100Gi"` | PVC Storage Request for `redis-store` data volume |
+| redisStore.storageSubPath | string | `""` | Optional subPath for the `redis-store` primary data volume mount |
 | searcher.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | searcher.image.defaultTag | string | `"6.0.0@sha256:c7508abda2202d4a33400ce23a95dd8d59fe6220d85d7fbee6fb186c55931336"` | Docker image tag for the `searcher` image |
 | searcher.image.name | string | `"searcher"` | Docker image name for the `searcher` image |
@@ -308,6 +318,7 @@ In addition to the documented values, all services also support the following va
 | searcher.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `searcher` |
 | searcher.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | searcher.storageSize | string | `"26Gi"` | Size of the PVC for searcher pods to store cache data |
+| searcher.storageSubPath | string | `""` | Optional subPath for the `searcher` primary data volume mount |
 | sgTestConnection | object | `{"enabled":true}` | Enable the busybox connection test after deployment |
 | sourcegraph.affinity | object | `{}` | Global Affinity, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | sourcegraph.disableKubernetesSecrets | bool | `false` | Disable the creation of Kubernetes secrets objects |

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -40,6 +40,7 @@ In addition to the documented values, all services also support the following va
 | blobstore.resources | object | `{"limits":{"cpu":"1","memory":"500M"},"requests":{"cpu":"1","memory":"500M"}}` | Resource requests & limits for the `blobstore` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | blobstore.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `blobstore` |
 | blobstore.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| blobstore.storageAnnotations | object | `{}` | Optional annotations to add to the `blobstore` PVC |
 | blobstore.storageSize | string | `"100Gi"` | PVC Storage Request for `blobstore` data volume |
 | blobstore.storageSubPath | string | `""` | Optional subPath for the `blobstore` primary data volume mount |
 | cadvisor.containerSecurityContext | object | `{"privileged":true}` | Security context for the `cadvisor` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
@@ -72,6 +73,7 @@ In addition to the documented values, all services also support the following va
 | codeInsightsDB.resources | object | `{"limits":{"cpu":"4","memory":"2Gi"},"requests":{"cpu":"4","memory":"2Gi"}}` | Resource requests & limits for the `codeinsights-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | codeInsightsDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeinsights-db` |
 | codeInsightsDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| codeInsightsDB.storageAnnotations | object | `{}` | Optional annotations to add to the `codeinsights-db` PVC |
 | codeInsightsDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeinsights-db` data volume |
 | codeInsightsDB.storageSubPath | string | `""` | Optional subPath for the `codeinsights-db` primary data volume mount |
 | codeIntelDB.additionalConfig | string | `""` | Additional PostgreSQL configuration. This will override or extend our default configuration. Notes: This is expecting a multiline string. Learn more from our [recommended PostgreSQL configuration](https://docs.sourcegraph.com/admin/config/postgres-conf) and [PostgreSQL documentation](https://www.postgresql.org/docs/12/config-setting.html) |
@@ -93,6 +95,7 @@ In addition to the documented values, all services also support the following va
 | codeIntelDB.resources | object | `{"limits":{"cpu":"4","memory":"4Gi"},"requests":{"cpu":"4","memory":"4Gi"}}` | Resource requests & limits for the `codeintel-db` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | codeIntelDB.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `codeintel-db` |
 | codeIntelDB.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| codeIntelDB.storageAnnotations | object | `{}` | Optional annotations to add to the `codeintel-db` PVC |
 | codeIntelDB.storageSize | string | `"200Gi"` | PVC Storage Request for `codeintel-db` data volume |
 | codeIntelDB.storageSubPath | string | `""` | Optional subPath for the `codeintel-db` primary data volume mount |
 | extraResources | list | `[]` | Additional resources to include in the rendered manifest. Templates are supported. |
@@ -126,6 +129,7 @@ In addition to the documented values, all services also support the following va
 | gitserver.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `gitserver` |
 | gitserver.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | gitserver.sshSecret | string | `""` | Name of existing Secret that contains SSH credentials to clone repositories. It usually contains keys, such as `id_rsa` (private key) and `known_hosts`. Learn more from [documentation](https://docs.sourcegraph.com/admin/install/kubernetes/helm#using-ssh-to-clone-repositories) |
+| gitserver.storageAnnotations | object | `{}` | Optional annotations to add to the `gitserver` PVC |
 | gitserver.storageSize | string | `"200Gi"` | PVC Storage Request for `gitserver` data volume |
 | gitserver.storageSubPath | string | `""` | Optional subPath for the `gitserver` primary data volume mount |
 | grafana.auth | object | `{"database":"","existingSecret":"","host":"","password":"","port":"","sslmode":"","user":""}` | NOTE: Create a separate user in the pgsql database with read-only perms on the minimum set of tables |
@@ -146,6 +150,7 @@ In addition to the documented values, all services also support the following va
 | grafana.resources | object | `{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"100m","memory":"512Mi"}}` | Resource requests & limits for the `grafana` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | grafana.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `grafana` |
 | grafana.serviceAccount.name | string | `"grafana"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| grafana.storageAnnotations | object | `{}` | Optional annotations to add to the `grafana` PVC |
 | grafana.storageSize | string | `"2Gi"` | PVC Storage Request for `grafana` data volume |
 | grafana.storageSubPath | string | `""` | Optional subPath for the `grafana` primary data volume mount |
 | indexedSearch.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `zoekt-webserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
@@ -157,6 +162,7 @@ In addition to the documented values, all services also support the following va
 | indexedSearch.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `zoekt-webserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | indexedSearch.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `indexed-search` |
 | indexedSearch.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| indexedSearch.storageAnnotations | object | `{}` | Optional annotations to add to the `indexed-search` PVC |
 | indexedSearch.storageSize | string | `"200Gi"` | PVC Storage Request for `indexed-search` data volume The size of disk to used for search indexes. This should typically be gitserver disk size multipled by the number of gitserver shards. |
 | indexedSearch.storageSubPath | string | `""` | Optional subPath for the `indexed-search` primary data volume mount |
 | indexedSearchIndexer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `zoekt-indexserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
@@ -248,6 +254,7 @@ In addition to the documented values, all services also support the following va
 | pgsql.resources | object | `{"limits":{"cpu":"4","memory":"4Gi"},"requests":{"cpu":"4","memory":"4Gi"}}` | Resource requests & limits for the `pgsql` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | pgsql.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `pgsql` |
 | pgsql.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| pgsql.storageAnnotations | object | `{}` | Optional annotations to add to the `pgsql` PVC |
 | pgsql.storageSize | string | `"200Gi"` | PVC Storage Request for `pgsql` data volume |
 | pgsql.storageSubPath | string | `""` | Optional subPath for the `pgsql` primary data volume mount |
 | postgresExporter.image.defaultTag | string | `"6.0.0@sha256:685a18f482e4a71a54e15814ffd6b8cd62844f6af056a81f7ec0ba5cf23fce27"` | Docker image tag for the `pgsql-exporter` image |
@@ -276,6 +283,7 @@ In addition to the documented values, all services also support the following va
 | prometheus.resources | object | `{"limits":{"cpu":"2","memory":"6G"},"requests":{"cpu":"500m","memory":"6G"}}` | Resource requests & limits for the `prometheus` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) Prometheus is relied upon to monitor services for sending alerts to site admins when something is wrong with Sourcegraph, thus its memory requests and limits are the same to guarantee it has enough memory to perform its job reliably and prevent conflicts with other pods on the same host node. The limit chosen here is based on what works reliably on Sourcegraph.com with lots of traffic. |
 | prometheus.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount |
 | prometheus.serviceAccount.name | string | `"prometheus"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| prometheus.storageAnnotations | object | `{}` | Optional annotations to add to the `prometheus` PVC |
 | prometheus.storageSize | string | `"200Gi"` | PVC Storage Request for `prometheus` data volume |
 | prometheus.storageSubPath | string | `""` | Optional subPath for the `prometheus` primary data volume mount |
 | redisCache.connection.endpoint | string | `"redis-cache:6379"` | Endpoint to use for redis-cache. Supports either host:port or IANA specification |
@@ -289,6 +297,7 @@ In addition to the documented values, all services also support the following va
 | redisCache.resources | object | `{"limits":{"cpu":"1","memory":"7Gi"},"requests":{"cpu":"1","memory":"7Gi"}}` | Resource requests & limits for the `redis-cache` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | redisCache.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `redis-cache` |
 | redisCache.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| redisCache.storageAnnotations | object | `{}` | Optional annotations to add to the `redis-cache` PVC |
 | redisCache.storageSize | string | `"100Gi"` | PVC Storage Request for `redis-cache` data volume |
 | redisCache.storageSubPath | string | `""` | Optional subPath for the `redis-cache` primary data volume mount |
 | redisExporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsUser":999}` | Security context for the `redis-exporter` sidecar container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
@@ -306,6 +315,7 @@ In addition to the documented values, all services also support the following va
 | redisStore.resources | object | `{"limits":{"cpu":"1","memory":"7Gi"},"requests":{"cpu":"1","memory":"7Gi"}}` | Resource requests & limits for the `redis-store` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | redisStore.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `redis-store` |
 | redisStore.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| redisStore.storageAnnotations | object | `{}` | Optional annotations to add to the `redis-store` PVC |
 | redisStore.storageSize | string | `"100Gi"` | PVC Storage Request for `redis-store` data volume |
 | redisStore.storageSubPath | string | `""` | Optional subPath for the `redis-store` primary data volume mount |
 | searcher.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
@@ -317,6 +327,7 @@ In addition to the documented values, all services also support the following va
 | searcher.resources | object | `{"limits":{"cpu":"2","memory":"2G"},"requests":{"cpu":"500m","memory":"500M"}}` | Resource requests & limits for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | searcher.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `searcher` |
 | searcher.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
+| searcher.storageAnnotations | object | `{}` | Optional annotations to add to the `searcher` PVC |
 | searcher.storageSize | string | `"26Gi"` | Size of the PVC for searcher pods to store cache data |
 | searcher.storageSubPath | string | `""` | Optional subPath for the `searcher` primary data volume mount |
 | sgTestConnection | object | `{"enabled":true}` | Enable the busybox connection test after deployment |

--- a/charts/sourcegraph/templates/blobstore/blobstore.Deployment.yaml
+++ b/charts/sourcegraph/templates/blobstore/blobstore.Deployment.yaml
@@ -80,6 +80,9 @@ spec:
         volumeMounts:
         - name: blobstore-data
           mountPath: /data
+          {{- if .Values.blobstore.storageSubPath }}
+          subPath: {{ .Values.blobstore.storageSubPath }}
+          {{- end }}
         - name: blobstore
           mountPath: /blobstore
         {{- if .Values.blobstore.extraVolumeMounts }}

--- a/charts/sourcegraph/templates/blobstore/blobstore.PersistentVolumeClaim.yaml
+++ b/charts/sourcegraph/templates/blobstore/blobstore.PersistentVolumeClaim.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     deploy: sourcegraph
     app.kubernetes.io/component: blobstore
+  {{- if .Values.blobstore.storageAnnotations }}
+  annotations:
+    {{- toYaml .Values.blobstore.storageAnnotations | nindent 4 }}
+  {{- end }}
   name: blobstore
 spec:
   accessModes:

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.PersistentVolumeClaim.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.PersistentVolumeClaim.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
+  {{- if .Values.codeInsightsDB.storageAnnotations }}
+  annotations:
+    {{- toYaml .Values.codeInsightsDB.storageAnnotations | nindent 4 }}
+  {{- end }}
   name: codeinsights-db
 spec:
   accessModes:

--- a/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -51,6 +51,9 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/postgresql/data/
           name: disk
+          {{- if .Values.codeInsightsDB.storageSubPath }}
+          subPath: {{ .Values.codeInsightsDB.storageSubPath }}
+          {{- end }}
         securityContext:
         {{- toYaml .Values.codeInsightsDB.init.containerSecurityContext | nindent 10 }}
         {{- if not .Values.sourcegraph.localDevMode }}
@@ -90,6 +93,9 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/postgresql/data/
           name: disk
+          {{- if .Values.codeInsightsDB.storageSubPath }}
+          subPath: {{ .Values.codeInsightsDB.storageSubPath }}
+          {{- end }}
         - mountPath: /conf
           name: codeinsights-conf
         - mountPath: /var/run/postgresql

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.PersistentVolumeClaim.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.PersistentVolumeClaim.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/component: codeintel-db
     deploy: sourcegraph
+  {{- if .Values.codeIntelDB.storageAnnotations }}
+  annotations:
+    {{- toYaml .Values.codeIntelDB.storageAnnotations | nindent 4 }}
+  {{- end }}
   name: {{ default "codeintel-db" .Values.codeIntelDB.name }}
 spec:
   accessModes:

--- a/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -51,6 +51,9 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: disk
+          {{- if .Values.codeIntelDB.storageSubPath }}
+          subPath: {{ .Values.codeIntelDB.storageSubPath }}
+          {{- end }}
         securityContext:
         {{- toYaml .Values.alpine.containerSecurityContext | nindent 10 }}
         {{- if not .Values.sourcegraph.localDevMode }}
@@ -101,6 +104,9 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: disk
+          {{- if .Values.codeIntelDB.storageSubPath }}
+          subPath: {{ .Values.codeIntelDB.storageSubPath }}
+          {{- end }}
         - mountPath: /conf
           name: pgsql-conf
         - mountPath: /var/run/postgresql

--- a/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -85,6 +85,9 @@ spec:
           name: tmpdir
         - mountPath: /data/repos
           name: repos
+          {{- if .Values.gitserver.storageSubPath }}
+          subPath: {{ .Values.gitserver.storageSubPath }}
+          {{- end }}
         {{- if .Values.gitserver.sshSecret }}
         - mountPath: /home/sourcegraph/.ssh
           name: ssh

--- a/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -127,6 +127,10 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: repos
+      {{- if .Values.gitserver.storageAnnotations }}
+      annotations:
+        {{- toYaml .Values.gitserver.storageAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       accessModes:
       - ReadWriteOnce

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -65,6 +65,9 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/grafana
           name: grafana-data
+          {{- if .Values.grafana.storageSubPath }}
+          subPath: {{ .Values.grafana.storageSubPath }}
+          {{- end }}
         - mountPath: /sg_config_grafana/provisioning/datasources
           name: config
         # Grafana is relied upon to send alerts to site admins when something is wrong with

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -108,6 +108,10 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: grafana-data
+      {{- if .Values.grafana.storageAnnotations }}
+      annotations:
+        {{- toYaml .Values.grafana.storageAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce"]
       resources:

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -153,6 +153,10 @@ spec:
       labels:
         deploy: sourcegraph
       name: data
+      {{- if .Values.indexedSearch.storageAnnotations }}
+      annotations:
+        {{- toYaml .Values.indexedSearch.storageAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       accessModes:
       - ReadWriteOnce

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.StatefulSet.yaml
@@ -89,6 +89,9 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: data
+          {{- if .Values.indexedSearch.storageSubPath }}
+          subPath: {{ .Values.indexedSearch.storageSubPath }}
+          {{- end }}
         {{- if .Values.indexedSearch.extraVolumeMounts }}
         {{- toYaml .Values.indexedSearch.extraVolumeMounts | nindent 8 }}
         {{- end }}
@@ -118,6 +121,9 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: data
+          {{- if .Values.indexedSearch.storageSubPath }}
+          subPath: {{ .Values.indexedSearch.storageSubPath }}
+          {{- end }}
         {{- if .Values.indexedSearchIndexer.extraVolumeMounts }}
         {{- toYaml .Values.indexedSearchIndexer.extraVolumeMounts | nindent 8 }}
         {{- end }}

--- a/charts/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     deploy: sourcegraph
     app.kubernetes.io/component: pgsql
+  {{- if .Values.pgsql.storageAnnotations }}
+  annotations:
+    {{- toYaml .Values.pgsql.storageAnnotations | nindent 4 }}
+  {{- end }}
   name: pgsql
 spec:
   accessModes:

--- a/charts/sourcegraph/templates/pgsql/pgsql.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/pgsql/pgsql.StatefulSet.yaml
@@ -51,6 +51,9 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: disk
+          {{- if .Values.pgsql.storageSubPath }}
+          subPath: {{ .Values.pgsql.storageSubPath }}
+          {{- end }}
         securityContext:
         {{- toYaml .Values.alpine.containerSecurityContext | nindent 10 }}
         {{- if not .Values.sourcegraph.localDevMode }}
@@ -101,6 +104,9 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: disk
+          {{- if .Values.pgsql.storageSubPath }}
+          subPath: {{ .Values.pgsql.storageSubPath }}
+          {{- end }}
         - mountPath: /conf
           name: pgsql-conf
         - mountPath: /dev/shm

--- a/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -70,6 +70,9 @@ spec:
         volumeMounts:
         - mountPath: /prometheus
           name: data
+          {{- if .Values.prometheus.storageSubPath }}
+          subPath: {{ .Values.prometheus.storageSubPath }}
+          {{- end }}
         - mountPath: /sg_prometheus_add_ons
           name: config
         {{- if .Values.prometheus.extraVolumeMounts }}

--- a/charts/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     deploy: sourcegraph
     app.kubernetes.io/component: prometheus
+  {{- if .Values.prometheus.storageAnnotations }}
+  annotations:
+    {{- toYaml .Values.prometheus.storageAnnotations | nindent 4 }}
+  {{- end }}
   name: prometheus
 spec:
   accessModes:

--- a/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -97,6 +97,9 @@ spec:
         volumeMounts:
         - mountPath: /redis-data
           name: redis-data
+          {{- if .Values.redisCache.storageSubPath }}
+          subPath: {{ .Values.redisCache.storageSubPath }}
+          {{- end }}
         {{- if .Values.redisCache.extraVolumeMounts }}
         {{- toYaml .Values.redisCache.extraVolumeMounts | nindent 8 }}
         {{- end }}

--- a/charts/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     deploy: sourcegraph
     app.kubernetes.io/component: redis
+  {{- if .Values.redisCache.storageAnnotations }}
+  annotations:
+    {{- toYaml .Values.redisCache.storageAnnotations | nindent 4 }}
+  {{- end }}
   name: redis-cache
 spec:
   accessModes:

--- a/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -96,6 +96,9 @@ spec:
         volumeMounts:
         - mountPath: /redis-data
           name: redis-data
+          {{- if .Values.redisStore.storageSubPath }}
+          subPath: {{ .Values.redisStore.storageSubPath }}
+          {{- end }}
         {{- if .Values.redisStore.extraVolumeMounts }}
         {{- toYaml .Values.redisStore.extraVolumeMounts | nindent 8 }}
         {{- end }}

--- a/charts/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     deploy: sourcegraph
     app.kubernetes.io/component: redis
+  {{- if .Values.redisStore.storageAnnotations }}
+  annotations:
+    {{- toYaml .Values.redisStore.storageAnnotations | nindent 4 }}
+  {{- end }}
   name: redis-store
 spec:
   accessModes:

--- a/charts/sourcegraph/templates/searcher/searcher.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.StatefulSet.yaml
@@ -99,6 +99,9 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache
+          {{- if .Values.searcher.storageSubPath }}
+          subPath: {{ .Values.searcher.storageSubPath }}
+          {{- end }}
         - mountPath: /tmp
           name: tmpdir
         {{- if .Values.searcher.extraVolumeMounts }}

--- a/charts/sourcegraph/templates/searcher/searcher.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.StatefulSet.yaml
@@ -138,6 +138,10 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: cache
+      {{- if .Values.searcher.storageAnnotations }}
+      annotations:
+        {{- toYaml .Values.searcher.storageAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       accessModes:
       - ReadWriteOnce

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -225,6 +225,8 @@ codeInsightsDB:
     name: ""
   # -- PVC Storage Request for `codeinsights-db` data volume
   storageSize: 200Gi
+  # -- Optional subPath for the `codeinsights-db` primary data volume mount
+  storageSubPath: ""
 
 codeIntelDB:
   # -- Enable `codeintel-db` PostgreSQL server
@@ -290,6 +292,8 @@ codeIntelDB:
     name: ""
   # -- PVC Storage Request for `codeintel-db` data volume
   storageSize: 200Gi
+  # -- Optional subPath for the `codeintel-db` primary data volume mount
+  storageSubPath: ""
 
 frontend:
   # -- Environment variables for the `frontend` container
@@ -446,6 +450,8 @@ gitserver:
     name: ""
   # -- PVC Storage Request for `gitserver` data volume
   storageSize: 200Gi
+  # -- Optional subPath for the `gitserver` primary data volume mount
+  storageSubPath: ""
 
 grafana:
   # -- Enable `grafana` dashboard (recommended)
@@ -508,6 +514,8 @@ grafana:
     name: grafana
   # -- PVC Storage Request for `grafana` data volume
   storageSize: 2Gi
+  # -- Optional subPath for the `grafana` primary data volume mount
+  storageSubPath: ""
 
 indexedSearch:
   image:
@@ -549,6 +557,8 @@ indexedSearch:
   # The size of disk to used for search indexes.
   # This should typically be gitserver disk size multipled by the number of gitserver shards.
   storageSize: 200Gi
+  # -- Optional subPath for the `indexed-search` primary data volume mount
+  storageSubPath: ""
 
 indexedSearchIndexer:
   image:
@@ -614,6 +624,8 @@ blobstore:
     name: ""
   # -- PVC Storage Request for `blobstore` data volume
   storageSize: 100Gi
+  # -- Optional subPath for the `blobstore` primary data volume mount
+  storageSubPath: ""
 
 openTelemetry:
   enabled: true
@@ -795,6 +807,8 @@ pgsql:
     name: ""
   # -- PVC Storage Request for `pgsql` data volume
   storageSize: 200Gi
+  # -- Optional subPath for the `pgsql` primary data volume mount
+  storageSubPath: ""
 
 postgresExporter:
   image:
@@ -943,6 +957,8 @@ prometheus:
     name: prometheus
   # -- PVC Storage Request for `prometheus` data volume
   storageSize: 200Gi
+  # -- Optional subPath for the `prometheus` primary data volume mount
+  storageSubPath: ""
 
 redisCache:
   # -- Enable `redis-cache` Redis server
@@ -989,6 +1005,8 @@ redisCache:
     name: ""
   # -- PVC Storage Request for `redis-cache` data volume
   storageSize: 100Gi
+  # -- Optional subPath for the `redis-cache` primary data volume mount
+  storageSubPath: ""
 
 redisExporter:
   image:
@@ -1058,6 +1076,8 @@ redisStore:
     name: ""
   # -- PVC Storage Request for `redis-store` data volume
   storageSize: 100Gi
+  # -- Optional subPath for the `redis-store` primary data volume mount
+  storageSubPath: ""
 
 searcher:
   image:
@@ -1098,6 +1118,8 @@ searcher:
     name: ""
   # -- Size of the PVC for searcher pods to store cache data
   storageSize: 26Gi
+  # -- Optional subPath for the `searcher` primary data volume mount
+  storageSubPath: ""
 
 storageClass:
   # -- Enable creation of storageClass.

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -227,6 +227,8 @@ codeInsightsDB:
   storageSize: 200Gi
   # -- Optional subPath for the `codeinsights-db` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `codeinsights-db` PVC
+  storageAnnotations: {}
 
 codeIntelDB:
   # -- Enable `codeintel-db` PostgreSQL server
@@ -294,6 +296,8 @@ codeIntelDB:
   storageSize: 200Gi
   # -- Optional subPath for the `codeintel-db` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `codeintel-db` PVC
+  storageAnnotations: {}
 
 frontend:
   # -- Environment variables for the `frontend` container
@@ -452,6 +456,8 @@ gitserver:
   storageSize: 200Gi
   # -- Optional subPath for the `gitserver` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `gitserver` PVC
+  storageAnnotations: {}
 
 grafana:
   # -- Enable `grafana` dashboard (recommended)
@@ -516,6 +522,8 @@ grafana:
   storageSize: 2Gi
   # -- Optional subPath for the `grafana` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `grafana` PVC
+  storageAnnotations: {}
 
 indexedSearch:
   image:
@@ -559,6 +567,8 @@ indexedSearch:
   storageSize: 200Gi
   # -- Optional subPath for the `indexed-search` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `indexed-search` PVC
+  storageAnnotations: {}
 
 indexedSearchIndexer:
   image:
@@ -626,6 +636,8 @@ blobstore:
   storageSize: 100Gi
   # -- Optional subPath for the `blobstore` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `blobstore` PVC
+  storageAnnotations: {}
 
 openTelemetry:
   enabled: true
@@ -809,6 +821,8 @@ pgsql:
   storageSize: 200Gi
   # -- Optional subPath for the `pgsql` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `pgsql` PVC
+  storageAnnotations: {}
 
 postgresExporter:
   image:
@@ -959,6 +973,8 @@ prometheus:
   storageSize: 200Gi
   # -- Optional subPath for the `prometheus` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `prometheus` PVC
+  storageAnnotations: {}
 
 redisCache:
   # -- Enable `redis-cache` Redis server
@@ -1007,6 +1023,8 @@ redisCache:
   storageSize: 100Gi
   # -- Optional subPath for the `redis-cache` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `redis-cache` PVC
+  storageAnnotations: {}
 
 redisExporter:
   image:
@@ -1078,6 +1096,8 @@ redisStore:
   storageSize: 100Gi
   # -- Optional subPath for the `redis-store` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `redis-store` PVC
+  storageAnnotations: {}
 
 searcher:
   image:
@@ -1120,6 +1140,8 @@ searcher:
   storageSize: 26Gi
   # -- Optional subPath for the `searcher` primary data volume mount
   storageSubPath: ""
+  # -- Optional annotations to add to the `searcher` PVC
+  storageAnnotations: {}
 
 storageClass:
   # -- Enable creation of storageClass.


### PR DESCRIPTION
Adding two additional PVC configuration options for the `sourcegraph/sourcegraph` helm chart for all stateful services:
- `storageSubPath`: allows mounting a subdirectory of a volume by setting the `subPath` on the primary data volume mount for each stateful service
- `storageAnnotations`: allows setting arbitrary annotations on PVC resources, for both standalone PersistentVolumeClaim resources and StatefulSet `volumeClaimTemplates` sections
### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

CI