### PR TITLE
Add conditional internal registry port (5000) to frontend service

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -112,6 +112,7 @@ In addition to the documented values, all services also support the following va
 | frontend.ingress.ingressClassName | string | `nil` | IngressClassName for the Ingress (Available in Kubernetes 1.18+) If you set this field, set the annotation `frontend.ingress.annotations."kubernetes.io/ingress.class"` to `null` |
 | frontend.ingress.tls | list | `[]` | Full TLS configuration for the ingress. Supersedes `tlsSecret` if set. Cannot be set together with `tlsSecret`. Omit `secretName` for controllers that manage certificates themselves (e.g. Tailscale). Example: tls:   - hosts:       - sourcegraph.example.com     secretName: sourcegraph-tls  # optional |
 | frontend.ingress.tlsSecret | string | `""` | Secret containing TLS cert. Cannot be set together with `tls`. |
+| frontend.internalRegistry.enabled | bool | `false` | Enable internal OCI registry port (5000) on frontend service |
 | frontend.name | string | `"sourcegraph-frontend"` | Name used by resources. Does not affect service names or PVCs. |
 | frontend.podSecurityContext | object | `{}` | Security context for the `frontend` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | frontend.privileged | bool | `true` | Enable creation of Role and RoleBinding (RBAC). Uses [view](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) ClusterRole if set to false |

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -125,6 +125,10 @@ spec:
           containerPort: 3080
         - name: http-debug
           containerPort: 6060
+        {{- if .Values.frontend.internalRegistry.enabled }}
+        - name: registry
+          containerPort: 5000
+        {{- end }}
         {{- if not .Values.sourcegraph.localDevMode }}
         resources:
           {{- toYaml .Values.frontend.resources | nindent 10 }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -126,7 +126,7 @@ spec:
         - name: http-debug
           containerPort: 6060
         {{- if .Values.frontend.internalRegistry.enabled }}
-        - name: registry
+        - name: http-registry
           containerPort: 5000
         {{- end }}
         {{- if not .Values.sourcegraph.localDevMode }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -24,9 +24,9 @@ spec:
     port: 6060
     targetPort: http-debug
   {{- if .Values.frontend.internalRegistry.enabled }}
-  - name: registry
+  - name: http-registry
     port: 5000
-    targetPort: registry
+    targetPort: http-registry
   {{- end }}
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}

--- a/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -23,6 +23,11 @@ spec:
   - name: http-debug
     port: 6060
     targetPort: http-debug
+  {{- if .Values.frontend.internalRegistry.enabled }}
+  - name: registry
+    port: 5000
+    targetPort: registry
+  {{- end }}
   selector:
     {{- include "sourcegraph.selectorLabels" . | nindent 4 }}
     app: sourcegraph-frontend

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -381,6 +381,10 @@ frontend:
     create: true
     # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: sourcegraph-frontend
+  # Internal registry configuration
+  internalRegistry:
+    # -- Enable internal OCI registry port (5000) on frontend service
+    enabled: false
 
 migrator:
   # -- Enable [migrator](https://docs.sourcegraph.com/admin/how-to/manual_database_migrations) initContainer in


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/12621

## Summary

- Adds `frontend.internalRegistry.enabled` configuration option to conditionally expose port 5000 on the frontend service
- Exposes port as a named port "registry" on both the Service and Deployment
- Supports the internal OCI image registry backed by blobstore for batch changes

## Context

This change enables exposing the internal image registry (go-containerregistry) running on port 5000 from the frontend service. This is needed to support batch changes that can build OCI images and publish them to an internal registry.

Slack thread: https://sourcegraph.slack.com/archives/C0A7PV1600P/p1779463759092779?thread_ts=1779268068.208029&cid=C0A7PV1600P

## Usage

To enable the internal registry port:

```yaml
frontend:
  internalRegistry:
    enabled: true
```

## Test plan

- [ ] Verify helm template renders correctly with `internalRegistry.enabled: false` (default)
- [ ] Verify helm template renders the registry port with `internalRegistry.enabled: true`
- [ ] Verify helm-docs generates correct documentation

https://claude.ai/code/session_016dk2KH5aCME6dzGTuyQzoG

---
_Generated by [Claude Code](https://claude.ai/code/session_016dk2KH5aCME6dzGTuyQzoG)_