### PR TITLE
fix: otel-collector exposes on 0.0.0.0

### DIFF
--- a/charts/sourcegraph/templates/otel-collector/otel-collector.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/otel-collector/otel-collector.ConfigMap.yaml
@@ -14,8 +14,13 @@ data:
     receivers:
       otlp:
         protocols:
-          grpc: # port 4317
-          http: # port 4318
+          # Bind to all interfaces. Since v0.104.0, the collector defaults the OTLP
+          # receiver to 127.0.0.1 (CVE-2024-36129 hardening), which silently drops
+          # traffic from other pods. See https://opentelemetry.io/blog/2024/hardening-the-collector-one/
+          grpc:
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
     {{ if .Values.openTelemetry.gateway.config.traces.processors }}
     processors:
       {{- toYaml .Values.openTelemetry.gateway.config.traces.processors | nindent 6 }}

--- a/scripts/ci/helm-unittest.sh
+++ b/scripts/ci/helm-unittest.sh
@@ -7,7 +7,7 @@ set -euf -o pipefail
 HELM_UNITTEST_VERSION="v1.0.2"
 
 ### Install the helm-unittest plugin
-helm plugin install https://github.com/helm-unittest/helm-unittest --version "$HELM_UNITTEST_VERSION"
+helm plugin install https://github.com/helm-unittest/helm-unittest --version "$HELM_UNITTEST_VERSION" --verify=false
 
 ### Run the helm tests
 helm unittest -q charts/sourcegraph


### PR DESCRIPTION
### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [NO change ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

e2e done
