### PR TITLE
fix(dind): set fsGroup so executor can write to ephemeral scratch volume

### DIFF
--- a/charts/sourcegraph-executor/dind/README.md
+++ b/charts/sourcegraph-executor/dind/README.md
@@ -77,6 +77,7 @@ In addition to the documented values, the `executor` and `private-docker-registr
 | executor.log.level | string | `"warn"` | Possible values are dbug, info, warn, eror, crit. |
 | executor.maximumNumJobs | int | `10` | The maximum amount of jobs that can be executed concurrently. |
 | executor.maximumRuntimePerJob | string | `"30m"` | The maximum wall time that can be spent on a single job. |
+| executor.podSecurityContext | object | `{"fsGroup":101}` | Pod-level security context applied to executor pods. fsGroup: 101 ensures the scratch volume is writable by the sourcegraph user (uid=100, gid=101) when running in Docker mode (dind). Set to {} to disable. |
 | executor.queueName | string | `""` | The name of the queue to pull jobs from. Possible values: batches and codeintel. Either this or queueNames is required (when not using queues). |
 | executor.queueNames | list | `[]` | The names of multiple queues to pull jobs from. Possible values: batches and codeintel. Either this or queueName is required (when not using queues). |
 | executor.replicaCount | int | `1` |  |

--- a/charts/sourcegraph-executor/dind/templates/_helpers.tpl
+++ b/charts/sourcegraph-executor/dind/templates/_helpers.tpl
@@ -181,6 +181,10 @@ spec:
         sourcegraph-resource-requires: no-cluster-admin
         app.kubernetes.io/component: executor
     spec:
+      {{- with $r.Values.executor.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: executor
           image: {{ include "sourcegraph.image" (list $r "executor") }}

--- a/charts/sourcegraph-executor/dind/values.yaml
+++ b/charts/sourcegraph-executor/dind/values.yaml
@@ -127,6 +127,11 @@ executor:
     # -- StorageClass for the ephemeral volume. Only used when type is ephemeral.
     # Defaults to the cluster default StorageClass when empty.
     class: ""
+  # -- Pod-level security context applied to executor pods.
+  # fsGroup: 101 ensures the scratch volume is writable by the sourcegraph user (uid=100, gid=101)
+  # when running in Docker mode (dind). Set to {} to disable.
+  podSecurityContext:
+    fsGroup: 101
 
 dind:
   image:


### PR DESCRIPTION
## Summary

- Add `executor.podSecurityContext` defaulting to `fsGroup: 101` so the `sourcegraph` user (uid=100, gid=101) can write to the `/scratch` volume
- Fixes `permission denied` errors when creating job workspace directories under `/scratch` with ephemeral storage

## Root cause

Executors running in Docker mode (dind) create job workspaces as directories under `$TMPDIR` (`/scratch`). When `storage.type: ephemeral`, the PVC is mounted `root:root 755` — the `sourcegraph` non-root user can't write to it.

This was never hit before because dind executors previously ran in `emptyDir` only, which is not affected

## Test plan

- [x] Deploy with `storage.type: ephemeral` and confirm workspace directories are created without permission errors
- [x] Confirm `emptyDir` deployments are unaffected