### PR TITLE
feat: support per-service image repository override

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Added support for overriding the image repository on a per-service basis via `<serviceName>.image.repository`, falling back to the global `sourcegraph.image.repository` when unset
 - Added livenessProbe to zoekt-webserver in indexed-search to detect and restart hung pods
 - Fix Pod Disruption Budget for sourcegraph-frontend
 - Added a startup probe to the gitserver statefulset to give it time to run the on-disk migration from repo names to repo IDs

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -24,6 +24,7 @@ In addition to the documented values, all services also support the following va
 - `<serviceName>.env` - consult `values.yaml` file
 - `<serviceName>.serivceAccount.create` - create service account for service
 - `<serviceName>.serviceAccount.annotations` - Annotations for the service-specific service account
+- `<serviceName>.image.repository` - override the global `sourcegraph.image.repository` (registry or prefix) for this service. Defaults to `sourcegraph.image.repository` when unset.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|

--- a/charts/sourcegraph/README.md.gotmpl
+++ b/charts/sourcegraph/README.md.gotmpl
@@ -24,5 +24,6 @@ In addition to the documented values, all services also support the following va
 - `<serviceName>.env` - consult `values.yaml` file
 - `<serviceName>.serivceAccount.create` - create service account for service
 - `<serviceName>.serviceAccount.annotations` - Annotations for the service-specific service account
+- `<serviceName>.image.repository` - override the global `sourcegraph.image.repository` (registry or prefix) for this service. Defaults to `sourcegraph.image.repository` when unset.
 
 {{ template "chart.valuesTable" . }}

--- a/charts/sourcegraph/templates/_helpers.tpl
+++ b/charts/sourcegraph/templates/_helpers.tpl
@@ -94,6 +94,8 @@ annotations:
 Create the docker image reference and allow it to be overridden on a per-service basis
 Default tags are toggled between a global and service-specific setting by the
 useGlobalTagAsDefault configuration
+The image repository defaults to the global sourcegraph.image.repository, but can be
+overridden on a per-service basis via the service's image.repository setting
 */}}
 {{- define "sourcegraph.image" -}}
 {{- $top := index . 0 }}
@@ -101,9 +103,10 @@ useGlobalTagAsDefault configuration
 {{- $imageName := (index $top.Values $service "image" "name")}}
 {{- $defaultTag := (index $top.Values $service "image" "defaultTag")}}
 {{- $defaultTagPrefix := (index $top.Values $service "image" "defaultTagPrefix")}}
+{{- $repository := default $top.Values.sourcegraph.image.repository (index $top.Values $service "image" "repository") }}
 {{- if $top.Values.sourcegraph.image.useGlobalTagAsDefault }}{{ $defaultTag = (tpl $top.Values.sourcegraph.image.defaultTag $top) }}{{ end }}
 
-{{- $top.Values.sourcegraph.image.repository }}/{{ $imageName }}:{{ $defaultTagPrefix }}{{ default $defaultTag (index $top.Values $service "image" "tag") }}
+{{- $repository }}/{{ $imageName }}:{{ $defaultTagPrefix }}{{ default $defaultTag (index $top.Values $service "image" "tag") }}
 {{- end }}
 
 {{- define "sourcegraph.nodeSelector" -}}

--- a/charts/sourcegraph/tests/imageRepository_test.yaml
+++ b/charts/sourcegraph/tests/imageRepository_test.yaml
@@ -1,0 +1,65 @@
+suite: imageRepository
+release:
+  name: sourcegraph
+  namespace: sourcegraph
+tests:
+- it: should use the global repository by default
+  template: frontend/sourcegraph-frontend.Deployment.yaml
+  set:
+    frontend:
+      image:
+        defaultTag: test
+  asserts:
+    - matchRegex:
+        path: "spec.template.spec.containers[0].image"
+        pattern: ^index\.docker\.io/sourcegraph/.+:test$
+- it: should override the repository on a per-service basis
+  template: frontend/sourcegraph-frontend.Deployment.yaml
+  set:
+    frontend:
+      image:
+        defaultTag: test
+        repository: my.registry.example/sg
+  asserts:
+    - matchRegex:
+        path: "spec.template.spec.containers[0].image"
+        pattern: ^my\.registry\.example/sg/.+:test$
+- it: should respect a custom global repository when no per-service override is set
+  template: frontend/sourcegraph-frontend.Deployment.yaml
+  set:
+    sourcegraph:
+      image:
+        repository: global.registry.example/sg
+    frontend:
+      image:
+        defaultTag: test
+  asserts:
+    - matchRegex:
+        path: "spec.template.spec.containers[0].image"
+        pattern: ^global\.registry\.example/sg/.+:test$
+- it: should let the per-service repository win over a custom global repository
+  template: frontend/sourcegraph-frontend.Deployment.yaml
+  set:
+    sourcegraph:
+      image:
+        repository: global.registry.example/sg
+    frontend:
+      image:
+        defaultTag: test
+        repository: my.registry.example/sg
+  asserts:
+    - matchRegex:
+        path: "spec.template.spec.containers[0].image"
+        pattern: ^my\.registry\.example/sg/.+:test$
+- it: should only affect the targeted service and leave others on the global repository
+  template: frontend/sourcegraph-frontend.Deployment.yaml
+  set:
+    frontend:
+      image:
+        defaultTag: test
+        repository: my.registry.example/sg
+  asserts:
+    # The migrator init container should remain on the global repository
+    - matchRegex:
+        path: "spec.template.spec.initContainers[0].image"
+        pattern: ^index\.docker\.io/sourcegraph/.+

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -54,6 +54,8 @@ sourcegraph:
 #     tag:
 #     # Override the default docker image name
 #     name:
+#     # Override the global sourcegraph.image.repository on a service-specific basis
+#     repository:
 #
 #   # Add additional labels and annotations to various resources
 #   labels: {}


### PR DESCRIPTION
https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1781020218336259

Adds a `<serviceName>.image.repository` value that overrides the global `sourcegraph.image.repository` for an individual service, resolved in the `sourcegraph.image` partial template and falling back to the global value when unset. The change is backward compatible — services without an override continue to use the global repository, and the override is scoped per image block (e.g. overriding `frontend.image.repository` does not move the frontend deployment's migrator init container). Includes documentation in `values.yaml`, the README, and the CHANGELOG, plus a 5-case helm-unittest suite covering default, per-service override, custom global repository, precedence, and isolation.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [x] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Added `charts/sourcegraph/tests/imageRepository_test.yaml`, a helm-unittest suite with 5 cases: (1) default uses the global repository, (2) a per-service `image.repository` redirects only that service, (3) a custom global repository is honored when no per-service value is set, (4) the per-service value wins over a custom global value, and (5) overriding one service leaves other containers (incl. the migrator init container) on the global repository. The full chart suite (97 tests) passes, confirming backward compatibility, and `./scripts/helm-docs.sh` produces no uncommitted changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)