### PR TITLE
Fix grafana StatefulSet rendering with extraContainers and a service account

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Fixed the grafana StatefulSet rendering invalid YAML when `grafana.extraContainers` and a service account are both set, by emitting `extraContainers` inside the `containers` list before `serviceAccountName`, matching the other templates
 - Added `searcher.autoCacheSize` (default `false`) to omit the `SEARCHER_CACHE_SIZE_MB` and `SYMBOLS_CACHE_SIZE_MB` env vars, letting `searcher` auto-size its cache to ~45% of the live cache volume so it tracks PVC expansion instead of staying frozen to the initial `storageSize`
 - Added support for ordering trace processors via `openTelemetry.gateway.config.traces.tracePipelineProcessors`, falling back to processors ordered by name when unset
 - Removed the unused executor controller `/data` PersistentVolumeClaim from the Kubernetes-native executor chart (`sourcegraph-executor/k8s`), along with the now-orphaned `storageClass` and `executor.storageSize` values and the vestigial `EXECUTOR_KUBERNETES_PERSISTENCE_VOLUME_NAME` env var. Since single-job-pod became the only k8s execution mode, job pods use their own ephemeral `emptyDir` volume and the controller writes nothing to `/data`.

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -83,10 +83,10 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.grafana.containerSecurityContext | nindent 10 }}
-      {{- include "sourcegraph.renderServiceAccountName" (list . "grafana") | trim | nindent 6 }}
       {{- if .Values.grafana.extraContainers }}
         {{- toYaml .Values.grafana.extraContainers | nindent 6 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "grafana") | trim | nindent 6 }}
       securityContext:
         {{- toYaml .Values.grafana.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "grafana" ) | trim | nindent 6 }}


### PR DESCRIPTION
The grafana StatefulSet template renders `serviceAccountName` between the `containers` list and `grafana.extraContainers`, so setting both a service account and `extraContainers` produces invalid YAML:

```
Error: YAML parse error on sourcegraph/templates/grafana/grafana.StatefulSet.yaml: error converting YAML to JSON: yaml: line 94: did not find expected key
```

This moves the `extraContainers` block before `renderServiceAccountName`, matching the ordering every other template uses (e.g. `gitserver.StatefulSet.yaml`). Grafana is the only template with this misordering.

This fix is required for customers using the Airgapped Analytics dashboard, with AWS IAM (IRSA) authentication to their Postgres database in RDS.

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [x] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes) — not needed, no user-facing upgrade steps

### Test plan

With test values setting both keys:

```yaml
grafana:
  serviceAccount:
    create: false
    name: grafana-test-sa
  extraContainers:
    - name: test-sidecar
      image: busybox
```

- Before: `helm template sourcegraph charts/sourcegraph -f test-values.yaml` fails with the YAML parse error above
- After: renders cleanly; parsed the StatefulSet with PyYAML and verified `spec.template.spec.serviceAccountName: grafana-test-sa` and `containers: [grafana, test-sidecar]`
- Verified no other template renders `extraContainers` after `renderServiceAccountName`