### PR TITLE
gitserver: make PVC access modes configurable via storageAccessModes

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Added `gitserver.storageAccessModes` (default `["ReadWriteOnce"]`) to allow `["ReadWriteOncePod"]`, which lets Kubernetes mount the repos volume with `-o context` on SELinux-enforcing nodes (e.g. Bottlerocket / EKS Auto Mode) instead of recursively relabeling every file on each pod start. Changing this on an existing deployment requires recreating the StatefulSet and PVC, as both fields are immutable.
 - Added `searcher.autoCacheSize` (default `false`) to omit the `SEARCHER_CACHE_SIZE_MB` and `SYMBOLS_CACHE_SIZE_MB` env vars, letting `searcher` auto-size its cache to ~45% of the live cache volume so it tracks PVC expansion instead of staying frozen to the initial `storageSize`
 - Added support for ordering trace processors via `openTelemetry.gateway.config.traces.tracePipelineProcessors`, falling back to processors ordered by name when unset
 - Removed the unused executor controller `/data` PersistentVolumeClaim from the Kubernetes-native executor chart (`sourcegraph-executor/k8s`), along with the now-orphaned `storageClass` and `executor.storageSize` values and the vestigial `EXECUTOR_KUBERNETES_PERSISTENCE_VOLUME_NAME` env var. Since single-job-pod became the only k8s execution mode, job pods use their own ephemeral `emptyDir` volume and the controller writes nothing to `/data`.

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -130,6 +130,7 @@ In addition to the documented values, all services also support the following va
 | gitserver.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `gitserver` |
 | gitserver.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | gitserver.sshSecret | string | `""` | Name of existing Secret that contains SSH credentials to clone repositories. It usually contains keys, such as `id_rsa` (private key) and `known_hosts`. Learn more from [documentation](https://docs.sourcegraph.com/admin/install/kubernetes/helm#using-ssh-to-clone-repositories) |
+| gitserver.storageAccessModes | list | `["ReadWriteOnce"]` | Access modes for the `gitserver` PVC. Set to `["ReadWriteOncePod"]` on SELinux-enforcing nodes (e.g. Bottlerocket / EKS Auto Mode) so Kubernetes mounts the volume with `-o context` instead of recursively relabeling every file on each pod start |
 | gitserver.storageAnnotations | object | `{}` | Optional annotations to add to the `gitserver` PVC |
 | gitserver.storageSize | string | `"200Gi"` | PVC Storage Request for `gitserver` data volume |
 | gitserver.storageSubPath | string | `""` | Optional subPath for the `gitserver` primary data volume mount |

--- a/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -133,7 +133,7 @@ spec:
       {{- end }}
     spec:
       accessModes:
-      - ReadWriteOnce
+      {{- toYaml .Values.gitserver.storageAccessModes | nindent 6 }}
       resources:
         requests:
           # The size of disk used to mirror your git repositories.

--- a/charts/sourcegraph/tests/gitserverStorageAccessModes_test.yaml
+++ b/charts/sourcegraph/tests/gitserverStorageAccessModes_test.yaml
@@ -1,0 +1,57 @@
+suite: gitserver storageAccessModes
+templates:
+- gitserver/gitserver.StatefulSet.yaml
+release:
+  name: sourcegraph
+  namespace: sourcegraph
+tests:
+- it: should default gitserver PVC accessModes to ReadWriteOnce
+  asserts:
+  - equal:
+      path: spec.volumeClaimTemplates[0].spec.accessModes
+      value:
+      - ReadWriteOnce
+- it: should render gitserver PVC accessModes from gitserver.storageAccessModes
+  set:
+    gitserver:
+      storageAccessModes:
+      - ReadWriteOncePod
+  asserts:
+  - equal:
+      path: spec.volumeClaimTemplates[0].spec.accessModes
+      value:
+      - ReadWriteOncePod
+- it: should render multiple gitserver PVC accessModes when several are set
+  set:
+    gitserver:
+      storageAccessModes:
+      - ReadWriteOnce
+      - ReadOnlyMany
+  asserts:
+  - equal:
+      path: spec.volumeClaimTemplates[0].spec.accessModes
+      value:
+      - ReadWriteOnce
+      - ReadOnlyMany
+- it: should keep the rest of the gitserver volumeClaimTemplate intact when overriding accessModes
+  set:
+    gitserver:
+      storageAccessModes:
+      - ReadWriteOncePod
+      storageSize: 500Gi
+      storageAnnotations:
+        example.com/annotation: value
+  asserts:
+  - equal:
+      path: spec.volumeClaimTemplates[0].metadata.name
+      value: repos
+  - equal:
+      path: spec.volumeClaimTemplates[0].metadata.annotations["example.com/annotation"]
+      value: value
+  - equal:
+      path: spec.volumeClaimTemplates[0].spec.accessModes
+      value:
+      - ReadWriteOncePod
+  - equal:
+      path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+      value: 500Gi

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -454,6 +454,8 @@ gitserver:
     create: false
     # -- Name of the ServiceAccount to be created or an existing ServiceAccount
     name: ""
+  # -- Access modes for the `gitserver` PVC. Set to `["ReadWriteOncePod"]` on SELinux-enforcing nodes (e.g. Bottlerocket / EKS Auto Mode) so Kubernetes mounts the volume with `-o context` instead of recursively relabeling every file on each pod start
+  storageAccessModes: ["ReadWriteOnce"]
   # -- PVC Storage Request for `gitserver` data volume
   storageSize: 200Gi
   # -- Optional subPath for the `gitserver` primary data volume mount


### PR DESCRIPTION
## Problem

The gitserver StatefulSet volumeClaimTemplate hardcodes `accessModes: [ReadWriteOnce]`.

On SELinux-enforcing nodes (Bottlerocket, EKS Auto Mode), every gitserver pod (re)start makes containerd recursively relabel every file on the repos volume with the new container's random MCS categories, because an RWO volume cannot use the `-o context` mount option (the `SELinuxMount` feature gate is off by default in Kubernetes <= 1.36, and managed offerings like EKS Auto Mode do not allow enabling it). On a repos volume with millions of git objects, this holds gitserver in `ContainerCreating` for 15-30+ minutes, with kubelet logging `failed to reserve container name ... another CreateContainer request is in progress` as its CRI calls time out and retry behind the still-running relabel walk.

## Fix

Add `gitserver.storageAccessModes`, defaulting to the previous hardcoded `["ReadWriteOnce"]` so existing deployments render identically.

Setting it to `["ReadWriteOncePod"]` enables the mount-option labeling path (`SELinuxMountReadWriteOncePod`, GA in Kubernetes 1.36): kubelet mounts the volume with `-o context=<label>` and the relabel walk is skipped entirely. Requires the pod to pin `gitserver.podSecurityContext.seLinuxOptions.level` and a CSI driver with `seLinuxMount: true` (the EBS CSI driver qualifies).

## Notes

- No behavior change for existing users: default renders the same manifest (verified with `helm template`; all 103 unit tests and 12 snapshots pass).
- Access modes are immutable on PVCs and `volumeClaimTemplates` are immutable on StatefulSets, so switching an existing deployment requires deleting the StatefulSet (`--cascade=orphan`) and recreating the PVC. Noted in the CHANGELOG.
- Diagnosed on an EKS Auto Mode cluster where a 3.7M-inode repos volume was fully relabeled (millions of xattr writes, ~9 GB of metadata IO) on every gitserver restart.

## Test plan

- `helm unittest charts/sourcegraph`: 24 suites, 103 tests, 12 snapshots pass
- `helm template` with defaults renders `ReadWriteOnce` (unchanged)
- `helm template --set 'gitserver.storageAccessModes={ReadWriteOncePod}'` renders `ReadWriteOncePod`
- README regenerated with helm-docs