### PR TITLE
[Backport 7.6.x] Fix grafana StatefulSet rendering with extraContainers and a service account (#924)

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Fixed the grafana StatefulSet rendering invalid YAML when `grafana.extraContainers` and a service account are both set, by emitting `extraContainers` inside the `containers` list before `serviceAccountName`, matching the other templates
 - Added support for ordering trace processors via `openTelemetry.gateway.config.traces.tracePipelineProcessors`, falling back to processors ordered by name when unset
 - Removed the unused executor controller `/data` PersistentVolumeClaim from the Kubernetes-native executor chart (`sourcegraph-executor/k8s`), along with the now-orphaned `storageClass` and `executor.storageSize` values and the vestigial `EXECUTOR_KUBERNETES_PERSISTENCE_VOLUME_NAME` env var. Since single-job-pod became the only k8s execution mode, job pods use their own ephemeral `emptyDir` volume and the controller writes nothing to `/data`.
 - Removed the non-functional `executor.replicas` value from the Kubernetes-native executor chart; the controller is a singleton (it pins Job pods to its own node), so `replicas > 1` never worked.

--- a/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/grafana/grafana.StatefulSet.yaml
@@ -83,10 +83,10 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.grafana.containerSecurityContext | nindent 10 }}
-      {{- include "sourcegraph.renderServiceAccountName" (list . "grafana") | trim | nindent 6 }}
       {{- if .Values.grafana.extraContainers }}
         {{- toYaml .Values.grafana.extraContainers | nindent 6 }}
       {{- end }}
+      {{- include "sourcegraph.renderServiceAccountName" (list . "grafana") | trim | nindent 6 }}
       securityContext:
         {{- toYaml .Values.grafana.podSecurityContext | nindent 8 }}
       {{- include "sourcegraph.nodeSelector" (list . "grafana" ) | trim | nindent 6 }}


### PR DESCRIPTION
Manual backport of #924 to `7.6.x` (the automated backport failed on a CHANGELOG conflict).

cc @sourcegraph/release

The grafana StatefulSet template renders `serviceAccountName` between the `containers` list and `grafana.extraContainers`, so setting both a service account and `extraContainers` produces invalid YAML. This moves the `extraContainers` block before `renderServiceAccountName`, matching the ordering every other template uses.

This fix is required for customers using the Airgapped Analytics dashboard, with AWS IAM (IRSA) authentication to their Postgres database in RDS.

### Conflict resolution

Only `charts/sourcegraph/CHANGELOG.md` conflicted: the hunk context on `main` included an unrelated `searcher.autoCacheSize` entry that does not exist on `7.6.x`. Kept only the grafana bullet; the template change applied cleanly.

### Test plan

With test values setting both keys:

```yaml
grafana:
  serviceAccount:
    create: false
    name: grafana-test-sa
  extraContainers:
    - name: test-sidecar
      image: busybox
```

`helm template sourcegraph charts/sourcegraph -f test-values.yaml -s templates/grafana/grafana.StatefulSet.yaml` on this branch renders cleanly, with `test-sidecar` inside the `containers` list and `serviceAccountName: grafana-test-sa` after it.
