### PR TITLE
dind: make private registry proxy URL configurable

### DIFF
--- a/charts/sourcegraph-executor/dind/README.md
+++ b/charts/sourcegraph-executor/dind/README.md
@@ -88,6 +88,7 @@ In addition to the documented values, the `executor` and `private-docker-registr
 | privateDockerRegistry.image.registry | string | `"index.docker.io"` |  |
 | privateDockerRegistry.image.repository | string | `"registry"` |  |
 | privateDockerRegistry.image.tag | int | `3` |  |
+| privateDockerRegistry.registryProxyRemoteUrl | string | `"https://registry-1.docker.io"` | Remote registry URL used by the private registry pull-through cache. |
 | privateDockerRegistry.storageSize | string | `"10Gi"` |  |
 | queues | list | `[]` | Optional list of queues to deploy as standalone Deployments. When set, the single executor Deployment is not rendered. Each entry supports:   name        (required) — used as the deployment name suffix (executor-<name>)   queueName   — sets EXECUTOR_QUEUE_NAME; defaults to name if omitted   queueNames  — sets EXECUTOR_QUEUE_NAMES (comma-joined); takes precedence over queueName when set   replicaCount, resources, env (merged with executor.env, queue overrides) |
 | sourcegraph.affinity | object | `{}` | Affinity, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |

--- a/charts/sourcegraph-executor/dind/templates/private-docker-registry/private-docker-registry.Statefulset.yaml
+++ b/charts/sourcegraph-executor/dind/templates/private-docker-registry/private-docker-registry.Statefulset.yaml
@@ -46,7 +46,7 @@ spec:
           imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
           env:
             - name: REGISTRY_PROXY_REMOTEURL
-              value: http://registry-1.docker.io
+              value: {{ .Values.privateDockerRegistry.registryProxyRemoteUrl | quote }}
           ports:
             - name: http
               containerPort: 5000

--- a/charts/sourcegraph-executor/dind/values.yaml
+++ b/charts/sourcegraph-executor/dind/values.yaml
@@ -203,6 +203,8 @@ privateDockerRegistry:
   # -- Whether to deploy the private registry. Only one registry is needed when deploying multiple executors.
   # More information: https://docs.sourcegraph.com/admin/executors/deploy_executors#using-private-registries
   enabled: true
+  # -- Remote registry URL used by the private registry pull-through cache.
+  registryProxyRemoteUrl: https://registry-1.docker.io
   image:
     registry: index.docker.io
     repository: registry


### PR DESCRIPTION
- Default value of `REGISTRY_PROXY_REMOTEURL` was `http://registry-1.docker.io`, which prevented the `private-docker-registry-0` from starting. 
- Default needed to be changed to `https`
- Made it configurable, so customers can point this at their internal image registries

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md) 
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

- `./scripts/helm-docs.sh && [[ -z $(git status -s) ]]`
- `helm lint charts/sourcegraph-executor/dind`
  - Passed with the pre-existing empty executor-name warning:
```
[WARNING] templates/executor/executor.Deployment.yaml: object name does not conform to Kubernetes naming requirements: "":
metadata.name: Invalid value: "": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
```
- `helm template sourcegraph-executor charts/sourcegraph-executor/dind --namespace m --show-only templates/private-docker-registry/private-docker-registry.Statefulset.yaml`
  - Verified default renders `REGISTRY_PROXY_REMOTEURL: "https://registry-1.docker.io"`.
- `helm template sourcegraph-executor charts/sourcegraph-executor/dind --namespace m --set privateDockerRegistry.registryProxyRemoteUrl=https://example.test --show-only templates/private-docker-registry/private-docker-registry.Statefulset.yaml`
  - Verified override renders `REGISTRY_PROXY_REMOTEURL: "https://example.test"`.
- `helm template sourcegraph-executor charts/sourcegraph-executor/dind --namespace m --values ../../../default-resource-requests-and-limits.yaml --values ../override.yaml --show-only templates/private-docker-registry/private-docker-registry.Statefulset.yaml`
  - Verified Marc's instance values render `REGISTRY_PROXY_REMOTEURL: "https://registry-1.docker.io"`.
