### PR TITLE
fix: set Helm deploy type for application services

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Set `DEPLOY_TYPE=helm` consistently for all Sourcegraph application containers
 - Fixed the grafana StatefulSet rendering invalid YAML when `grafana.extraContainers` and a service account are both set, by emitting `extraContainers` inside the `containers` list before `serviceAccountName`, matching the other templates
 - Added `searcher.autoCacheSize` (default `false`) to omit the `SEARCHER_CACHE_SIZE_MB` and `SYMBOLS_CACHE_SIZE_MB` env vars, letting `searcher` auto-size its cache to ~45% of the live cache volume so it tracks PVC expansion instead of staying frozen to the initial `storageSize`
 - Added support for ordering trace processors via `openTelemetry.gateway.config.traces.tracePipelineProcessors`, falling back to processors ordered by name when unset

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -34,6 +34,7 @@ In addition to the documented values, all services also support the following va
 | alpine.resources | object | `{"limits":{"cpu":"10m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Resource requests & limits for the `alpine` initContainer, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | blobstore.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsGroup":101,"runAsUser":100}` | Security context for the `blobstore` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | blobstore.enabled | bool | `true` | Enable `blobstore` (S3 compatible storage) |
+| blobstore.env | object | the chart will add some default environment values | Environment variables for the `blobstore` container |
 | blobstore.image.defaultTag | string | `"6.0.0@sha256:82caab40f920282069c84e0e4ca503857926e934c67fb022f6d93823b4ea98b5"` | Docker image tag for the `blobstore` image |
 | blobstore.image.name | string | `"blobstore"` | Docker image name for the `blobstore` image |
 | blobstore.name | string | `"blobstore"` | Name used by resources. Does not affect service names or PVCs. |
@@ -121,6 +122,7 @@ In addition to the documented values, all services also support the following va
 | frontend.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount for `frontend` |
 | frontend.serviceAccount.name | string | `"sourcegraph-frontend"` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | gitserver.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `gitserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| gitserver.env | object | the chart will add some default environment values | Environment variables for the `gitserver` container |
 | gitserver.image.defaultTag | string | `"6.0.0@sha256:aec9bf6993c243a283109104cd7c44be3c85680b77e3e8be0c5fba8f01a3bd35"` | Docker image tag for the `gitserver` image |
 | gitserver.image.name | string | `"gitserver"` | Docker image name for the `gitserver` image |
 | gitserver.name | string | `"gitserver"` | Name used by resources. Does not affect service names or PVCs. |
@@ -155,6 +157,7 @@ In addition to the documented values, all services also support the following va
 | grafana.storageSize | string | `"2Gi"` | PVC Storage Request for `grafana` data volume |
 | grafana.storageSubPath | string | `""` | Optional subPath for the `grafana` primary data volume mount |
 | indexedSearch.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `zoekt-webserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| indexedSearch.env | object | the chart will add some default environment values | Environment variables for the `zoekt-webserver` container |
 | indexedSearch.image.defaultTag | string | `"6.0.0@sha256:99038e0ec9bef930030c118d774fcdcd67d7fe57ad4c80d216703a4d29d64323"` | Docker image tag for the `zoekt-webserver` image |
 | indexedSearch.image.name | string | `"indexed-searcher"` | Docker image name for the `zoekt-webserver` image |
 | indexedSearch.name | string | `"indexed-search"` | Name used by resources. Does not affect service names or PVCs. |
@@ -167,6 +170,7 @@ In addition to the documented values, all services also support the following va
 | indexedSearch.storageSize | string | `"200Gi"` | PVC Storage Request for `indexed-search` data volume The size of disk to used for search indexes. This should typically be gitserver disk size multipled by the number of gitserver shards. |
 | indexedSearch.storageSubPath | string | `""` | Optional subPath for the `indexed-search` primary data volume mount |
 | indexedSearchIndexer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `zoekt-indexserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| indexedSearchIndexer.env | object | the chart will add some default environment values | Environment variables for the `zoekt-indexserver` container |
 | indexedSearchIndexer.image.defaultTag | string | `"6.0.0@sha256:11539e07040b85045a9aa07f970aa310066e240dc28e6c9627653ee2bc6e0b91"` | Docker image tag for the `zoekt-indexserver` image |
 | indexedSearchIndexer.image.name | string | `"search-indexer"` | Docker image name for the `zoekt-indexserver` image |
 | indexedSearchIndexer.resources | object | `{"limits":{"cpu":"8","memory":"8G"},"requests":{"cpu":"4","memory":"4G"}}` | Resource requests & limits for the `zoekt-indexserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) zoekt-indexserver is CPU bound. The more CPU you allocate to it, the lower lag between a new commit and it being indexed for search. |
@@ -196,7 +200,7 @@ In addition to the documented values, all services also support the following va
 | jaeger.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | migrator.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `migrator` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | migrator.enabled | bool | `true` | Enable [migrator](https://docs.sourcegraph.com/admin/how-to/manual_database_migrations) initContainer in `frontend` deployment to perform database migration |
-| migrator.env | object | `{}` | Environment variables for the `migrator` container |
+| migrator.env | object | the chart will add some default environment values | Environment variables for the `migrator` container |
 | migrator.image.defaultTag | string | `"6.0.0@sha256:ec295eb0b743da6bf56777ca6524972267a5c442b0288095e2fe12fce38ebacc"` | Docker image tag for the `migrator` image |
 | migrator.image.name | string | `"migrator"` | Docker image name for the `migrator` image |
 | migrator.resources | object | `{"limits":{"cpu":"500m","memory":"100M"},"requests":{"cpu":"100m","memory":"50M"}}` | Resource requests & limits for the `migrator` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -264,7 +268,7 @@ In addition to the documented values, all services also support the following va
 | postgresExporter.image.name | string | `"postgres_exporter"` | Docker image name for the `pgsql-exporter` image |
 | postgresExporter.resources | object | `{"limits":{"cpu":"10m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Resource requests & limits for the `pgsql-exporter` sidecar container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | preciseCodeIntel.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `precise-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
-| preciseCodeIntel.env | object | `{"NUM_WORKERS":{"value":"4"}}` | Environment variables for the `precise-code-intel-worker` container |
+| preciseCodeIntel.env | object | the chart will add some default environment values | Environment variables for the `precise-code-intel-worker` container |
 | preciseCodeIntel.image.defaultTag | string | `"6.0.0@sha256:3a72cf893cb25731d4636593c544c91781d925d867417416255e56debc27ed37"` | Docker image tag for the `precise-code-intel-worker` image |
 | preciseCodeIntel.image.name | string | `"precise-code-intel-worker"` | Docker image name for the `precise-code-intel-worker` image |
 | preciseCodeIntel.name | string | `"precise-code-intel-worker"` | Name used by resources. Does not affect service names or PVCs. |
@@ -323,6 +327,7 @@ In addition to the documented values, all services also support the following va
 | redisStore.storageSubPath | string | `""` | Optional subPath for the `redis-store` primary data volume mount |
 | searcher.autoCacheSize | bool | `false` | When enabled, omit the `SEARCHER_CACHE_SIZE_MB` and `SYMBOLS_CACHE_SIZE_MB` env vars so `searcher` auto-sizes its cache to ~45% of the live cache volume. This tracks PVC expansion automatically, whereas the hardcoded env vars are frozen to the initial `storageSize` and do not follow later disk growth. |
 | searcher.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| searcher.env | object | the chart will add some default environment values | Environment variables for the `searcher` container |
 | searcher.image.defaultTag | string | `"6.0.0@sha256:c7508abda2202d4a33400ce23a95dd8d59fe6220d85d7fbee6fb186c55931336"` | Docker image tag for the `searcher` image |
 | searcher.image.name | string | `"searcher"` | Docker image name for the `searcher` image |
 | searcher.name | string | `"searcher"` | Name used by resources. Does not affect service names or PVCs. |
@@ -360,6 +365,7 @@ In addition to the documented values, all services also support the following va
 | storageClass.type | string | `"pd-ssd"` | Value of `type` key in storageClass `parameters`, consult your cloud provider persistent storage documentation |
 | syntacticCodeIntel.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `syntactic-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | syntacticCodeIntel.enabled | bool | `false` |  |
+| syntacticCodeIntel.env | object | the chart will add some default environment values | Environment variables for the `syntactic-code-intel-worker` container |
 | syntacticCodeIntel.image.defaultTag | string | `"6.0.0@sha256:50bdeb38b196f0fc21404969016bf8263f78144292e905867e93480f66c8251c"` | Docker image tag for the `syntactic-code-intel-worker` image |
 | syntacticCodeIntel.image.name | string | `"syntactic-code-intel-worker"` | Docker image name for the `syntactic-code-intel-worker` image |
 | syntacticCodeIntel.name | string | `"syntactic-code-intel-worker"` | Name used by resources. Does not affect service names or PVCs. |
@@ -370,6 +376,7 @@ In addition to the documented values, all services also support the following va
 | syntacticCodeIntel.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `syntactic-code-intel-worker` |
 | syntacticCodeIntel.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | syntectServer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| syntectServer.env | object | the chart will add some default environment values | Environment variables for the `syntect-server` container |
 | syntectServer.image.defaultTag | string | `"6.0.0@sha256:1e35f77690222a76724b45f2305b838c40c35201e60b0f619b3fe8499504ff60"` | Docker image tag for the `syntect-server` image |
 | syntectServer.image.name | string | `"syntax-highlighter"` | Docker image name for the `syntect-server` image |
 | syntectServer.name | string | `"syntect-server"` | Name used by resources. Does not affect service names or PVCs. |
@@ -380,7 +387,7 @@ In addition to the documented values, all services also support the following va
 | syntectServer.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | worker.blocklist | list | `[]` | List of jobs to block globally If replicas are configured, use this values to block jobs instead of manually setting WORKER_JOB_BLOCKLIST |
 | worker.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
-| worker.env | object | `{}` | Environment variables for the `worker` container |
+| worker.env | object | the chart will add some default environment values | Environment variables for the `worker` container |
 | worker.image.defaultTag | string | `"6.0.0@sha256:4892c5aa107d4384f811afcf1980e0fb2cb8beb5585a15adcb64353a2d8abf5a"` | Docker image tag for the `worker` image |
 | worker.image.name | string | `"worker"` | Docker image name for the `worker` image |
 | worker.name | string | `"worker"` | Name used by resources. Does not affect service names or PVCs. |

--- a/charts/sourcegraph/tests/deployType_test.yaml
+++ b/charts/sourcegraph/tests/deployType_test.yaml
@@ -1,0 +1,110 @@
+suite: deploy type
+release:
+  name: sourcegraph
+  namespace: sourcegraph
+tests:
+- it: should identify blobstore as a Helm deployment
+  template: blobstore/blobstore.Deployment.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+- it: should identify frontend as a Helm deployment
+  template: frontend/sourcegraph-frontend.Deployment.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+- it: should identify gitserver as a Helm deployment
+  template: gitserver/gitserver.StatefulSet.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+- it: should identify both indexed search containers as Helm deployments
+  template: indexed-search/indexed-search.StatefulSet.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+  - contains:
+      path: spec.template.spec.containers[1].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+- it: should identify migrator as a Helm deployment
+  template: frontend/sourcegraph-frontend.Deployment.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.initContainers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+- it: should identify precise code intel as a Helm deployment
+  template: precise-code-intel/worker.Deployment.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+- it: should identify searcher as a Helm deployment
+  template: searcher/searcher.StatefulSet.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+- it: should identify syntactic code intel as a Helm deployment
+  template: syntactic-code-intel/worker.Deployment.yaml
+  set:
+    syntacticCodeIntel.enabled: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+- it: should identify syntect server as a Helm deployment
+  template: syntect-server/syntect-server.Deployment.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+- it: should identify every worker replica as a Helm deployment
+  template: worker/worker.Deployment.yaml
+  set:
+    worker:
+      replicas:
+      - jobs: ["job1"]
+      - jobs: ["job2"]
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+    documentIndex: 0
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+    documentIndex: 1
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEPLOY_TYPE
+        value: helm
+    documentIndex: 2

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -394,7 +394,10 @@ migrator:
     # -- Docker image name for the `migrator` image
     name: "migrator"
   # -- Environment variables for the `migrator` container
-  env: {}
+  # @default -- the chart will add some default environment values
+  env:
+    DEPLOY_TYPE:
+      value: helm
   # -- Resource requests & limits for the `migrator` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -413,6 +416,11 @@ migrator:
     readOnlyRootFilesystem: true
 
 gitserver:
+  # -- Environment variables for the `gitserver` container
+  # @default -- the chart will add some default environment values
+  env:
+    DEPLOY_TYPE:
+      value: helm
   image:
     # -- Docker image tag for the `gitserver` image
     defaultTag: 6.0.0@sha256:aec9bf6993c243a283109104cd7c44be3c85680b77e3e8be0c5fba8f01a3bd35
@@ -528,6 +536,11 @@ grafana:
   storageAnnotations: {}
 
 indexedSearch:
+  # -- Environment variables for the `zoekt-webserver` container
+  # @default -- the chart will add some default environment values
+  env:
+    DEPLOY_TYPE:
+      value: helm
   image:
     # -- Docker image tag for the `zoekt-webserver` image
     defaultTag: 6.0.0@sha256:99038e0ec9bef930030c118d774fcdcd67d7fe57ad4c80d216703a4d29d64323
@@ -573,6 +586,11 @@ indexedSearch:
   storageAnnotations: {}
 
 indexedSearchIndexer:
+  # -- Environment variables for the `zoekt-indexserver` container
+  # @default -- the chart will add some default environment values
+  env:
+    DEPLOY_TYPE:
+      value: helm
   image:
     # -- Docker image tag for the `zoekt-indexserver` image
     defaultTag: 6.0.0@sha256:11539e07040b85045a9aa07f970aa310066e240dc28e6c9627653ee2bc6e0b91
@@ -600,6 +618,11 @@ indexedSearchIndexer:
 blobstore:
   # -- Enable `blobstore` (S3 compatible storage)
   enabled: true
+  # -- Environment variables for the `blobstore` container
+  # @default -- the chart will add some default environment values
+  env:
+    DEPLOY_TYPE:
+      value: helm
   image:
     # -- Docker image tag for the `blobstore` image
     defaultTag: 6.0.0@sha256:82caab40f920282069c84e0e4ca503857926e934c67fb022f6d93823b4ea98b5
@@ -854,6 +877,11 @@ postgresExporter:
 
 syntacticCodeIntel:
   enabled: false
+  # -- Environment variables for the `syntactic-code-intel-worker` container
+  # @default -- the chart will add some default environment values
+  env:
+    DEPLOY_TYPE:
+      value: helm
   properties:
     # -- port to whick worker API will bind
     workerPort: 3188
@@ -893,7 +921,10 @@ syntacticCodeIntel:
 
 preciseCodeIntel:
   # -- Environment variables for the `precise-code-intel-worker` container
+  # @default -- the chart will add some default environment values
   env:
+    DEPLOY_TYPE:
+      value: helm
     NUM_WORKERS:
       value: "4"
   image:
@@ -1112,6 +1143,11 @@ redisStore:
   storageAnnotations: {}
 
 searcher:
+  # -- Environment variables for the `searcher` container
+  # @default -- the chart will add some default environment values
+  env:
+    DEPLOY_TYPE:
+      value: helm
   image:
     # -- Docker image tag for the `searcher` image
     defaultTag: 6.0.0@sha256:c7508abda2202d4a33400ce23a95dd8d59fe6220d85d7fbee6fb186c55931336
@@ -1182,6 +1218,11 @@ storageClass:
   allowedTopologies: []
 
 syntectServer:
+  # -- Environment variables for the `syntect-server` container
+  # @default -- the chart will add some default environment values
+  env:
+    DEPLOY_TYPE:
+      value: helm
   image:
     # -- Docker image tag for the `syntect-server` image
     defaultTag: 6.0.0@sha256:1e35f77690222a76724b45f2305b838c40c35201e60b0f619b3fe8499504ff60
@@ -1309,7 +1350,10 @@ worker:
   # -- Name used by resources. Does not affect service names or PVCs.
   name: "worker"
   # -- Environment variables for the `worker` container
-  env: {}
+  # @default -- the chart will add some default environment values
+  env:
+    DEPLOY_TYPE:
+      value: helm
   # -- Security context for the `worker` pod,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   podSecurityContext: {}


### PR DESCRIPTION
Set `DEPLOY_TYPE=helm` consistently for every Sourcegraph application container rendered by the chart: Blobstore, Frontend, Migrator, Gitserver, both indexed-search containers, Searcher, precise and syntactic code-intel workers, Syntect, and all Worker deployments.

Third-party infrastructure containers such as PostgreSQL, Redis, Prometheus, Grafana, Jaeger, and OpenTelemetry are intentionally excluded because this Sourcegraph-specific variable has no meaning for them.

This env var tells our services to be in Kubernetes mode. Right now, not setting it defaults to kubernetes, so in practice this change will not change behavior. But it seems way safer to set this explicitly instead of relying on the env vars default.