### PR TITLE
docs: add beta warnings for Kubernetes native executor deployment options

### DIFF
--- a/charts/sourcegraph-executor/README.md
+++ b/charts/sourcegraph-executor/README.md
@@ -3,7 +3,13 @@
 This directory contains two Helm charts for deploying executors on Kubernetes. [See the docs](https://docs.sourcegraph.com/admin/executors/deploy_executors_kubernetes) for more information on executors on Kubernetes.
 
 ## Native Kubernetes (k8s)
-This chart deploys executors that interact with the Kubernetes API to handle jobs. This is the preferred deployment option.  
+This chart deploys executors that interact with the Kubernetes API to handle jobs.
+
+> ⚠️ **Beta:** Native Kubernetes executors are not recommended for production use. This deployment
+> mode has known durability and reliability limitations. For production workloads, deploy using
+> [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform) or the
+> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary) instead.
+
 Your cluster will need to allow configuration of the following RBAC rules:
 
 | API Groups | Resources          | Verbs                     | Reason                                                                                    |
@@ -12,5 +18,10 @@ Your cluster will need to allow configuration of the following RBAC rules:
 |            | `pods`, `pods/log` | `get`, `list`, `watch`    | Executors need to look up and steam logs from the Job Pods.                               |
 
 ## Docker in Docker (dind)
-This chart deploys executors that deploy a [Docker in Docker](https://www.docker.com/blog/docker-can-now-run-within-docker/) sidecar with each executor pod to avoid accessing the host container runtime directly. This method requires privileged access to a container runtime daemon in order to operate correctly.  
-If you have security concerns, consider deploying via [a non-Kubernetes method](https://docs.sourcegraph.com/admin/executors).
+
+> ⚠️ **Beta:** Docker-in-Docker Kubernetes executors are not recommended for production use.
+> This method requires privileged access to a container runtime daemon and does not use Firecracker
+> isolation. For production workloads, consider a
+> [non-Kubernetes method](https://docs.sourcegraph.com/admin/executors).
+
+This chart deploys executors that deploy a [Docker in Docker](https://www.docker.com/blog/docker-can-now-run-within-docker/) sidecar with each executor pod to avoid accessing the host container runtime directly. This method requires privileged access to a container runtime daemon in order to operate correctly.

--- a/charts/sourcegraph-executor/README.md
+++ b/charts/sourcegraph-executor/README.md
@@ -5,10 +5,9 @@ This directory contains two Helm charts for deploying executors on Kubernetes. [
 ## Native Kubernetes (k8s)
 This chart deploys executors that interact with the Kubernetes API to handle jobs.
 
-> ⚠️ **Beta:** Native Kubernetes executors are not recommended for production use. This deployment
-> mode has known durability and reliability limitations. For production workloads, deploy using
+> ⚠️ **Beta:** Native Kubernetes executors are in beta. For production workloads, consider deploying using
 > [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform) or the
-> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary) instead.
+> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary) for better long-term support.
 
 Your cluster will need to allow configuration of the following RBAC rules:
 

--- a/charts/sourcegraph-executor/dind/README.md
+++ b/charts/sourcegraph-executor/dind/README.md
@@ -5,7 +5,13 @@
 
 # Sourcegraph Executor Helm Chart
 
-This chart contains two deployments, Sourcegraph Executors and a private Docker Registry. It is a supplemental chart for the parent [sourcegraph/sourcegraph] Helm Chart if you wish to deploy executors
+This chart contains two deployments, Sourcegraph Executors and a private Docker Registry. It is a supplemental chart for the parent [sourcegraph/sourcegraph] Helm Chart if you wish to deploy executors.
+
+> ⚠️ **Beta:** Docker-in-Docker Kubernetes executors are not recommended for production use.
+> This method requires privileged access to a container runtime daemon. For production workloads,
+> consider deploying via
+> [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform) or
+> [binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary).
 
 Use cases:
 

--- a/charts/sourcegraph-executor/dind/README.md.gotmpl
+++ b/charts/sourcegraph-executor/dind/README.md.gotmpl
@@ -5,7 +5,13 @@
 
 # Sourcegraph Executor Helm Chart
 
-This chart contains two deployments, Sourcegraph Executors and a private Docker Registry. It is a supplemental chart for the parent [sourcegraph/sourcegraph] Helm Chart if you wish to deploy executors
+This chart contains two deployments, Sourcegraph Executors and a private Docker Registry. It is a supplemental chart for the parent [sourcegraph/sourcegraph] Helm Chart if you wish to deploy executors.
+
+> ⚠️ **Beta:** Docker-in-Docker Kubernetes executors are not recommended for production use.
+> This method requires privileged access to a container runtime daemon. For production workloads,
+> consider deploying via
+> [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform) or
+> [binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary).
 
 Use cases:
 

--- a/charts/sourcegraph-executor/k8s/README.md
+++ b/charts/sourcegraph-executor/k8s/README.md
@@ -7,6 +7,12 @@
 
 This chart contains two deployments, Sourcegraph Kubernetes native Executors and a private Docker Registry. It is a supplemental chart for the parent [sourcegraph/sourcegraph] Helm Chart if you wish to deploy Kubernetes native executors.
 
+> ⚠️ **Beta:** Native Kubernetes executors are not recommended for production use. This deployment
+> mode has known durability and reliability limitations including job loss on node failure and
+> best-effort resource cleanup. For production workloads, deploy using
+> [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform) or the
+> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary).
+
 Use cases:
 
 - Deploy Sourcegraph Kubernetes native Executors on Kubernetes

--- a/charts/sourcegraph-executor/k8s/README.md
+++ b/charts/sourcegraph-executor/k8s/README.md
@@ -7,11 +7,9 @@
 
 This chart contains two deployments, Sourcegraph Kubernetes native Executors and a private Docker Registry. It is a supplemental chart for the parent [sourcegraph/sourcegraph] Helm Chart if you wish to deploy Kubernetes native executors.
 
-> ⚠️ **Beta:** Native Kubernetes executors are not recommended for production use. This deployment
-> mode has known durability and reliability limitations including job loss on node failure and
-> best-effort resource cleanup. For production workloads, deploy using
+> ⚠️ **Beta:** Native Kubernetes executors are in beta. For production workloads, consider deploying using
 > [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform) or the
-> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary).
+> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary) for better long-term support.
 
 Use cases:
 

--- a/charts/sourcegraph-executor/k8s/README.md.gotmpl
+++ b/charts/sourcegraph-executor/k8s/README.md.gotmpl
@@ -7,6 +7,12 @@
 
 This chart contains two deployments, Sourcegraph Kubernetes native Executors and a private Docker Registry. It is a supplemental chart for the parent [sourcegraph/sourcegraph] Helm Chart if you wish to deploy Kubernetes native executors.
 
+> ⚠️ **Beta:** Native Kubernetes executors are not recommended for production use. This deployment
+> mode has known durability and reliability limitations including job loss on node failure and
+> best-effort resource cleanup. For production workloads, deploy using
+> [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform) or the
+> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary).
+
 Use cases:
 
 - Deploy Sourcegraph Kubernetes native Executors on Kubernetes

--- a/charts/sourcegraph-executor/k8s/README.md.gotmpl
+++ b/charts/sourcegraph-executor/k8s/README.md.gotmpl
@@ -7,11 +7,9 @@
 
 This chart contains two deployments, Sourcegraph Kubernetes native Executors and a private Docker Registry. It is a supplemental chart for the parent [sourcegraph/sourcegraph] Helm Chart if you wish to deploy Kubernetes native executors.
 
-> ⚠️ **Beta:** Native Kubernetes executors are not recommended for production use. This deployment
-> mode has known durability and reliability limitations including job loss on node failure and
-> best-effort resource cleanup. For production workloads, deploy using
+> ⚠️ **Beta:** Native Kubernetes executors are in beta. For production workloads, consider deploying using
 > [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform) or the
-> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary).
+> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary) for better long-term support.
 
 Use cases:
 


### PR DESCRIPTION
closes PLAT-704

Provide a warning to admins or developers reviewing the k8s-native executors deployment type. These changes are intended to prevent further adoption of a deployment type that may not work with future iteractions sourcegraph and executors