### PR TITLE
Add Searcher PodDisruptionBudget support

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Added optional `searcher.podDisruptionBudget` support
 - Set `DEPLOY_TYPE=helm` consistently for all Sourcegraph application containers
 - Fixed the grafana StatefulSet rendering invalid YAML when `grafana.extraContainers` and a service account are both set, by emitting `extraContainers` inside the `containers` list before `serviceAccountName`, matching the other templates
 - Added `searcher.autoCacheSize` (default `false`) to omit the `SEARCHER_CACHE_SIZE_MB` and `SYMBOLS_CACHE_SIZE_MB` env vars, letting `searcher` auto-size its cache to ~45% of the live cache volume so it tracks PVC expansion instead of staying frozen to the initial `storageSize`

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -331,6 +331,7 @@ In addition to the documented values, all services also support the following va
 | searcher.image.defaultTag | string | `"6.0.0@sha256:c7508abda2202d4a33400ce23a95dd8d59fe6220d85d7fbee6fb186c55931336"` | Docker image tag for the `searcher` image |
 | searcher.image.name | string | `"searcher"` | Docker image name for the `searcher` image |
 | searcher.name | string | `"searcher"` | Name used by resources. Does not affect service names or PVCs. |
+| searcher.podDisruptionBudget | object | `{}` | Pod disruption budget for `searcher`. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | searcher.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":100}` | Security context for the `searcher` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | searcher.replicaCount | int | `1` | Number of `searcher` pod |
 | searcher.resources | object | `{"limits":{"cpu":"2","memory":"2G"},"requests":{"cpu":"500m","memory":"500M"}}` | Resource requests & limits for the `searcher` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |

--- a/charts/sourcegraph/templates/searcher/searcher.PodDisruptionBudget.yaml
+++ b/charts/sourcegraph/templates/searcher/searcher.PodDisruptionBudget.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.searcher.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.searcher.name }}
+spec:
+  {{- toYaml .Values.searcher.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: searcher
+{{- end }}

--- a/charts/sourcegraph/tests/podDisruptionBudget_test.yaml
+++ b/charts/sourcegraph/tests/podDisruptionBudget_test.yaml
@@ -3,6 +3,11 @@ release:
   name: sourcegraph
   namespace: sourcegraph
 tests:
+- it: should not render podDisruptionBudget for searcher by default
+  template: searcher/searcher.PodDisruptionBudget.yaml
+  asserts:
+  - hasDocuments:
+      count: 0
 - it: should render podDisruptionBudget for frontend
   template: frontend/sourcegraph-frontend.PodDisruptionBudget.yaml
   set:
@@ -16,3 +21,28 @@ tests:
   - equal:
       path: spec.selector.matchLabels.app
       value: sourcegraph-frontend
+- it: should render podDisruptionBudget for searcher
+  template: searcher/searcher.PodDisruptionBudget.yaml
+  set:
+    searcher:
+      podDisruptionBudget:
+        maxUnavailable: 1
+  asserts:
+  - equal:
+      path: apiVersion
+      value: policy/v1
+  - equal:
+      path: metadata.name
+      value: searcher
+  - equal:
+      path: spec.maxUnavailable
+      value: 1
+  - equal:
+      path: spec.selector.matchLabels.app
+      value: searcher
+  - equal:
+      path: spec.selector.matchLabels["app.kubernetes.io/name"]
+      value: sourcegraph
+  - equal:
+      path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+      value: sourcegraph

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1170,6 +1170,8 @@ searcher:
   name: "searcher"
   # -- Number of `searcher` pod
   replicaCount: 1
+  # -- Pod disruption budget for `searcher`. Configure either `minAvailable` or `maxUnavailable` to enable it.
+  podDisruptionBudget: {}
   # -- Resource requests & limits for the `searcher` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:


### PR DESCRIPTION
Add optional `searcher.podDisruptionBudget` configuration following the frontend PDB config shape. It's off by default, so this will not change anything for existing deployments.

## Test plan

- `helm unittest -f 'tests/podDisruptionBudget_test.yaml' charts/sourcegraph`
- `helm lint charts/sourcegraph`
- verify the default chart renders no PodDisruptionBudget
- render the Searcher PDB with `searcher.podDisruptionBudget.minAvailable=1`