### PR TITLE
Add syntacticCodeIntel to S3 bucket example

### DIFF
--- a/charts/sourcegraph/examples/external-object-storage/override.yaml
+++ b/charts/sourcegraph/examples/external-object-storage/override.yaml
@@ -32,3 +32,7 @@ frontend:
 preciseCodeIntel:
   env:
     <<: *objectStorageEnv
+
+syntacticCodeIntel:
+  env:
+    <<: *objectStorageEnv

--- a/charts/sourcegraph/examples/external-object-storage/override.yaml
+++ b/charts/sourcegraph/examples/external-object-storage/override.yaml
@@ -16,6 +16,8 @@ objectStorageEnv: &objectStorageEnv
     value: https://s3.us-east-1.amazonaws.com
   PRECISE_CODE_INTEL_UPLOAD_AWS_REGION:
     value: us-east-1
+
+  # If using access key for authentication
   PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID:
     secretKeyRef: # Pre-existing secret, not created by this chart
       name: sourcegraph-s3-credentials
@@ -24,6 +26,11 @@ objectStorageEnv: &objectStorageEnv
     secretKeyRef: # Pre-existing secret, not created by this chart
       name: sourcegraph-s3-credentials
       key: PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY
+
+  # If using IRSA for role-based authentication on the Kubernetes service account
+  # Do not set ACCESS_KEY_ID or SECRET_ACCESS_KEY; omitting them triggers fallback to IRSA
+  PRECISE_CODE_INTEL_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS:
+    value: "true"
 
 frontend:
   env:


### PR DESCRIPTION
DS thread https://sourcegraph.sourcegraph.com/deepsearch/10f82edc-b90b-4453-8471-563ddb4fa8ec says Syntactic also needs the bucket config

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Doc change
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
