### PR TITLE
fix(executor): render tolerations as json

### DIFF
--- a/charts/sourcegraph-executor/k8s/templates/executor.ConfigMap.yaml
+++ b/charts/sourcegraph-executor/k8s/templates/executor.ConfigMap.yaml
@@ -22,7 +22,7 @@ data:
 
   EXECUTOR_KUBERNETES_NODE_NAME: "{{ .Values.executor.kubernetesJob.node.name }}"
   EXECUTOR_KUBERNETES_NODE_SELECTOR: "{{ .Values.executor.kubernetesJob.node.selector }}"
-  EXECUTOR_KUBERNETES_NODE_TOLERATIONS: "{{ .Values.executor.kubernetesJob.node.tolerations }}"
+  EXECUTOR_KUBERNETES_NODE_TOLERATIONS: {{ if kindIs "string" .Values.executor.kubernetesJob.node.tolerations }}{{ .Values.executor.kubernetesJob.node.tolerations | quote }}{{ else }}{{ .Values.executor.kubernetesJob.node.tolerations | toJson | quote }}{{ end }}
   EXECUTOR_KUBERNETES_NODE_REQUIRED_AFFINITY_MATCH_EXPRESSIONS: "{{ .Values.executor.kubernetesJob.node.requiredAffinityMatchExpressions }}"
   EXECUTOR_KUBERNETES_NODE_REQUIRED_AFFINITY_MATCH_FIELDS: "{{ .Values.executor.kubernetesJob.node.requiredAffinityMatchFields }}"
 

--- a/charts/sourcegraph-executor/k8s/tests/executor_test.yaml
+++ b/charts/sourcegraph-executor/k8s/tests/executor_test.yaml
@@ -131,3 +131,43 @@ tests:
           path: spec.template.spec.securityContext.runAsUser
       - isNull:
           path: spec.template.spec.securityContext.runAsGroup
+
+  - it: should JSON-encode kubernetesJob.node.tolerations when given a YAML list (issue #349)
+    template: executor.ConfigMap.yaml
+    set:
+      executor:
+        queueName: "test"
+        kubernetesJob:
+          node:
+            tolerations:
+              - key: foo
+                operator: Equal
+                value: bar
+                effect: NoSchedule
+    asserts:
+      - equal:
+          path: data.EXECUTOR_KUBERNETES_NODE_TOLERATIONS
+          value: '[{"effect":"NoSchedule","key":"foo","operator":"Equal","value":"bar"}]'
+
+  - it: should pass through kubernetesJob.node.tolerations when given a pre-encoded JSON string
+    template: executor.ConfigMap.yaml
+    set:
+      executor:
+        queueName: "test"
+        kubernetesJob:
+          node:
+            tolerations: '[{"key":"foo","operator":"Equal","value":"bar","effect":"NoSchedule"}]'
+    asserts:
+      - equal:
+          path: data.EXECUTOR_KUBERNETES_NODE_TOLERATIONS
+          value: '[{"key":"foo","operator":"Equal","value":"bar","effect":"NoSchedule"}]'
+
+  - it: should render default kubernetesJob.node.tolerations as empty string
+    template: executor.ConfigMap.yaml
+    set:
+      executor:
+        queueName: "test"
+    asserts:
+      - equal:
+          path: data.EXECUTOR_KUBERNETES_NODE_TOLERATIONS
+          value: ""

--- a/scripts/ci/helm-unittest.sh
+++ b/scripts/ci/helm-unittest.sh
@@ -11,3 +11,4 @@ helm plugin install https://github.com/helm-unittest/helm-unittest --version "$H
 
 ### Run the helm tests
 helm unittest -q charts/sourcegraph
+helm unittest -q charts/sourcegraph-executor/k8s


### PR DESCRIPTION
Fixes #349

## Reproduction
When `executor.kubernetesJob.node.tolerations` is provided as a YAML list, the executor ConfigMap rendered it as a Go-style `map[...]` string instead of JSON. The executor then fails to parse `EXECUTOR_KUBERNETES_NODE_TOLERATIONS`.

## Fix summary
- Render non-string tolerations values with `toJson | quote`.
- Preserve existing string/default behavior for pre-encoded JSON strings and the default empty string.
- Add helm-unittest coverage for YAML list, pre-encoded JSON string, and default empty string inputs.
- Add the executor k8s chart unittest suite to the existing Buildkite unittest script.

## Tests run
- `git diff --check upstream/main...HEAD` → pass
- `sh -n scripts/ci/helm-unittest.sh` → pass
- `helm unittest -q charts/sourcegraph-executor/k8s` → pass, 10/10 tests
- `helm lint charts/sourcegraph-executor/k8s` → pass, 1 chart linted, 0 failed (existing metadata-name warnings only)
- Static CI wiring check: `.buildkite/pipeline.yaml` runs `scripts/ci/helm-unittest.sh`, and the script now runs `helm unittest -q charts/sourcegraph-executor/k8s`

## Risk
Low. Defaults remain unchanged and string inputs are preserved; YAML list/map inputs now render as JSON for the executor.

## Non-goals
- No changes to executor chart defaults.
- No changes to sibling executor config fields with similar rendering patterns.