### PR TITLE
set port to connect to for frontend configmap

### DIFF
--- a/charts/sourcegraph-executor/dind/README.md
+++ b/charts/sourcegraph-executor/dind/README.md
@@ -70,7 +70,7 @@ In addition to the documented values, the `executor` and `private-docker-registr
 | executor.env | object | `{}` | Extra environment variables to set on the executor container. |
 | executor.frontendExistingSecret | string | `""` | Name of existing k8s Secret to use for frontend password. The k8s Secret must contain the key EXECUTOR_FRONTEND_PASSWORD matching the site config executors.accessToken value. frontendPassword is ignored if this is set. |
 | executor.frontendPassword | string | `""` | The shared secret configured in the Sourcegraph instance site config under executors.accessToken. Required if frontendExistingSecret is not configured. |
-| executor.frontendUrl | string | `""` | The external URL of the Sourcegraph instance. Required. |
+| executor.frontendUrl | string | `""` | The external URL of the Sourcegraph instance. Required. **Recommended:** set to the internal service endpoint (e.g. `http://sourcegraph-frontend.sourcegraph.svc.cluster.local:30080` if Sourcegraph is deployed in the `sourcegraph` namespace). This will avoid unnecessary network charges as traffic will stay within the local network. |
 | executor.image.defaultTag | string | `"6.0.0@sha256:0be94a7c91f8273db10fdf46718c6596340ab2acc570e7b85353806e67a27508"` |  |
 | executor.image.name | string | `"executor"` |  |
 | executor.log.format | string | `"json"` |  |

--- a/charts/sourcegraph-executor/dind/values.yaml
+++ b/charts/sourcegraph-executor/dind/values.yaml
@@ -86,7 +86,8 @@ queues: []
 #   env: {}
 
 executor:
-  # -- The external URL of the Sourcegraph instance. Required.
+  # -- The external URL of the Sourcegraph instance. Required. **Recommended:** set to the internal service endpoint (e.g. `http://sourcegraph-frontend.sourcegraph.svc.cluster.local:30080` if Sourcegraph is deployed in the `sourcegraph` namespace).
+  # This will avoid unnecessary network charges as traffic will stay within the local network.
   frontendUrl: ""
   # -- The shared secret configured in the Sourcegraph instance site config under executors.accessToken. Required if frontendExistingSecret is not configured.
   frontendPassword: ""


### PR DESCRIPTION
closes PLAT-757

## Description

The executor Kubernetes deployment configurations contain incorrect or incomplete `frontendUrl` values that cause the executor to silently hang on startup, never connecting to the Sourcegraph instance.

The Sourcegraph frontend Kubernetes service exposes port **30080** in both Helm and Kustomize deployments. The Kustomize executor ConfigMap patches ship with `http://sourcegraph-frontend` (no port), and the Helm dind chart's `values.yaml` provides no guidance on the correct port. Both result in a silent connection failure with no error log.

When a URL omits the port, the HTTP client defaults to port **80** per the HTTP spec. The frontend Kubernetes service does not listen on port 80, so the connection attempt hangs indefinitely — no TCP RST (because the pod IP exists), no application-level error (because the request never reaches the frontend), and no timeout (because Go's default HTTP client has no dial timeout configured). The executor simply blocks forever on its initial connection attempt with no indication of what went wrong.

## How I Identified It

During end-to-end testing of the executor dind Helm chart in a local kind cluster (Apple Silicon / OrbStack with Rosetta), the executor container started successfully but never registered with the Sourcegraph instance. The executor logs showed:

```json
{"Body":"Connecting to Sourcegraph instance","Attributes":{"url":"http://sourcegraph-frontend:3080"}}
```

No follow-up log ever appeared — no "Connected", no error, no timeout. The container sat indefinitely on this line. I confirmed the frontend pod was healthy (1/1 Running, HTTP 200 via port-forward).

Testing connectivity from within the executor pod (via the dind sidecar) revealed the issue:

```bash
$ wget -q -O- --timeout=5 http://sourcegraph-frontend:3080/sign-in
# → download timed out

$ wget -q -O- --timeout=5 http://sourcegraph-frontend:30080/sign-in
# → 200 OK
```

The frontend service definitions confirmed it:

```yaml
# Helm: charts/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
# Kustomize: base/sourcegraph/frontend/sourcegraph-frontend.Service.yaml
spec:
  ports:
    - name: http
      port: 30080        # ← service port (what in-cluster clients must use)
      targetPort: http    # ← maps to container port 3080
```

After changing `frontendUrl` to `http://sourcegraph-frontend:30080`, the executor connected immediately.

Note: The incorrect port (3080) in my test came from my own override file, not from a docs example — the docs don't show any port at all, which is part of the problem.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
