### PR TITLE
bug/release: fix test to work during internal release build

### DIFF
--- a/charts/sourcegraph/tests/imageRepository_test.yaml
+++ b/charts/sourcegraph/tests/imageRepository_test.yaml
@@ -6,6 +6,9 @@ tests:
 - it: should use the global repository by default
   template: frontend/sourcegraph-frontend.Deployment.yaml
   set:
+    sourcegraph:
+      image:
+        repository: index.docker.io/sourcegraph
     frontend:
       image:
         defaultTag: test
@@ -54,6 +57,9 @@ tests:
 - it: should only affect the targeted service and leave others on the global repository
   template: frontend/sourcegraph-frontend.Deployment.yaml
   set:
+    sourcegraph:
+      image:
+        repository: index.docker.io/sourcegraph
     frontend:
       image:
         defaultTag: test


### PR DESCRIPTION
Fix tests introduced in https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/885 to work during the release flow.

This test broke the release for the internal build https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/888

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
