### PR TITLE
Add pod disruption budgets for additional services

### DIFF
--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -129,6 +129,7 @@ In addition to the documented values, all services also support the following va
 | gitserver.image.defaultTag | string | `"6.0.0@sha256:aec9bf6993c243a283109104cd7c44be3c85680b77e3e8be0c5fba8f01a3bd35"` | Docker image tag for the `gitserver` image |
 | gitserver.image.name | string | `"gitserver"` | Docker image name for the `gitserver` image |
 | gitserver.name | string | `"gitserver"` | Name used by resources. Does not affect service names or PVCs. |
+| gitserver.podDisruptionBudget | object | `{}` | Pod disruption budget for `gitserver`. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | gitserver.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":101,"runAsUser":100}` | Security context for the `gitserver` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | gitserver.replicaCount | int | `1` | Number of `gitserver` pod |
 | gitserver.resources | object | `{"limits":{"cpu":"4","memory":"8G"},"requests":{"cpu":"4","memory":"8G"}}` | Resource requests & limits for the `gitserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -164,6 +165,7 @@ In addition to the documented values, all services also support the following va
 | indexedSearch.image.defaultTag | string | `"6.0.0@sha256:99038e0ec9bef930030c118d774fcdcd67d7fe57ad4c80d216703a4d29d64323"` | Docker image tag for the `zoekt-webserver` image |
 | indexedSearch.image.name | string | `"indexed-searcher"` | Docker image name for the `zoekt-webserver` image |
 | indexedSearch.name | string | `"indexed-search"` | Name used by resources. Does not affect service names or PVCs. |
+| indexedSearch.podDisruptionBudget | object | `{}` | Pod disruption budget for `indexed-search`. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | indexedSearch.podSecurityContext | object | `{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch"}` | Security context for the `indexed-search` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | indexedSearch.replicaCount | int | `1` | Number of `indexed-search` pod |
 | indexedSearch.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `zoekt-webserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -275,6 +277,7 @@ In addition to the documented values, all services also support the following va
 | preciseCodeIntel.image.defaultTag | string | `"6.0.0@sha256:3a72cf893cb25731d4636593c544c91781d925d867417416255e56debc27ed37"` | Docker image tag for the `precise-code-intel-worker` image |
 | preciseCodeIntel.image.name | string | `"precise-code-intel-worker"` | Docker image name for the `precise-code-intel-worker` image |
 | preciseCodeIntel.name | string | `"precise-code-intel-worker"` | Name used by resources. Does not affect service names or PVCs. |
+| preciseCodeIntel.podDisruptionBudget | object | `{}` | Pod disruption budget for `precise-code-intel-worker`. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | preciseCodeIntel.podSecurityContext | object | `{}` | Security context for the `precise-code-intel-worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | preciseCodeIntel.replicaCount | int | `2` | Number of `precise-code-intel-worker` pod |
 | preciseCodeIntel.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `precise-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -303,6 +306,7 @@ In addition to the documented values, all services also support the following va
 | redisCache.image.defaultTag | string | `"6.0.0@sha256:40ea19e8944b93e05d7697c808969fe0c81a014a56245f3a97b645aa34a9ab78"` | Docker image tag for the `redis-cache` image |
 | redisCache.image.name | string | `"redis-cache"` | Docker image name for the `redis-cache` image |
 | redisCache.name | string | `"redis-cache"` | Name used by resources. Does not affect service names or PVCs. |
+| redisCache.podDisruptionBudget | object | `{}` | Pod disruption budget for `redis-cache`. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | redisCache.podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch"}` | Security context for the `redis-cache` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | redisCache.resources | object | `{"limits":{"cpu":"1","memory":"7Gi"},"requests":{"cpu":"1","memory":"7Gi"}}` | Resource requests & limits for the `redis-cache` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | redisCache.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `redis-cache` |
@@ -321,6 +325,7 @@ In addition to the documented values, all services also support the following va
 | redisStore.image.defaultTag | string | `"6.0.0@sha256:39f3b27d993652c202c1f892df83e1a3e8e8ea5ae58291f79ad14b56672ab8be"` | Docker image tag for the `redis-store` image |
 | redisStore.image.name | string | `"redis-store"` | Docker image name for the `redis-store` image |
 | redisStore.name | string | `"redis-store"` | Name used by resources. Does not affect service names or PVCs. |
+| redisStore.podDisruptionBudget | object | `{}` | Pod disruption budget for `redis-store`. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | redisStore.podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch"}` | Security context for the `redis-store` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | redisStore.resources | object | `{"limits":{"cpu":"1","memory":"7Gi"},"requests":{"cpu":"1","memory":"7Gi"}}` | Resource requests & limits for the `redis-store` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | redisStore.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `redis-store` |
@@ -376,6 +381,7 @@ In addition to the documented values, all services also support the following va
 | syntacticCodeIntel.image.defaultTag | string | `"6.0.0@sha256:50bdeb38b196f0fc21404969016bf8263f78144292e905867e93480f66c8251c"` | Docker image tag for the `syntactic-code-intel-worker` image |
 | syntacticCodeIntel.image.name | string | `"syntactic-code-intel-worker"` | Docker image name for the `syntactic-code-intel-worker` image |
 | syntacticCodeIntel.name | string | `"syntactic-code-intel-worker"` | Name used by resources. Does not affect service names or PVCs. |
+| syntacticCodeIntel.podDisruptionBudget | object | `{}` | Pod disruption budget for `syntactic-code-intel-worker`. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | syntacticCodeIntel.podSecurityContext | object | `{}` | Security context for the `syntactic-code-intel-worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | syntacticCodeIntel.properties.workerPort | int | `3188` | port to whick worker API will bind |
 | syntacticCodeIntel.replicaCount | int | `2` | Number of `syntactic-code-intel-worker` pod |
@@ -399,6 +405,7 @@ In addition to the documented values, all services also support the following va
 | worker.image.defaultTag | string | `"6.0.0@sha256:4892c5aa107d4384f811afcf1980e0fb2cb8beb5585a15adcb64353a2d8abf5a"` | Docker image tag for the `worker` image |
 | worker.image.name | string | `"worker"` | Docker image name for the `worker` image |
 | worker.name | string | `"worker"` | Name used by resources. Does not affect service names or PVCs. |
+| worker.podDisruptionBudget | object | `{}` | Pod disruption budget for every `worker` deployment. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | worker.podSecurityContext | object | `{}` | Security context for the `worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | worker.replicaCount | int | `1` | Number of `worker` pod |
 | worker.replicas | list | `[]` | Scale worker horizontally by configuring additional replicas dedicated to specific jobs. for each replica, configure the dedicated jobs to run on this replica. learn more from https://sourcegraph.com/docs/admin/workers#3-split-jobs-and-scale-independently |

--- a/charts/sourcegraph/templates/gitserver/gitserver.PodDisruptionBudget.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.PodDisruptionBudget.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.gitserver.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.gitserver.name }}
+spec:
+  {{- toYaml .Values.gitserver.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: gitserver
+{{- end }}

--- a/charts/sourcegraph/templates/indexed-search/indexed-search.PodDisruptionBudget.yaml
+++ b/charts/sourcegraph/templates/indexed-search/indexed-search.PodDisruptionBudget.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.indexedSearch.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.indexedSearch.name }}
+spec:
+  {{- toYaml .Values.indexedSearch.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: indexed-search
+{{- end }}

--- a/charts/sourcegraph/templates/precise-code-intel/worker.PodDisruptionBudget.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.PodDisruptionBudget.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.preciseCodeIntel.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.preciseCodeIntel.name }}
+spec:
+  {{- toYaml .Values.preciseCodeIntel.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: precise-code-intel-worker
+{{- end }}

--- a/charts/sourcegraph/templates/redis/redis-cache.PodDisruptionBudget.yaml
+++ b/charts/sourcegraph/templates/redis/redis-cache.PodDisruptionBudget.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.redisCache.enabled .Values.redisCache.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.redisCache.name }}
+spec:
+  {{- toYaml .Values.redisCache.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: redis-cache
+{{- end }}

--- a/charts/sourcegraph/templates/redis/redis-store.PodDisruptionBudget.yaml
+++ b/charts/sourcegraph/templates/redis/redis-store.PodDisruptionBudget.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.redisStore.enabled .Values.redisStore.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.redisStore.name }}
+spec:
+  {{- toYaml .Values.redisStore.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: redis-store
+{{- end }}

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.PodDisruptionBudget.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.PodDisruptionBudget.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.syntacticCodeIntel.enabled .Values.syntacticCodeIntel.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.syntacticCodeIntel.name }}
+spec:
+  {{- toYaml .Values.syntacticCodeIntel.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" . | nindent 6 }}
+      app: syntactic-code-intel-worker
+{{- end }}

--- a/charts/sourcegraph/templates/worker/worker.PodDisruptionBudget.yaml
+++ b/charts/sourcegraph/templates/worker/worker.PodDisruptionBudget.yaml
@@ -1,0 +1,34 @@
+{{- define "sourcegraph.worker.podDisruptionBudget" -}}
+{{- $top := index . 0 -}}
+{{- $suffix := index . 1 -}}
+{{- $name := $top.Values.worker.name -}}
+{{- if $suffix -}}
+{{- $name = printf "%s-%s" $name $suffix -}}
+{{- end -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}
+spec:
+  {{- toYaml $top.Values.worker.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "sourcegraph.selectorLabels" $top | nindent 6 }}
+      app: worker
+      {{- if $suffix }}
+      worker-replica: {{ $name | quote }}
+      {{- end }}
+    {{- if and (not $suffix) $top.Values.worker.replicas }}
+    matchExpressions:
+    - key: worker-replica
+      operator: DoesNotExist
+    {{- end }}
+{{- end -}}
+
+{{- if .Values.worker.podDisruptionBudget }}
+{{- include "sourcegraph.worker.podDisruptionBudget" (list . "") }}
+{{- range $idx, $_ := .Values.worker.replicas }}
+---
+{{- include "sourcegraph.worker.podDisruptionBudget" (list $ (printf "%d" $idx)) | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/charts/sourcegraph/tests/podDisruptionBudget_test.yaml
+++ b/charts/sourcegraph/tests/podDisruptionBudget_test.yaml
@@ -76,3 +76,129 @@ tests:
   - equal:
       path: spec.selector.matchLabels["app.kubernetes.io/instance"]
       value: sourcegraph
+- it: should render podDisruptionBudget for gitserver
+  template: gitserver/gitserver.PodDisruptionBudget.yaml
+  set:
+    gitserver.podDisruptionBudget.minAvailable: 1
+  asserts:
+  - equal:
+      path: metadata.name
+      value: gitserver
+  - equal:
+      path: spec.minAvailable
+      value: 1
+  - equal:
+      path: spec.selector.matchLabels.app
+      value: gitserver
+- it: should render podDisruptionBudget for indexed search
+  template: indexed-search/indexed-search.PodDisruptionBudget.yaml
+  set:
+    indexedSearch.podDisruptionBudget.maxUnavailable: 1
+  asserts:
+  - equal:
+      path: metadata.name
+      value: indexed-search
+  - equal:
+      path: spec.maxUnavailable
+      value: 1
+  - equal:
+      path: spec.selector.matchLabels.app
+      value: indexed-search
+- it: should render podDisruptionBudget for precise code intel
+  template: precise-code-intel/worker.PodDisruptionBudget.yaml
+  set:
+    preciseCodeIntel.podDisruptionBudget.maxUnavailable: 1
+  asserts:
+  - equal:
+      path: metadata.name
+      value: precise-code-intel-worker
+  - equal:
+      path: spec.maxUnavailable
+      value: 1
+  - equal:
+      path: spec.selector.matchLabels.app
+      value: precise-code-intel-worker
+- it: should render podDisruptionBudget for redis cache
+  template: redis/redis-cache.PodDisruptionBudget.yaml
+  set:
+    redisCache.podDisruptionBudget.minAvailable: 1
+  asserts:
+  - equal:
+      path: metadata.name
+      value: redis-cache
+  - equal:
+      path: spec.minAvailable
+      value: 1
+  - equal:
+      path: spec.selector.matchLabels.app
+      value: redis-cache
+- it: should render podDisruptionBudget for redis store
+  template: redis/redis-store.PodDisruptionBudget.yaml
+  set:
+    redisStore.podDisruptionBudget.minAvailable: 1
+  asserts:
+  - equal:
+      path: metadata.name
+      value: redis-store
+  - equal:
+      path: spec.minAvailable
+      value: 1
+  - equal:
+      path: spec.selector.matchLabels.app
+      value: redis-store
+- it: should render podDisruptionBudget for syntactic code intel when enabled
+  template: syntactic-code-intel/worker.PodDisruptionBudget.yaml
+  set:
+    syntacticCodeIntel.enabled: true
+    syntacticCodeIntel.podDisruptionBudget.maxUnavailable: 1
+  asserts:
+  - equal:
+      path: metadata.name
+      value: syntactic-code-intel-worker
+  - equal:
+      path: spec.maxUnavailable
+      value: 1
+  - equal:
+      path: spec.selector.matchLabels.app
+      value: syntactic-code-intel-worker
+- it: should render a podDisruptionBudget for every worker deployment
+  template: worker/worker.PodDisruptionBudget.yaml
+  set:
+    worker:
+      podDisruptionBudget:
+        maxUnavailable: 1
+      replicas:
+      - jobs: ["job1"]
+      - jobs: ["job2"]
+  asserts:
+  - hasDocuments:
+      count: 3
+  - equal:
+      path: metadata.name
+      value: worker
+    documentIndex: 0
+  - notExists:
+      path: spec.selector.matchLabels.worker-replica
+    documentIndex: 0
+  - equal:
+      path: spec.selector.matchExpressions[0]
+      value:
+        key: worker-replica
+        operator: DoesNotExist
+    documentIndex: 0
+  - equal:
+      path: metadata.name
+      value: worker-0
+    documentIndex: 1
+  - equal:
+      path: spec.selector.matchLabels.worker-replica
+      value: worker-0
+    documentIndex: 1
+  - equal:
+      path: metadata.name
+      value: worker-1
+    documentIndex: 2
+  - equal:
+      path: spec.selector.matchLabels.worker-replica
+      value: worker-1
+    documentIndex: 2

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -449,6 +449,8 @@ gitserver:
     readOnlyRootFilesystem: true
   # -- Number of `gitserver` pod
   replicaCount: 1
+  # -- Pod disruption budget for `gitserver`. Configure either `minAvailable` or `maxUnavailable` to enable it.
+  podDisruptionBudget: {}
   # -- Resource requests & limits for the `gitserver` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -567,6 +569,8 @@ indexedSearch:
   name: "indexed-search"
   # -- Number of `indexed-search` pod
   replicaCount: 1
+  # -- Pod disruption budget for `indexed-search`. Configure either `minAvailable` or `maxUnavailable` to enable it.
+  podDisruptionBudget: {}
   # -- Resource requests & limits for the `zoekt-webserver` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -914,6 +918,8 @@ syntacticCodeIntel:
   podSecurityContext: {}
   # -- Number of `syntactic-code-intel-worker` pod
   replicaCount: 2
+  # -- Pod disruption budget for `syntactic-code-intel-worker`. Configure either `minAvailable` or `maxUnavailable` to enable it.
+  podDisruptionBudget: {}
   # -- Resource requests & limits for the `syntactic-code-intel-worker` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -956,6 +962,8 @@ preciseCodeIntel:
   podSecurityContext: {}
   # -- Number of `precise-code-intel-worker` pod
   replicaCount: 2
+  # -- Pod disruption budget for `precise-code-intel-worker`. Configure either `minAvailable` or `maxUnavailable` to enable it.
+  podDisruptionBudget: {}
   # -- Resource requests & limits for the `precise-code-intel-worker` container,
   # learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources:
@@ -1067,6 +1075,8 @@ redisCache:
   podSecurityContext:
     fsGroup: 1000
     fsGroupChangePolicy: "OnRootMismatch"
+  # -- Pod disruption budget for `redis-cache`. Configure either `minAvailable` or `maxUnavailable` to enable it.
+  podDisruptionBudget: {}
   serviceAccount:
     # -- Enable creation of ServiceAccount for `redis-cache`
     create: false
@@ -1140,6 +1150,8 @@ redisStore:
   podSecurityContext:
     fsGroup: 1000
     fsGroupChangePolicy: "OnRootMismatch"
+  # -- Pod disruption budget for `redis-store`. Configure either `minAvailable` or `maxUnavailable` to enable it.
+  podDisruptionBudget: {}
   serviceAccount:
     # -- Enable creation of ServiceAccount for `redis-store`
     create: false
@@ -1373,6 +1385,8 @@ worker:
   podSecurityContext: {}
   # -- Number of `worker` pod
   replicaCount: 1
+  # -- Pod disruption budget for every `worker` deployment. Configure either `minAvailable` or `maxUnavailable` to enable it.
+  podDisruptionBudget: {}
   # -- List of jobs to block globally
   # If replicas are configured, use this values to block jobs instead of manually setting WORKER_JOB_BLOCKLIST
   blocklist: []


### PR DESCRIPTION
Adds opt-in PodDisruptionBudget support for gitserver, indexed search, precise and syntactic code intel, redis cache/store, and worker.

For worker, it geenerates independently scoped budgets for primary and dedicated worker deployments.