### PR TITLE
fix/docs: Fix spelling errors in the documentation

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -56,7 +56,7 @@ Make sure you test both enabled and disabled toggles. For example, if you added 
 
 ### Update the image tag
 
-You have two options to target specificy Sourcegraph version. Add the below to your `override.yaml`:
+You have two options to target specific Sourcegraph version. Add the below to your `override.yaml`:
 
 ```yaml
 sourcegraph:

--- a/charts/sourcegraph-executor/dind/values.yaml
+++ b/charts/sourcegraph-executor/dind/values.yaml
@@ -1,4 +1,4 @@
-# These values are dervied from https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml
+# These values are derived from https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml
 
 ### Common Configuration ###
 sourcegraph:

--- a/charts/sourcegraph-executor/k8s/values.yaml
+++ b/charts/sourcegraph-executor/k8s/values.yaml
@@ -1,4 +1,4 @@
-# These values are dervied from https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml
+# These values are derived from https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml
 
 ### Common Configuration ###
 sourcegraph:

--- a/charts/sourcegraph-migrator/values.yaml
+++ b/charts/sourcegraph-migrator/values.yaml
@@ -1,4 +1,4 @@
-# These values are dervied from https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml
+# These values are derived from https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml
 
 ### Common Configuration ###
 sourcegraph:

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -110,7 +110,7 @@ In addition to the documented values, all services also support the following va
 | frontend.image.defaultTag | string | `"6.0.0@sha256:d4f21178096da5fdb3804099ae9de2e050b06e859a327aa79452b1ea2f3ede0a"` | Docker image tag for the `frontend` image |
 | frontend.image.name | string | `"frontend"` | Docker image name for the `frontend` image |
 | frontend.ingress.annotations | object | `{"kubernetes.io/ingress.class":"nginx","nginx.ingress.kubernetes.io/proxy-body-size":"150m"}` | Annotations for the Sourcegraph server ingress. For example, securing ingress with TLS provided by [cert-manager](https://cert-manager.io/docs/usage/ingress/) |
-| frontend.ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` | [Deprecated annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) for specifing the IngressClass in Kubernetes 1.17 and earlier. If you are using Kubernetes 1.18+, use `ingressClassName` instead and set an override value of `null` for this annotation. |
+| frontend.ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` | [Deprecated annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) for specifying the IngressClass in Kubernetes 1.17 and earlier. If you are using Kubernetes 1.18+, use `ingressClassName` instead and set an override value of `null` for this annotation. |
 | frontend.ingress.enabled | bool | `true` | Enable ingress for the Sourcegraph server |
 | frontend.ingress.host | string | `""` | External hostname for the Sourcegraph server ingress (SSL) |
 | frontend.ingress.hosts | list | `[]` | List of hosts for the ingress rules. Supersedes `host` if set. Cannot be set together with `host`. Example: hosts:   - host: sourcegraph.example.com |
@@ -173,7 +173,7 @@ In addition to the documented values, all services also support the following va
 | indexedSearch.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `indexed-search` |
 | indexedSearch.serviceAccount.name | string | `""` | Name of the ServiceAccount to be created or an existing ServiceAccount |
 | indexedSearch.storageAnnotations | object | `{}` | Optional annotations to add to the `indexed-search` PVC |
-| indexedSearch.storageSize | string | `"200Gi"` | PVC Storage Request for `indexed-search` data volume The size of disk to used for search indexes. This should typically be gitserver disk size multipled by the number of gitserver shards. |
+| indexedSearch.storageSize | string | `"200Gi"` | PVC Storage Request for `indexed-search` data volume The size of disk to used for search indexes. This should typically be gitserver disk size multiplied by the number of gitserver shards. |
 | indexedSearch.storageSubPath | string | `""` | Optional subPath for the `indexed-search` primary data volume mount |
 | indexedSearchIndexer.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsUser":100}` | Security context for the `zoekt-indexserver` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | indexedSearchIndexer.env | object | the chart will add some default environment values | Environment variables for the `zoekt-indexserver` container |
@@ -384,7 +384,7 @@ In addition to the documented values, all services also support the following va
 | syntacticCodeIntel.name | string | `"syntactic-code-intel-worker"` | Name used by resources. Does not affect service names or PVCs. |
 | syntacticCodeIntel.podDisruptionBudget | object | `{}` | Pod disruption budget for `syntactic-code-intel-worker`. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | syntacticCodeIntel.podSecurityContext | object | `{}` | Security context for the `syntactic-code-intel-worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| syntacticCodeIntel.properties.workerPort | int | `3188` | port to whick worker API will bind |
+| syntacticCodeIntel.properties.workerPort | int | `3188` | port to which worker API will bind |
 | syntacticCodeIntel.replicaCount | int | `2` | Number of `syntactic-code-intel-worker` pod |
 | syntacticCodeIntel.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `syntactic-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | syntacticCodeIntel.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `syntactic-code-intel-worker` |

--- a/charts/sourcegraph/examples/kustomize-chart/README.md
+++ b/charts/sourcegraph/examples/kustomize-chart/README.md
@@ -6,7 +6,7 @@ This example demonstrate the escape hatch whenever you encounter something that 
 
 In this example, we will change the `http` port of `sourcegraph-frontend.Service.yaml` and update the corresponding backend service port number in `sourcegraph-frontend.Ingress.yaml`.
 
-We will utilize the [post renderering] featue from Helm to integrate with [Kustomize]. The `./kustomize` script below will run `kustomize build` on the rendered manifests from helm and return the transformed manifests back to Helm.
+We will utilize the [post rendering] feature from Helm to integrate with [Kustomize]. The `./kustomize` script below will run `kustomize build` on the rendered manifests from helm and return the transformed manifests back to Helm.
 
 > Below command should be run within the current directory
 
@@ -17,4 +17,4 @@ helm upgrade --install --create-namespace -n sourcegraph sourcegraph sourcegraph
 [kustomize]: https://kustomize.io
 [strategic merge patch]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md
 [json patch]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment
-[post renderering]: https://helm.sh/docs/topics/advanced/#post-rendering
+[post rendering]: https://helm.sh/docs/topics/advanced/#post-rendering

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -333,7 +333,7 @@ frontend:
     enabled: true
     # -- Annotations for the Sourcegraph server ingress. For example, securing ingress with TLS provided by [cert-manager](https://cert-manager.io/docs/usage/ingress/)
     annotations:
-      # --  [Deprecated annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) for specifing the IngressClass in Kubernetes 1.17 and earlier.
+      # --  [Deprecated annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) for specifying the IngressClass in Kubernetes 1.17 and earlier.
       # If you are using Kubernetes 1.18+, use `ingressClassName` instead and set an override value of `null` for this annotation.
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/proxy-body-size: 150m
@@ -594,7 +594,7 @@ indexedSearch:
     name: ""
   # -- PVC Storage Request for `indexed-search` data volume
   # The size of disk to used for search indexes.
-  # This should typically be gitserver disk size multipled by the number of gitserver shards.
+  # This should typically be gitserver disk size multiplied by the number of gitserver shards.
   storageSize: 200Gi
   # -- Optional subPath for the `indexed-search` primary data volume mount
   storageSubPath: ""
@@ -899,7 +899,7 @@ syntacticCodeIntel:
     DEPLOY_TYPE:
       value: helm
   properties:
-    # -- port to whick worker API will bind
+    # -- port to which worker API will bind
     workerPort: 3188
   image:
     # -- Docker image tag for the `syntactic-code-intel-worker` image


### PR DESCRIPTION
Corrections were produced by running [codespell](https://github.com/codespell-project/codespell) over the repository's hand-written Markdown, then reviewing every proposed change in context so that code samples, CLI flags, config keys, YAML keys and values, URLs, identifiers, and quoted output were left untouched. Only spelling is changed; no wording, formatting, or content was otherwise altered.

Files that are generated or vendored are skipped, since fixes there would be overwritten. Where a generated file has a checked-in source, the source is corrected and the generated output is regenerated so the two stay in sync.

[_Created by a Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/1136)