### PR TITLE
Add syntax highlighter PDB support

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Added optional `syntectServer.podDisruptionBudget` support
 - Added optional `searcher.podDisruptionBudget` support
 - Set `DEPLOY_TYPE=helm` consistently for all Sourcegraph application containers
 - Fixed the grafana StatefulSet rendering invalid YAML when `grafana.extraContainers` and a service account are both set, by emitting `extraContainers` inside the `containers` list before `serviceAccountName`, matching the other templates

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -381,6 +381,7 @@ In addition to the documented values, all services also support the following va
 | syntectServer.image.defaultTag | string | `"6.0.0@sha256:1e35f77690222a76724b45f2305b838c40c35201e60b0f619b3fe8499504ff60"` | Docker image tag for the `syntect-server` image |
 | syntectServer.image.name | string | `"syntax-highlighter"` | Docker image name for the `syntect-server` image |
 | syntectServer.name | string | `"syntect-server"` | Name used by resources. Does not affect service names or PVCs. |
+| syntectServer.podDisruptionBudget | object | `{}` | Pod disruption budget for `syntect-server`. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | syntectServer.podSecurityContext | object | `{}` | Security context for the `syntect-server` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | syntectServer.replicaCount | int | `1` | Number of `syntect-server` pod |
 | syntectServer.resources | object | `{"limits":{"cpu":"4","memory":"6G"},"requests":{"cpu":"250m","memory":"2G"}}` | Resource requests & limits for the `syntect-server` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |

--- a/charts/sourcegraph/templates/syntect-server/syntect-server.PodDisruptionBudget.yaml
+++ b/charts/sourcegraph/templates/syntect-server/syntect-server.PodDisruptionBudget.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.syntectServer.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.syntectServer.name }}
+spec:
+  {{- toYaml .Values.syntectServer.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: syntect-server
+{{- end }}

--- a/charts/sourcegraph/tests/podDisruptionBudget_test.yaml
+++ b/charts/sourcegraph/tests/podDisruptionBudget_test.yaml
@@ -8,6 +8,11 @@ tests:
   asserts:
   - hasDocuments:
       count: 0
+- it: should not render podDisruptionBudget for syntax highlighter by default
+  template: syntect-server/syntect-server.PodDisruptionBudget.yaml
+  asserts:
+  - hasDocuments:
+      count: 0
 - it: should render podDisruptionBudget for frontend
   template: frontend/sourcegraph-frontend.PodDisruptionBudget.yaml
   set:
@@ -40,6 +45,31 @@ tests:
   - equal:
       path: spec.selector.matchLabels.app
       value: searcher
+  - equal:
+      path: spec.selector.matchLabels["app.kubernetes.io/name"]
+      value: sourcegraph
+  - equal:
+      path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+      value: sourcegraph
+- it: should render podDisruptionBudget for syntax highlighter
+  template: syntect-server/syntect-server.PodDisruptionBudget.yaml
+  set:
+    syntectServer:
+      podDisruptionBudget:
+        maxUnavailable: 1
+  asserts:
+  - equal:
+      path: apiVersion
+      value: policy/v1
+  - equal:
+      path: metadata.name
+      value: syntect-server
+  - equal:
+      path: spec.maxUnavailable
+      value: 1
+  - equal:
+      path: spec.selector.matchLabels.app
+      value: syntect-server
   - equal:
       path: spec.selector.matchLabels["app.kubernetes.io/name"]
       value: sourcegraph

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -1244,6 +1244,8 @@ syntectServer:
   podSecurityContext: {}
   # -- Number of `syntect-server` pod
   replicaCount: 1
+  # -- Pod disruption budget for `syntect-server`. Configure either `minAvailable` or `maxUnavailable` to enable it.
+  podDisruptionBudget: {}
   # -- Resource requests & limits for the `syntect-server` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:


### PR DESCRIPTION
Syntax highlighter needs an optional PodDisruptionBudget so that multi-replica deployments can protect availability during voluntary disruptions such as node drains.

This adds `syntectServer.podDisruptionBudget`, disabled by default, using the same values shape and selector behavior as the recently added Searcher support. Operators can enable it with either `minAvailable` or `maxUnavailable`; existing installations are unchanged.

## Test plan

- `./scripts/helm-docs.sh`
- `helm unittest -q charts/sourcegraph` (117 tests and 12 snapshots passed)
- `helm lint charts/sourcegraph`