### PR TITLE
feat(worker): support per-replica replicaCount override

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Added support for overriding `replicaCount` per dedicated `worker` replica via `worker.replicas[].replicaCount`, falling back to `worker.replicaCount` when unset
 - Added support for overriding the image repository on a per-service basis via `<serviceName>.image.repository`, falling back to the global `sourcegraph.image.repository` when unset
 - Added livenessProbe to zoekt-webserver in indexed-search to detect and restart hung pods
 - Fix Pod Disruption Budget for sourcegraph-frontend

--- a/charts/sourcegraph/templates/_worker.tpl
+++ b/charts/sourcegraph/templates/_worker.tpl
@@ -4,6 +4,7 @@
 {{- $allowlist := index . 2 -}}
 {{- $blocklist := index . 3 -}}
 {{- $resources := index . 4 -}}
+{{- $replicaCount := index . 5 -}}
 
 {{- $name := $top.Values.worker.name -}}
 {{- if $suffix -}}
@@ -24,7 +25,7 @@ metadata:
   name: {{ $name }}
 spec:
   minReadySeconds: 10
-  replicas: {{ $top.Values.worker.replicaCount }}
+  replicas: {{ $replicaCount }}
   revisionHistoryLimit: {{ $top.Values.sourcegraph.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/sourcegraph/templates/worker/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/worker/worker.Deployment.yaml
@@ -4,7 +4,7 @@
 {{- end }}
 
 {{- if not .Values.worker.replicas }}
-  {{- include "sourcegraph.worker" (list . "" "" $globalBlocklist .Values.worker.resources ) | nindent 0 }}
+  {{- include "sourcegraph.worker" (list . "" "" $globalBlocklist .Values.worker.resources .Values.worker.replicaCount ) | nindent 0 }}
 {{- else }}
   {{- $dedicatedJobs := list }}
   {{- $dedicatedJobs = $dedicatedJobs | concat .Values.worker.blocklist }}
@@ -13,7 +13,7 @@
   {{- end }}
   {{- $primaryBlocklist := join "," ($dedicatedJobs | uniq | sortAlpha) }}
 ---
-  {{-  include "sourcegraph.worker" (list . "" "all" $primaryBlocklist $.Values.worker.resources) | nindent 0 }}
+  {{-  include "sourcegraph.worker" (list . "" "all" $primaryBlocklist $.Values.worker.resources $.Values.worker.replicaCount) | nindent 0 }}
 
   {{- range $idx, $item := .Values.worker.replicas }}
 ---
@@ -23,6 +23,10 @@
     {{- if $item.resources -}}
     {{- $resources = $item.resources -}}
     {{- end -}}
-    {{- include "sourcegraph.worker" (list $ $replicaName $allowlist "" $resources) | nindent 0 }}
+    {{- $replicaCount := $.Values.worker.replicaCount -}}
+    {{- if $item.replicaCount -}}
+    {{- $replicaCount = $item.replicaCount -}}
+    {{- end -}}
+    {{- include "sourcegraph.worker" (list $ $replicaName $allowlist "" $resources $replicaCount) | nindent 0 }}
   {{- end }}
 {{- end }}

--- a/charts/sourcegraph/tests/worker_test.yaml
+++ b/charts/sourcegraph/tests/worker_test.yaml
@@ -147,3 +147,61 @@ tests:
         requests:
           cpu: 2000m
           memory: 4Gi
+- it: should default each replica deployment to worker.replicaCount when replicaCount is not overridden
+  template: worker/worker.Deployment.yaml
+  set:
+    worker:
+      replicaCount: 2
+      replicas:
+      - jobs: ["job1", "job2"]
+      - jobs: ["job3", "job4"]
+  asserts:
+  - equal:
+      path: spec.replicas
+      value: 2
+    documentIndex: 0
+  - equal:
+      path: spec.replicas
+      value: 2
+    documentIndex: 1
+  - equal:
+      path: spec.replicas
+      value: 2
+    documentIndex: 2
+- it: should override replicaCount per replica deployment
+  template: worker/worker.Deployment.yaml
+  set:
+    worker:
+      replicaCount: 1
+      replicas:
+      - jobs: ["job1", "job2"]
+        replicaCount: 3
+      - jobs: ["job3", "job4"]
+  asserts:
+  - containsDocument:
+      kind: Deployment
+      apiVersion: apps/v1
+      name: worker
+    documentIndex: 0
+  - equal:
+      path: spec.replicas
+      value: 1
+    documentIndex: 0
+  - containsDocument:
+      kind: Deployment
+      apiVersion: apps/v1
+      name: worker-0
+    documentIndex: 1
+  - equal:
+      path: spec.replicas
+      value: 3
+    documentIndex: 1
+  - containsDocument:
+      kind: Deployment
+      apiVersion: apps/v1
+      name: worker-1
+    documentIndex: 2
+  - equal:
+      path: spec.replicas
+      value: 1
+    documentIndex: 2

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1314,6 +1314,9 @@ worker:
   replicas:
     []
     # - jobs: []
+    #   # -- Number of pods for this dedicated worker replica. Defaults to worker.replicaCount.
+    #   # Only increase this for replicas whose jobs are safe to scale horizontally.
+    #   replicaCount: 1
     #   resources:
     #     limits:
     #       cpu: "2"


### PR DESCRIPTION
## Summary

Follow-up to #582, which added support for scaling `worker` horizontally by configuring dedicated replicas per set of jobs.

This PR adds a `replicaCount` override for each distinct worker replica. Previously every generated worker deployment (the primary `worker` and each dedicated `worker-N`) inherited the single top-level `worker.replicaCount`. Now each entry under `worker.replicas` can set its own `replicaCount`, falling back to `worker.replicaCount` when unset.

This lets operators scale individual dedicated workers horizontally only for jobs that are safe to scale that way.

```yaml
worker:
  replicas:
    - replicaCount: 3 # make sure jobs are safe to scale horizontally
      jobs:
        - job1
        - job2
    - jobs:
        - job3 # inherits worker.replicaCount
```

## Changes

- `templates/_worker.tpl`: added a `$replicaCount` parameter to the `sourcegraph.worker` helper and use it for `spec.replicas`.
- `templates/worker/worker.Deployment.yaml`: pass `worker.replicaCount` for the primary worker, and per-replica `replicaCount` (defaulting to `worker.replicaCount`) for each dedicated replica.
- `values.yaml`: documented the new per-replica `replicaCount` option.
- `tests/worker_test.yaml`: added tests covering the default-inheritance and per-replica override behaviour.
- `CHANGELOG.md`: added an entry.

## Test plan

- `helm unittest charts/sourcegraph` — all 99 tests pass (7 in the worker suite).
- `./scripts/helm-docs.sh` produces no uncommitted changes.

Slack thread: https://sourcegraph.slack.com/archives/C0ATB8N5P3Q/p1781106413632049


---
_Generated by [Claude Code](https://claude.ai/code/session_01L76QgBN8t9M3gbJo5NdyZo)_