### PR TITLE
Fix CI lint script to lint all charts

### DIFF
--- a/scripts/ci/lint.sh
+++ b/scripts/ci/lint.sh
@@ -4,20 +4,49 @@ set -euf -o pipefail
 
 ### Run the helm tests
 function lint_chart() {
-  echo "Linting chart $1"
-  LINT_OUTPUT=$(helm lint charts/$1)
-  ORG_STATUS=$?
+  local chart_path="$1"
+  local lint_output
+  local lint_status
 
-  printf "\n\n===== Lint Output =====\n$LINT_OUTPUT\n"
+  shift
 
-  LINT_OUTPUT_LOWER=$(echo "$LINT_OUTPUT" | awk '{print tolower($0)}')
-  if grep -q "warning" <<<"$LINT_OUTPUT_LOWER"; then
-    exit 255
+  echo "Linting chart ${chart_path}"
+  if lint_output=$(helm lint "${chart_path}" "$@" 2>&1); then
+    lint_status=0
   else
-    exit $ORG_STATUS
+    lint_status=$?
   fi
+
+  printf "\n\n===== Lint Output: %s =====\n%s\n" "${chart_path}" "${lint_output}"
+
+  if grep -qi "warning" <<<"${lint_output}"; then
+    printf "Helm lint emitted warnings for %s\n" "${chart_path}" >&2
+    return 255
+  fi
+
+  return "${lint_status}"
 }
 
-lint_chart "sourcegraph"
-lint_chart "sourcegraph-migrator"
-lint_chart "sourcegraph-executor"
+function lint_and_record() {
+  local chart_status
+
+  if lint_chart "$@"; then
+    return 0
+  else
+    chart_status=$?
+  fi
+
+  if [ "${exit_status}" -eq 0 ]; then
+    exit_status="${chart_status}"
+  fi
+
+  return 0
+}
+
+exit_status=0
+lint_and_record "charts/sourcegraph"
+lint_and_record "charts/sourcegraph-migrator"
+lint_and_record "charts/sourcegraph-executor/k8s" --set "executor.queueName=batches"
+lint_and_record "charts/sourcegraph-executor/dind" --set "executor.queueName=batches"
+
+exit "${exit_status}"


### PR DESCRIPTION
- lint_chart exited the whole script after the first chart, so only charts/sourcegraph was ever linted
- Lint every chart even after a failure, report per-chart results, and exit with the first failing status

Amp-Thread-ID: https://ampcode.com/threads/T-01a04192-5b1d-7040-9dc3-76f8d5a10ab0

### Checklist

- [x] Follow the [manual testing process](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/TEST.md)
- [ ] Update [changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG.md)
- [ ] Update [Kubernetes update doc](https://docs.sourcegraph.com/admin/updates/kubernetes)

### Test plan

Before

```
$ cd deploy-sourcegraph-helm
$ ./scripts/ci/lint.sh
Linting chart sourcegraph


===== Lint Output =====
==> Linting charts/sourcegraph

1 chart(s) linted, 0 chart(s) failed
```

After

```
$ cd deploy-sourcegraph-helm
$ ./scripts/ci/lint.sh
Linting chart charts/sourcegraph


===== Lint Output: charts/sourcegraph =====
==> Linting charts/sourcegraph

1 chart(s) linted, 0 chart(s) failed
Linting chart charts/sourcegraph-migrator


===== Lint Output: charts/sourcegraph-migrator =====
==> Linting charts/sourcegraph-migrator

1 chart(s) linted, 0 chart(s) failed
Linting chart charts/sourcegraph-executor/k8s


===== Lint Output: charts/sourcegraph-executor/k8s =====
==> Linting charts/sourcegraph-executor/k8s

1 chart(s) linted, 0 chart(s) failed
Linting chart charts/sourcegraph-executor/dind


===== Lint Output: charts/sourcegraph-executor/dind =====
==> Linting charts/sourcegraph-executor/dind

1 chart(s) linted, 0 chart(s) failed
```