### PR TITLE
chore: remove stale Jaeger agent scrape rule

### DIFF
--- a/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
@@ -145,9 +145,6 @@ data:
       - source_labels: [__meta_kubernetes_service_annotation_sourcegraph_prometheus_scrape]
         action: keep
         regex: true
-      - source_labels: [__meta_kubernetes_pod_container_name]
-        action: drop
-        regex: jaeger-agent
       - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
         action: replace
         target_label: __scheme__


### PR DESCRIPTION
## Problem

Jaeger deprecated and removed the standalone `jaeger-agent` in favor of the OpenTelemetry Collector: https://github.com/jaegertracing/jaeger/issues/4739

Sourcegraph's active Helm deployment uses the maintained `sourcegraph/jaeger-all-in-one` image with Jaeger v2 configuration and OTLP ingestion. However, the Prometheus configuration still contained a relabel rule from 2021 that dropped scrape targets whose container name was `jaeger-agent`.

The rule did not deploy or reference the retired image, but it became dead configuration once the agent workload was removed.

## Changes

- remove the stale `jaeger-agent` Prometheus scrape-drop rule

This does not change the Jaeger workload, image, ports, storage, or tracing configuration.

## Related work

- Sourcegraph package and image cleanup: https://github.com/sourcegraph/sourcegraph/pull/14456
- Merged infrastructure registry and scanning cleanup: https://github.com/sourcegraph/infrastructure/pull/7458

## Test plan

- `helm lint charts/sourcegraph`
- `git diff --check`
- verify no `jaeger-agent` references remain under `charts/`
