### PR TITLE
fix(ci): publish executor charts as insiders builds

### DIFF
--- a/.github/workflows/gcs_chart_publish_insiders.yml
+++ b/.github/workflows/gcs_chart_publish_insiders.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Update chart versions
         run: |
-          sed -i 's/appVersion:.*/appVersion: insiders/g' charts/*/Chart.yaml
-          sed -i '/^version:/ s/"$/-insiders.${{ steps.metadata.outputs.shortSHA }}"/' charts/*/Chart.yaml
+          sed -i 's/appVersion:.*/appVersion: insiders/g' charts/*/Chart.yaml charts/sourcegraph-executor/*/Chart.yaml
+          sed -i '/^version:/ s/"$/-insiders.${{ steps.metadata.outputs.shortSHA }}"/' charts/*/Chart.yaml charts/sourcegraph-executor/*/Chart.yaml
 
       - name: Package Sourcegraph helm charts
         run: for i in charts/*; do [ -f "$i/Chart.yaml" ] && helm package -u $i; done


### PR DESCRIPTION
The insiders publish workflow stamps the per-commit `-insiders.<sha>` version using `sed ... charts/*/Chart.yaml`, but that glob only matches direct children of `charts/` — it misses the executor charts nested at `charts/sourcegraph-executor/{k8s,dind}/Chart.yaml`, so they were packaged with their static `5.11.0` version and deduped away at publish time, freezing the `sourcegraph-executor-k8s`/`-dind` insiders feed since 2024-12-20. This extends both `sed` globs to also cover `charts/sourcegraph-executor/*/Chart.yaml` so the executor charts get the same `-insiders.<sha>` versioning and per-commit publish as the `sourcegraph` and `sourcegraph-migrator` charts. Verified with GNU sed (matching `ubuntu-latest`) that all four publishable charts now receive `version: "5.x.y-insiders.<sha>"` and `appVersion: insiders`.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

CI-only change. Validated the modified `sed` commands locally with GNU sed against copies of all `Chart.yaml` files: `sourcegraph`, `sourcegraph-migrator`, `sourcegraph-executor-k8s`, and `sourcegraph-executor-dind` all correctly get `version: "5.11.0-insiders.<sha>"` and `appVersion: insiders`, whereas before only the first two did. After merge, the next push touching `charts/**` should publish fresh `5.x.y-insiders.<hash>` executor entries to `insiders/index.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)