### PR TITLE
executor: increase k8s executor memory limit to avoid OOM

### DIFF
--- a/charts/sourcegraph-executor/k8s/README.md
+++ b/charts/sourcegraph-executor/k8s/README.md
@@ -96,7 +96,7 @@ In addition to the documented values, the `executor` and `private-docker-registr
 | executor.queueNames | list | `[]` | The names of multiple queues to pull jobs from to. Possible values: batches and codeintel. **Either this or queueName is required.** |
 | executor.replicas | int | `1` |  |
 | executor.resources.limits.cpu | string | `"1"` |  |
-| executor.resources.limits.memory | string | `"1Gi"` |  |
+| executor.resources.limits.memory | string | `"4Gi"` |  |
 | executor.resources.requests.cpu | string | `"500m"` |  |
 | executor.resources.requests.memory | string | `"200Mi"` |  |
 | executor.securityContext | object | `{"fsGroup":null,"privileged":false,"runAsGroup":null,"runAsUser":null}` | DEPRECATED: Use `executor.containerSecurityContext` or `executor.podSecurityContext` instead. |

--- a/charts/sourcegraph-executor/k8s/values.yaml
+++ b/charts/sourcegraph-executor/k8s/values.yaml
@@ -66,7 +66,7 @@ executor:
   resources:
     limits:
       cpu: "1"
-      memory: 1Gi
+      memory: 4Gi
     requests:
       cpu: 500m
       memory: 200Mi


### PR DESCRIPTION
# Summary

Increase k8s executor memory limit 1Gi->4Gi to avoid OOM.
Does not increase memory request not to cause relocating of pods and greater nodes.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

```sh
### Chart [ sourcegraph-executor-k8s ] ./charts/sourcegraph-executor/k8s/

 PASS  executor	charts/sourcegraph-executor/k8s/tests/executor_test.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshot:    0 passed, 0 total
Time:        42.867208ms
```
