### PR TITLE
fix test script

### DIFF
--- a/scripts/ci/helm-unittest.sh
+++ b/scripts/ci/helm-unittest.sh
@@ -7,7 +7,7 @@ set -euf -o pipefail
 HELM_UNITTEST_VERSION="v1.0.2"
 
 ### Install the helm-unittest plugin
-helm plugin install https://github.com/helm-unittest/helm-unittest --version "$HELM_UNITTEST_VERSION"
+helm plugin install https://github.com/helm-unittest/helm-unittest --version "$HELM_UNITTEST_VERSION" --verify=false
 
 ### Run the helm tests
 helm unittest -q charts/sourcegraph


### PR DESCRIPTION
The Helm 4.x package from the buildkite repo introduced a verification requirement for plugin sources. Adding --verify=false skips that check for the GitHub-hosted plugin.

### Test plan

Unit tests must pass.
