### PR TITLE
searcher: add autoCacheSize opt-in to auto-size disk cache

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Added `searcher.autoCacheSize` (default `false`) to omit the `SEARCHER_CACHE_SIZE_MB` and `SYMBOLS_CACHE_SIZE_MB` env vars, letting `searcher` auto-size its cache to ~45% of the live cache volume so it tracks PVC expansion instead of staying frozen to the initial `storageSize`
 - Added support for ordering trace processors via `openTelemetry.gateway.config.traces.tracePipelineProcessors`, falling back to processors ordered by name when unset
 - Removed the unused executor controller `/data` PersistentVolumeClaim from the Kubernetes-native executor chart (`sourcegraph-executor/k8s`), along with the now-orphaned `storageClass` and `executor.storageSize` values and the vestigial `EXECUTOR_KUBERNETES_PERSISTENCE_VOLUME_NAME` env var. Since single-job-pod became the only k8s execution mode, job pods use their own ephemeral `emptyDir` volume and the controller writes nothing to `/data`.
 - Removed the non-functional `executor.replicas` value from the Kubernetes-native executor chart; the controller is a singleton (it pins Job pods to its own node), so `replicas > 1` never worked.

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -321,6 +321,7 @@ In addition to the documented values, all services also support the following va
 | redisStore.storageAnnotations | object | `{}` | Optional annotations to add to the `redis-store` PVC |
 | redisStore.storageSize | string | `"100Gi"` | PVC Storage Request for `redis-store` data volume |
 | redisStore.storageSubPath | string | `""` | Optional subPath for the `redis-store` primary data volume mount |
+| searcher.autoCacheSize | bool | `false` | When enabled, omit the `SEARCHER_CACHE_SIZE_MB` and `SYMBOLS_CACHE_SIZE_MB` env vars so `searcher` auto-sizes its cache to ~45% of the live cache volume. This tracks PVC expansion automatically, whereas the hardcoded env vars are frozen to the initial `storageSize` and do not follow later disk growth. |
 | searcher.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | searcher.image.defaultTag | string | `"6.0.0@sha256:c7508abda2202d4a33400ce23a95dd8d59fe6220d85d7fbee6fb186c55931336"` | Docker image tag for the `searcher` image |
 | searcher.image.name | string | `"searcher"` | Docker image name for the `searcher` image |

--- a/charts/sourcegraph/templates/searcher/searcher.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.StatefulSet.yaml
@@ -55,6 +55,11 @@ spec:
         - name: {{ $name }}
           {{- $item | toYaml | nindent 10 }}
         {{- end }}
+        {{- if not .Values.searcher.autoCacheSize }}
+        # When autoCacheSize is enabled, these env vars are omitted so searcher
+        # sizes its cache to ~45% of the live cache volume, tracking PVC
+        # expansion automatically. SEARCHER_CACHE_SIZE_MB / SYMBOLS_CACHE_SIZE_MB
+        # are deprecated in favor of this auto-detection.
         - name: SEARCHER_CACHE_SIZE_MB
           # Set the cache size to ~45% of the PVC size
           {{- if .Values.searcher.storageSize }}
@@ -73,6 +78,7 @@ spec:
           # storageSize in the VolumeClaimTemplate below
           value: "11700"
           {{- end }}
+        {{- end }}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1148,6 +1148,11 @@ searcher:
     create: false
     # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: ""
+  # -- When enabled, omit the `SEARCHER_CACHE_SIZE_MB` and `SYMBOLS_CACHE_SIZE_MB`
+  # env vars so `searcher` auto-sizes its cache to ~45% of the live cache volume.
+  # This tracks PVC expansion automatically, whereas the hardcoded env vars are
+  # frozen to the initial `storageSize` and do not follow later disk growth.
+  autoCacheSize: false
   # -- Size of the PVC for searcher pods to store cache data
   storageSize: 26Gi
   # -- Optional subPath for the `searcher` primary data volume mount


### PR DESCRIPTION
Adds a `searcher.autoCacheSize` flag (default `false`) that, when enabled, omits the hardcoded `SEARCHER_CACHE_SIZE_MB`/`SYMBOLS_CACHE_SIZE_MB` env vars so `searcher` auto-sizes its cache to ~45% of the live cache volume. Today those env vars are frozen to the initial `storageSize` and never follow later PVC expansion, so instances whose searcher disks have been live-resized (e.g. to 2TiB) still use only ~11GB of cache; this flag lets the binary track the actual expanded disk. Existing instances are unaffected until they opt in. Also regenerates the chart README and adds a CHANGELOG entry.

### Checklist

- [ ] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Rendered the searcher StatefulSet both ways with `helm template`: default (`autoCacheSize: false`) still emits `SEARCHER_CACHE_SIZE_MB`/`SYMBOLS_CACHE_SIZE_MB` (`"11700"`), and `--set searcher.autoCacheSize=true` omits both env vars while leaving `CACHE_DIR` intact. Confirmed `./scripts/helm-docs.sh` produces no further diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)