### PR TITLE
gitserver: Expose HTTP clone listener

### DIFF
--- a/charts/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -24,6 +24,9 @@ spec:
   - name: grpc
     port: 3178
     targetPort: grpc
+  - name: http-clone
+    port: 3179
+    targetPort: http-clone
   - name: http-debug
     port: 6060
     targetPort: http-debug

--- a/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
+++ b/charts/sourcegraph/templates/gitserver/gitserver.StatefulSet.yaml
@@ -62,18 +62,31 @@ spec:
         # gitserver can take a little while to start up. To avoid killing the
         # pod because of a failed liveness probe, we give it 2 minutes to start up.
         startupProbe:
-          tcpSocket:
-            port: grpc
+          httpGet:
+            path: /ready
+            port: http-debug
+            scheme: HTTP
           failureThreshold: 120
           periodSeconds: 1
         livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http-debug
+            scheme: HTTP
           initialDelaySeconds: 5
-          tcpSocket:
-            port: grpc
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http-debug
+            scheme: HTTP
+          periodSeconds: 5
           timeoutSeconds: 5
         ports:
         - name: grpc
           containerPort: 3178
+        - name: http-clone
+          containerPort: 3179
         - name: http-debug
           containerPort: 6060
         {{- if not .Values.sourcegraph.localDevMode }}


### PR DESCRIPTION
Exposes the Gitserver HTTP clone listener on port 3179 in the StatefulSet and headless Service that we're adding to have a dedicated endpoint for HTTP clone operations.

Also moves to use Gitserver's debug HTTP endpoints for startup and liveness probes which will cover both ports.
Also adds a readiness probe against `/ready`, which ideally prevents traffic being routed a bit too early.