### PR TITLE
fix: checkcov ci is broken

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Install Checkov
         run: pip install checkov


### PR DESCRIPTION
it was failing https://github.com/sourcegraph/deploy-sourcegraph-helm/actions/runs/31059908951/job/92522759144?pr=917

<img width="1048" height="457" alt="CleanShot 2026-08-05 at 21 55 18" src="https://github.com/user-attachments/assets/79f9f3ce-a9f2-49e8-b4e3-62717ecc862b" />


checkdov dependencies dropped py 3.9 support