### PR TITLE
code-intel: remove unused worker ports

### DIFF
--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,6 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
+- Removed the unused port 3188 from the precise code intel worker Deployment and Service; health checks and Prometheus metrics continue to use the debug server on port 6060.
 - Added `gitserver.storageAccessModes` (default `["ReadWriteOnce"]`) to allow `["ReadWriteOncePod"]`, which lets Kubernetes mount the repos volume with `-o context` on SELinux-enforcing nodes (e.g. Bottlerocket / EKS Auto Mode) instead of recursively relabeling every file on each pod start. Changing this on an existing deployment requires recreating the StatefulSet and PVC, as both fields are immutable.
 - Added configurable pre-shutdown pauses, graceful-shutdown timeouts, and termination grace periods for application services
 - Added optional `syntectServer.podDisruptionBudget` support

--- a/charts/sourcegraph/CHANGELOG.md
+++ b/charts/sourcegraph/CHANGELOG.md
@@ -8,7 +8,7 @@ Use `**BREAKING**:` to denote a breaking change
 
 ## Unreleased
 
-- Removed the unused port 3188 from the precise code intel worker Deployment and Service; health checks and Prometheus metrics continue to use the debug server on port 6060.
+- Removed the unused application ports from the precise and syntactic code intel worker Deployments and Services; health checks and Prometheus metrics continue to use the debug server on port 6060.
 - Added `gitserver.storageAccessModes` (default `["ReadWriteOnce"]`) to allow `["ReadWriteOncePod"]`, which lets Kubernetes mount the repos volume with `-o context` on SELinux-enforcing nodes (e.g. Bottlerocket / EKS Auto Mode) instead of recursively relabeling every file on each pod start. Changing this on an existing deployment requires recreating the StatefulSet and PVC, as both fields are immutable.
 - Added configurable pre-shutdown pauses, graceful-shutdown timeouts, and termination grace periods for application services
 - Added optional `syntectServer.podDisruptionBudget` support

--- a/charts/sourcegraph/README.md
+++ b/charts/sourcegraph/README.md
@@ -384,7 +384,6 @@ In addition to the documented values, all services also support the following va
 | syntacticCodeIntel.name | string | `"syntactic-code-intel-worker"` | Name used by resources. Does not affect service names or PVCs. |
 | syntacticCodeIntel.podDisruptionBudget | object | `{}` | Pod disruption budget for `syntactic-code-intel-worker`. Configure either `minAvailable` or `maxUnavailable` to enable it. |
 | syntacticCodeIntel.podSecurityContext | object | `{}` | Security context for the `syntactic-code-intel-worker` pod, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| syntacticCodeIntel.properties.workerPort | int | `3188` | port to which worker API will bind |
 | syntacticCodeIntel.replicaCount | int | `2` | Number of `syntactic-code-intel-worker` pod |
 | syntacticCodeIntel.resources | object | `{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"500m","memory":"2G"}}` | Resource requests & limits for the `syntactic-code-intel-worker` container, learn more from the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | syntacticCodeIntel.serviceAccount.create | bool | `false` | Enable creation of ServiceAccount for `syntactic-code-intel-worker` |

--- a/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.Deployment.yaml
@@ -87,8 +87,6 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 5
         ports:
-        - name: http
-          containerPort: 3188
         - name: http-debug
           containerPort: 6060
         {{- if not .Values.sourcegraph.localDevMode }}

--- a/charts/sourcegraph/templates/precise-code-intel/worker.Service.yaml
+++ b/charts/sourcegraph/templates/precise-code-intel/worker.Service.yaml
@@ -17,9 +17,6 @@ metadata:
   name: precise-code-intel-worker
 spec:
   ports:
-  - name: http
-    port: 3188
-    targetPort: http
   - name: http-debug
     port: 6060
     targetPort: http-debug

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Deployment.yaml
@@ -65,8 +65,6 @@ spec:
         - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT
           value: http://blobstore:9000
         {{- end }}
-        - name: SYNTACTIC_CODE_INTEL_WORKER_ADDR
-          value: ":{{ .Values.syntacticCodeIntel.properties.workerPort }}"
         {{- include "sourcegraph.openTelemetryEnv" . | nindent 8 }}
         image: {{ include "sourcegraph.image" (list . "syntacticCodeIntel") }}
         imagePullPolicy: {{ .Values.sourcegraph.image.pullPolicy }}
@@ -78,7 +76,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: http
+            port: http-debug
             scheme: HTTP
           initialDelaySeconds: 60
           timeoutSeconds: 5
@@ -90,8 +88,6 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 5
         ports:
-        - name: http
-          containerPort: {{ .Values.syntacticCodeIntel.properties.workerPort }}
         - name: http-debug
           containerPort: 6060
         {{- if not .Values.sourcegraph.localDevMode }}

--- a/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
+++ b/charts/sourcegraph/templates/syntactic-code-intel/worker.Service.yaml
@@ -18,9 +18,6 @@ metadata:
   name: syntactic-code-intel-worker
 spec:
   ports:
-  - name: http
-    port: {{ .Values.syntacticCodeIntel.properties.workerPort }}
-    targetPort: http
   - name: http-debug
     port: 6060
     targetPort: http-debug

--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -898,9 +898,6 @@ syntacticCodeIntel:
   env:
     DEPLOY_TYPE:
       value: helm
-  properties:
-    # -- port to which worker API will bind
-    workerPort: 3188
   image:
     # -- Docker image tag for the `syntactic-code-intel-worker` image
     defaultTag: 6.0.0@sha256:50bdeb38b196f0fc21404969016bf8263f78144292e905867e93480f66c8251c


### PR DESCRIPTION
Remove the unused application ports from the precise and syntactic code intel workers. Health checks, readiness, and Prometheus metrics use their debugservers on port 6060 instead.